### PR TITLE
Simplify build process and add option to not build HCRT, add 60fps flag

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,8 @@
 ﻿---
-BasedOnStyle: WebKit
-TabWidth: '4'
-UseTab: Always
-
+BasedOnStyle: LLVM
+TabWidth: '2'
+UseTab: Never
+Language: Cpp
+AllowShortFunctionsOnASingleLine: false
+IndentPPDirectives: BeforeHash
 ...

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ compile_commands.json
 CTestTestfile.cmake
 _deps
 Tmp.DD.Z
+Src/STAGE1.HC
+aiwnios
+HCRT2.BIN
+HCRT2.DBG.Z
+build

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 **.o
 **.a
 **.obj
+**.dll
 FUZZ*.HC
 **.exe
 CMakeLists.txt.user
@@ -20,3 +21,4 @@ aiwnios
 HCRT2.BIN
 HCRT2.DBG.Z
 build
+Registry.HC.Z

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/DetectArch.cmake")
 project(AIWNIOS
   LANGUAGES C CXX ASM
 )
+option(BUILD_HCRT "Build HCRT" YES)
 set(default_build_type "Release")
 
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -114,7 +115,6 @@ else()
   target_link_libraries(aiwnios PRIVATE pthread)
 endif()
 
-# Build HCRT2.BIN
 set_target_properties(aiwnios
     PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
@@ -125,29 +125,29 @@ set_target_properties(aiwnios
     C_EXTENSIONS YES
 )
 
-set (USE_WINE 0)
-if(NOT (CMAKE_SYSTEM MATCHES Windows))
-  if(WIN32)
-    set(USE_WINE 1)
+if (BUILD_HCRT)
+  set (USE_WINE NO)
+  if(NOT (CMAKE_SYSTEM MATCHES Windows))
+    if(WIN32)
+      set(USE_WINE YES)
+    endif()
   endif()
-endif()
 
-if (NOT "$USE_WINE")
-  add_custom_target(
-    "HCRT2.BIN"
-    ALL
-    COMMAND aiwnios -b
-    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/Src" ${PROJ_NAME}
-    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-  )
-else ()
-  add_custom_target(
-    "HCRT2.BIN"
-    ALL
-    COMMAND wine64 aiwnios -b
-    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/Src" ${PROJ_NAME}
-    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-  )
+  if (NOT USE_WINE)
+    add_custom_target(HCRT2.BIN
+      ALL
+      COMMAND aiwnios -b
+      DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/Src" aiwnios
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    )
+  else ()
+    add_custom_target(HCRT2.BIN
+      ALL
+      COMMAND wine64 aiwnios -b
+      DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/Src" aiwnios
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    )
+  endif ()
 endif ()
 
 target_compile_options(aiwnios

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,27 +1,38 @@
-cmake_minimum_required(VERSION 3.10) #For sauce I have come,and to sauce I shall return
-#For SD2 cmake modules 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/sdl2)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR) #For sauce I have come,and to sauce I shall return
 include("${CMAKE_CURRENT_LIST_DIR}/DetectArch.cmake")
-project(AIWNIOS)
+project(AIWNIOS
+  LANGUAGES C CXX ASM
+)
+set(default_build_type "Release")
+
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}"
+    CACHE STRING "Choose the type of build." FORCE
+  )
+  set_property(CACHE CMAKE_BUILD_TYPE
+    PROPERTY
+      STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo"
+  )
+endif ()
+
 target_architecture(ARCH)
-if("${ARCH}" STREQUAL "x86_64")
-	if(WIN32)
-		set(
-			ASM_SOURCES
-			miscWIN.s
-			swapctxWIN.s
-			ffi_call_tos_WIN.s
-			miscTOSX86.s
-		)
-	else()
-		set(
-			ASM_SOURCES
-			miscX86.s
-			swapctxX86.s
-			ffi_call_tos.s
-			miscTOSX86.s
-		)
-	endif()
+if ("${ARCH}" STREQUAL "x86_64")
+  if (WIN32)
+    set(ASM_SOURCES
+      miscWIN.s
+      swapctxWIN.s
+      ffi_call_tos_WIN.s
+      miscTOSX86.s
+    )
+  else ()
+    set(ASM_SOURCES
+      miscX86.s
+      swapctxX86.s
+      ffi_call_tos.s
+      miscTOSX86.s
+    )
+endif ()
   set(
     C_SOURCES
     x86_64_backend.c 
@@ -45,16 +56,17 @@ if("${ARCH}" STREQUAL "x86_64")
     argtable3.c
     socket.c
   )
-elseif("${ARCH}" STREQUAL "arm64")
-	set(
-		ASM_SOURCES
-		miscAARCH64.s
-		swapctxAARCH64.s
-		ffi_call_tos_aarch64.s
+elseif ("${ARCH}" STREQUAL "arm64")
+  #For SDL2 cmake modules
+  list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/sdl2)
+
+  set(ASM_SOURCES
+    miscAARCH64.s
+    swapctxAARCH64.s
+    ffi_call_tos_aarch64.s
     miscTOSaarch64.s
-	)
-  set(
-    C_SOURCES
+  )
+  set(C_SOURCES
     arm64_asm.c 
     arm_backend.c
     bungis.c
@@ -83,74 +95,75 @@ add_executable(
   ${C_SOURCES}
 )
 find_package(SDL2 REQUIRED)
-target_compile_options(aiwnios PUBLIC ${SDL2_CFLAGS_OTHER})
+if (NOT SDL2_FOUND)
+  message(FATAL_ERROR "Please install SDL2")
+endif ()
 target_include_directories(aiwnios PUBLIC ${SDL2_INCLUDE_DIRS})
+target_link_libraries(aiwnios PRIVATE SDL2::SDL2)
 
 target_compile_options(aiwnios PRIVATE -w)
-set(ASM_OBJS "")
-if("${ARCH}" STREQUAL "x86_64")
-  foreach(X IN LISTS ASM_SOURCES)
-    add_custom_command(
-      COMMAND yasm
-      ARGS "${CMAKE_CURRENT_SOURCE_DIR}/${X}" -fwin64 -o "${CMAKE_CURRENT_BINARY_DIR}/${X}.obj"
-      DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${X}"
-      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${X}.obj"
-    )
-    set(ASM_OBJS "${ASM_OBJS}" "${CMAKE_CURRENT_BINARY_DIR}/${X}.obj")
-  endforeach()
-elseif("${ARCH}" STREQUAL "arm64")
-  foreach(X IN LISTS ASM_SOURCES)
-    add_custom_command(
-      COMMAND gcc
-      ARGS -c "${CMAKE_CURRENT_SOURCE_DIR}/${X}" -o "${CMAKE_CURRENT_BINARY_DIR}/${X}.obj"
-      DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${X}"
-      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${X}.obj"
-    )
-    set(ASM_OBJS "${ASM_OBJS}" "${CMAKE_CURRENT_BINARY_DIR}/${X}.obj")
-  endforeach()
-endif()
-#https://stackoverflow.com/questions/34657287/cmakebuild-yasm-source-files
-if(WIN32)
-    add_library(FFI SHARED ${ASM_OBJS})
-else()
-    add_library(FFI ${ASM_OBJS})
-endif() 
+
+add_library(FFI STATIC ${ASM_SOURCES})
+target_compile_options(FFI PRIVATE -w)
 set_target_properties(FFI PROPERTIES LINKER_LANGUAGE CXX)
-target_link_directories(aiwnios PUBLIC ${SDL2_LIBRARY_DIRS})
-if(WIN32)
-	target_link_libraries(aiwnios ${SDL2_LIBRARIES} ${ASM_OBJS} m shlwapi winmm ws2_32)
+target_link_libraries(aiwnios PRIVATE FFI m)
+
+if (WIN32)
+  target_link_libraries(aiwnios PRIVATE shlwapi winmm ws2_32 -static)
 else()
-	target_link_libraries(aiwnios  ${SDL2_LIBRARIES} FFI m pthread)
+  target_link_libraries(aiwnios PRIVATE pthread)
 endif()
 
-#Build HCRT2.BIN
+# Build HCRT2.BIN
 set_target_properties(aiwnios
     PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    INTERPROCEDURAL_OPTIMIZATION ON
+    C_VISIBILITY_PRESET hidden
+    C_STANDARD 11
+    C_STANDARD_REQUIRED YES
+    C_EXTENSIONS YES
 )
+
 set (USE_WINE 0)
 if(NOT (CMAKE_SYSTEM MATCHES Windows))
   if(WIN32)
     set(USE_WINE 1)
   endif()
 endif()
-if(NOT "$USE_WINE")
+
+if (NOT "$USE_WINE")
   add_custom_target(
-	"HCRT2.BIN"
-	ALL
-	COMMAND aiwnios -b
-	DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/Src" ${PROJ_NAME}
-	WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    "HCRT2.BIN"
+    ALL
+    COMMAND aiwnios -b
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/Src" ${PROJ_NAME}
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
   )
-else()
+else ()
   add_custom_target(
-	"HCRT2.BIN"
-	ALL
-	COMMAND wine64 aiwnios -b
-	DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/Src" ${PROJ_NAME}
-	WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    "HCRT2.BIN"
+    ALL
+    COMMAND wine64 aiwnios -b
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/Src" ${PROJ_NAME}
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
   )
-endif()
+endif ()
+
+target_compile_options(aiwnios
+  PRIVATE
+    -fno-math-errno
+    -fno-trapping-math
+    -fno-exceptions
+    -fno-omit-frame-pointer
+    -fno-signaling-nans
+    -fno-stack-protector
+    -fno-unwind-tables
+    -fno-asynchronous-unwind-tables
+    -fcf-protection=none
+    -mno-shstk
+)
+
 #
 # Install section
 #
@@ -201,3 +214,4 @@ foreach(F IN LISTS TEMPLATE_FILES)
   endif()
 endforeach()
 
+# vim: set expandtab ts=2 sw=2 :

--- a/README.MD
+++ b/README.MD
@@ -18,7 +18,6 @@ To build Aiwnios, you will need the following dependencies:
 - `gcc`
 - `libsdl2-dev`
 - `cmake`
-- `yasm` (required for x86_64)
 
 Once you have the dependencies installed, building Aiwnios is straightforward:
 

--- a/Src/FULL_PACKAGE.HC
+++ b/Src/FULL_PACKAGE.HC
@@ -271,5 +271,8 @@ WinMax(User);
 ACInit("T:/Src/Kernel*.HH*");
 ExePrint2("#include \"T:/Src/WallPaper.HC\";WallPaperInit;;");
 ExePrint2("#include \"T:/Src/AMouse.HC\";");
+if (_SixtyFPS)
+  SetFPS(60.);
+
 CoreAPSethTask;
 #endif;

--- a/Src/KGlbls.HC
+++ b/Src/KGlbls.HC
@@ -17,6 +17,7 @@ F64	*pow10_I64,
 
 CAutoCompleteDictGlbls acd;
 CAutoCompleteGlbls ac;
+F64 target_fps=30.;
 CBlkDevGlbls	blkdev;
 //CCntsGlbls	cnts={1,0,2676302000,2676302,2676302000,0,0,0,FALSE}; I DONT LIKE THIS
 CDbgGlbls	dbg;

--- a/Src/KernelA.HH
+++ b/Src/KernelA.HH
@@ -1446,8 +1446,10 @@ class CWinMgrTimingGlbls
   I64	calc_idle_cnt;
 };
 
-#define WINMGR_FPS	(30000.0/1001)
-#define WINMGR_PERIOD	(1001/30000.0)
+extern F64 target_fps;
+#define WINMGR_FPS	(target_fps)
+#define WINMGR_PERIOD	(1./target_fps)
+public extern F64 SetFPS(F64 target);
 
 /*public */ class CWinMgrGlbls
 {
@@ -3907,6 +3909,7 @@ import I64 FUnixTime(U8*);
 import U0 VFsFTrunc(U8*,I64);
 import F64 Sqrt(F64);
 import I64 MemCmp(U8*,U8*,I64);
+import Bool _SixtyFPS();
 import U0 SetKBCallback(U8 *fptr);
 import U0 SetMSCallback(U8 *fptr);
 import U0 SndFreq(I64);
@@ -4041,6 +4044,7 @@ extern U0 BlkDevsRelease();
 extern U8 Drv2Let(CDrv *dv=NULL);
 extern Bool FileFind(U8 *filename,CDirEntry *_de=NULL,I64 fuf_flags=FUF_Z_OR_NOT_Z);
 extern Bool IsDir(U8*);
+extern Bool _SixtyFPS();
 extern CBlkDev *BlkDevChk(CBlkDev *bd,Bool except=TRUE); 
 extern CDrv *Let2Drv(U8 drv_let=0,Bool except=TRUE);
 extern Bool RedSeaValidate(U8 drv_let);

--- a/Src/WinMgr.HC
+++ b/Src/WinMgr.HC
@@ -857,3 +857,10 @@ wmt_start:
     }
   }
 }
+
+public F64 SetFPS(F64 target) {
+  if (target>100.)
+    target=99.;
+  target_fps=target;
+  return target_fps;
+}

--- a/aiwn.h
+++ b/aiwn.h
@@ -1,31 +1,31 @@
 #pragma once
-#if defined (__MINGW64__)
-#define _WIN32 1
-#define WIN32
+#if defined(__MINGW64__)
+  #define _WIN32 1
+  #define WIN32
 #endif
+#include <SDL2/SDL.h>
+#include <assert.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdint.h>
-#include <signal.h>
-#include <unistd.h>
 #include <time.h>
-#include <stdio.h>
-#include <assert.h>
-#include <SDL2/SDL.h>
+#include <unistd.h>
 #define ERR 0x7fFFffFFffFFffFF
 #define INVALID_PTR ERR
 #define A_FREE __AIWNIOS_Free
-#define A_MALLOC(sz,task) __AIWNIOS_MAlloc(sz,task)
-#define A_CALLOC(sz,task) __AIWNIOS_CAlloc(sz,task)
-#define A_STRDUP(str,task) __AIWNIOS_StrDup(str,task)
+#define A_MALLOC(sz, task) __AIWNIOS_MAlloc(sz, task)
+#define A_CALLOC(sz, task) __AIWNIOS_CAlloc(sz, task)
+#define A_STRDUP(str, task) __AIWNIOS_StrDup(str, task)
 struct CHash;
 struct CHashTable;
 struct CHashFun;
 struct CTask;
-void *__AIWNIOS_CAlloc(int64_t cnt,void *t);
-void *__AIWNIOS_MAlloc(int64_t cnt,void *t);
+void *__AIWNIOS_CAlloc(int64_t cnt, void *t);
+void *__AIWNIOS_MAlloc(int64_t cnt, void *t);
 void __AIWNIOS_Free(void *ptr);
-char *__AIWNIOS_StrDup(char *str,void *t);
+char *__AIWNIOS_StrDup(char *str, void *t);
 #define ARM_ERR -1
 #define ARM_ERR_INV_OFF -2
 #define ARM_ERR_INV_REG -3
@@ -77,7 +77,6 @@ char *__AIWNIOS_StrDup(char *str,void *t);
 #define ARM_AL 0xe
 #define ARM_NV 0xf
 
-
 #define HTT_INVALID 0
 #define HTT_DEFINE_STR 0x1
 #define HTT_KEYWORD 0x2
@@ -88,11 +87,11 @@ char *__AIWNIOS_StrDup(char *str,void *t);
 #define HTF_EXTERN 0x40
 #define HTT_IMPORT_SYS_SYM 0x80
 #define HTT_EXPORT_SYS_SYM 0x100
-#define HTT_IMPORT_SYS_SYM2 0x200 //See arm_loader.c
+#define HTT_IMPORT_SYS_SYM2 0x200 // See arm_loader.c
 struct CCmpCtrl;
 struct CRPN;
 struct CHashClass;
-typedef struct CRPN CRPN; 
+typedef struct CRPN CRPN;
 //
 // README
 //
@@ -111,7 +110,7 @@ struct CCodeCtrl;
 struct CHashFun;
 struct CCodeMisc;
 typedef struct CQue {
-	struct CQue *last, *next;
+  struct CQue *last, *next;
 } CQue;
 #define HClF_LOCKED 1
 #define MEM_HEAP_HASH_SIZE 1024
@@ -120,196 +119,196 @@ typedef struct CQue {
 struct CHashTable;
 #include <setjmp.h>
 typedef struct CExceptPad {
-	int64_t gp[30-18+1];
-	double fp[15-8+1];
+  int64_t gp[30 - 18 + 1];
+  double fp[15 - 8 + 1];
 } CExceptPad;
 typedef struct CExcept {
-	CQue base;
-	jmp_buf ctx;
+  CQue base;
+  jmp_buf ctx;
 } CExcept;
 typedef struct CTask {
-	int64_t task_signature;
-	CQue* except; // CExcept
-	int64_t except_ch;
-	int64_t catch_except;
-	struct CHashTable* hash_table;
-	void* stack;
-	char ctx[2048];
-	jmp_buf throw_pad;
-	struct CHeapCtrl* heap;
+  int64_t task_signature;
+  CQue *except; // CExcept
+  int64_t except_ch;
+  int64_t catch_except;
+  struct CHashTable *hash_table;
+  void *stack;
+  char ctx[2048];
+  jmp_buf throw_pad;
+  struct CHeapCtrl *heap;
 } CTask;
 typedef struct CHeapCtrl {
-	int32_t hc_signature;
-	char is_code_heap;
-	int64_t locked_flags, alloced_u8s, used_u8s;
-	struct CTask* mem_task;
-	struct CMemUnused *malloc_free_lst, *heap_hash[MEM_HEAP_HASH_SIZE / 8+1];
-	CQue mem_blks;
+  int32_t hc_signature;
+  char is_code_heap;
+  int64_t locked_flags, alloced_u8s, used_u8s;
+  struct CTask *mem_task;
+  struct CMemUnused *malloc_free_lst, *heap_hash[MEM_HEAP_HASH_SIZE / 8 + 1];
+  CQue mem_blks;
 } CHeapCtrl;
 typedef struct CMemBlk {
-	CQue base;
-	int64_t pags;
+  CQue base;
+  int64_t pags;
 } CMemBlk;
 typedef struct CMemUnused {
-	// MUST BE FIRST MEMBER
-	struct CMemUnused* next;
-	CHeapCtrl* hc;
-	int64_t sz, pad;
+  // MUST BE FIRST MEMBER
+  struct CMemUnused *next;
+  CHeapCtrl *hc;
+  int64_t sz, pad;
 } CMemUnused;
 typedef struct CHash {
-	struct CHash* next;
-	char* str;
-	int32_t type, use_cnt;
+  struct CHash *next;
+  char *str;
+  int32_t type, use_cnt;
 } CHash;
 typedef struct CHashTable {
-	struct CHashTable* next;
-	int64_t mask, locked_flags;
-	CHash** body;
+  struct CHashTable *next;
+  int64_t mask, locked_flags;
+  CHash **body;
 } CHashTable;
 // This represents a peice of text being lexed(it could be a file macro, or
 // such)
 typedef struct CLexFile {
-	//
-	// If we include a file,we put the current file on hold
-	// last will point to the "old" file we are in
-	//
-	struct CLexFile* last;
-	char *filename, *text,*dir;
-	int64_t ln, col, pos,is_file;
+  //
+  // If we include a file,we put the current file on hold
+  // last will point to the "old" file we are in
+  //
+  struct CLexFile *last;
+  char *filename, *text, *dir;
+  int64_t ln, col, pos, is_file;
 } CLexFile;
 typedef struct CHashDefineStr {
-	struct CHash base;
-	char* src_link;
-	char* name;
-	char* data;
+  struct CHash base;
+  char *src_link;
+  char *name;
+  char *data;
 } CHashDefineStr;
 typedef struct CHashKeyword {
-	struct CHash base;
-	int64_t tk;
+  struct CHash base;
+  int64_t tk;
 } CHashKeyword;
 #define STR_LEN 144
 typedef struct CLexer {
-	CLexFile* file;
-	//
-	// These are our lexer values,I put them in a union to save memory
-	//
-	int64_t str_len;
-	union {
-		int64_t integer;
-		double flt;
-		char string[STR_LEN*6];
-	};
-	//
-	// Sometimes we are lexing and want to go back a charactor
-	// LEXF_USE_LAST_CHAR allows us to simulate this.
-	//
+  CLexFile *file;
+  //
+  // These are our lexer values,I put them in a union to save memory
+  //
+  int64_t str_len;
+  union {
+    int64_t integer;
+    double flt;
+    char string[STR_LEN * 6];
+  };
+  //
+  // Sometimes we are lexing and want to go back a charactor
+  // LEXF_USE_LAST_CHAR allows us to simulate this.
+  //
 #define LEXF_USE_LAST_CHAR 1
 #define LEXF_ERROR 2
 #define LEXF_NO_EXPAND 4 // Don't expand macros
-	int64_t flags, cur_char;
-	int64_t cur_tok;
+  int64_t flags, cur_char;
+  int64_t cur_tok;
 } CLexer;
 typedef enum {
-	TK_I64 = 0x100,
-	TK_F64,
-	TK_NAME,
-	TK_STR,
-	TK_CHR,
-	TK_ERR,
-	TK_INC_INC,
-	TK_DEC_DEC,
-	TK_AND_AND,
-	TK_XOR_XOR,
-	TK_OR_OR,
-	TK_EQ_EQ,
-	TK_NE,
-	TK_LE,
-	TK_GE,
-	TK_LSH,
-	TK_RSH,
-	TK_ADD_EQ,
-	TK_SUB_EQ,
-	TK_MUL_EQ,
-	TK_DIV_EQ,
-	TK_LSH_EQ,
-	TK_RSH_EQ,
-	TK_AND_EQ,
-	TK_OR_EQ,
-	TK_XOR_EQ,
-	TK_ARROW,
-	TK_DOT_DOT_DOT,
-	TK_MOD_EQ,
-	TK_KW_UNION,
-	TK_KW_CATCH,
-	TK_KW_CLASS,
-	TK_KW_TRY,
-	TK_KW_IF,
-	TK_KW_ELSE,
-	TK_KW_FOR,
-	TK_KW_WHILE,
-	TK_KW_EXTERN,
-	TK_KW__EXTERN,
-	TK_KW_RETURN,
-	TK_KW_SIZEOF,
-	TK_KW__INTERN,
-	TK_KW_DO,
-	TK_KW_ASM,
-	TK_KW_GOTO,
-	TK_KW_BREAK,
-	TK_KW_SWITCH,
-	TK_KW_START,
-	TK_KW_END,
-	TK_KW_CASE,
-	TK_KW_DEFUALT,
-	TK_KW_PUBLIC,
-	TK_KW_OFFSET,
-	TK_KW_IMPORT,
-	TK_KW__IMPORT,
-	TK_KW_REG,
-	TK_KW_NOREG,
-	TK_KW_LASTCLASS,
-	TK_KW_NOWARN,
-	TK_KW_STATIC,
-	TK_KW_LOCK,
-	TK_KW_DEFINED,
-	TK_KW_INTERRUPT,
-	TK_KW_HASERRCODE,
-	TK_KW_ARGPOP,
-	TK_KW_NOARGPOP,
+  TK_I64 = 0x100,
+  TK_F64,
+  TK_NAME,
+  TK_STR,
+  TK_CHR,
+  TK_ERR,
+  TK_INC_INC,
+  TK_DEC_DEC,
+  TK_AND_AND,
+  TK_XOR_XOR,
+  TK_OR_OR,
+  TK_EQ_EQ,
+  TK_NE,
+  TK_LE,
+  TK_GE,
+  TK_LSH,
+  TK_RSH,
+  TK_ADD_EQ,
+  TK_SUB_EQ,
+  TK_MUL_EQ,
+  TK_DIV_EQ,
+  TK_LSH_EQ,
+  TK_RSH_EQ,
+  TK_AND_EQ,
+  TK_OR_EQ,
+  TK_XOR_EQ,
+  TK_ARROW,
+  TK_DOT_DOT_DOT,
+  TK_MOD_EQ,
+  TK_KW_UNION,
+  TK_KW_CATCH,
+  TK_KW_CLASS,
+  TK_KW_TRY,
+  TK_KW_IF,
+  TK_KW_ELSE,
+  TK_KW_FOR,
+  TK_KW_WHILE,
+  TK_KW_EXTERN,
+  TK_KW__EXTERN,
+  TK_KW_RETURN,
+  TK_KW_SIZEOF,
+  TK_KW__INTERN,
+  TK_KW_DO,
+  TK_KW_ASM,
+  TK_KW_GOTO,
+  TK_KW_BREAK,
+  TK_KW_SWITCH,
+  TK_KW_START,
+  TK_KW_END,
+  TK_KW_CASE,
+  TK_KW_DEFUALT,
+  TK_KW_PUBLIC,
+  TK_KW_OFFSET,
+  TK_KW_IMPORT,
+  TK_KW__IMPORT,
+  TK_KW_REG,
+  TK_KW_NOREG,
+  TK_KW_LASTCLASS,
+  TK_KW_NOWARN,
+  TK_KW_STATIC,
+  TK_KW_LOCK,
+  TK_KW_DEFINED,
+  TK_KW_INTERRUPT,
+  TK_KW_HASERRCODE,
+  TK_KW_ARGPOP,
+  TK_KW_NOARGPOP,
 } LexTok;
 typedef struct CArrayDim {
-	struct CArrayDim* next;
-	int64_t cnt, total_cnt;
+  struct CArrayDim *next;
+  int64_t cnt, total_cnt;
 } CArrayDim;
 typedef struct CMemberLst {
-	struct CMemberLst *next, *last;
-	struct CHashClass* member_class;
-	CArrayDim dim;
-	struct CHashFun* fun_ptr;
-	char* str;
+  struct CMemberLst *next, *last;
+  struct CHashClass *member_class;
+  CArrayDim dim;
+  struct CHashFun *fun_ptr;
+  char *str;
 #define MLF_STATIC 1
 #define MLF_DFT_AVAILABLE 2
-	int64_t off, reg, use_cnt, flags;
-	union {
-		int64_t dft_val;
-		double dft_val_flt;
-		//USed for MLF_STATIC,this is a heap allocated "static" variable
-		char *static_bytes;
-	};
+  int64_t off, reg, use_cnt, flags;
+  union {
+    int64_t dft_val;
+    double dft_val_flt;
+    // USed for MLF_STATIC,this is a heap allocated "static" variable
+    char *static_bytes;
+  };
 } CMemberLst;
 typedef struct CHashImport {
-	CHash base;
-	char** address;
+  CHash base;
+  char **address;
 } CHashImport;
 #define STAR_CNT 5
 typedef struct CHashClass {
-	CHash base;
-	char* src_link;
-	char* import_name;
+  CHash base;
+  char *src_link;
+  char *import_name;
 #define REG_ALLOC -1
 #define REG_NONE -2
 #define REG_MAYBE -3
-	// TODO make a mechanism for assigning hardware regs
+  // TODO make a mechanism for assigning hardware regs
 
 #define RT_U0 -1
 #define RT_UNDEF 0
@@ -328,10 +327,10 @@ typedef struct CHashClass {
 #define CLSF_VARGS 1
 #define CLSF_FUNPTR 2
 
-	int64_t member_cnt, ptr_star_cnt, raw_type, flags, use_cnt, sz;
-	struct CHashClass* base_class;
-	CMemberLst* members_lst;
-	struct CHashClass* fwd_class;
+  int64_t member_cnt, ptr_star_cnt, raw_type, flags, use_cnt, sz;
+  struct CHashClass *base_class;
+  CMemberLst *members_lst;
+  struct CHashClass *fwd_class;
 } CHashClass;
 
 typedef struct CHashExport {
@@ -339,77 +338,78 @@ typedef struct CHashExport {
   char *val;
 } CHashExport;
 
-
 typedef struct CHashFun {
-	CHashClass base;
-	char* import_name;
-	CHashClass* return_class;
-	int64_t argc;
-	void* fun_ptr;
+  CHashClass base;
+  char *import_name;
+  CHashClass *return_class;
+  int64_t argc;
+  void *fun_ptr;
 } CHashFun;
 typedef struct CHashGlblVar {
-	CHash base;
-	char *src_link, *import_name;
-	CHashClass* var_class;
-	void* data_addr;
-	CArrayDim dim;
-	CHashFun* fun_ptr;
+  CHash base;
+  char *src_link, *import_name;
+  CHashClass *var_class;
+  void *data_addr;
+  CArrayDim dim;
+  CHashFun *fun_ptr;
 } CHashGlblVar;
 typedef struct CCodeCtrl {
-	struct CCodeCtrl* next;
-	CQue* ir_code;
-	CQue* code_misc;
-	struct CCodeMisc* break_to;
-	int64_t final_pass; //See OptPassFinal
+  struct CCodeCtrl *next;
+  CQue *ir_code;
+  CQue *code_misc;
+  struct CCodeMisc *break_to;
+  int64_t final_pass; // See OptPassFinal
   int64_t min_ln;
   char **dbg_info;
   int64_t statics_offset;
   CHeapCtrl *hc;
 } CCodeCtrl;
 typedef struct CCodeMiscRef {
-	struct CCodeMiscRef *next;
-	int32_t *add_to,offset;
-  //For arm
-  int32_t (*patch_cond_br)(int64_t,int64_t);
+  struct CCodeMiscRef *next;
+  int32_t *add_to, offset;
+  // For arm
+  int32_t (*patch_cond_br)(int64_t, int64_t);
   int32_t (*patch_uncond_br)(int64_t);
   int64_t user_data1;
   int64_t user_data2;
 } CCodeMiscRef;
 typedef struct CCodeMisc {
-	CQue base;
+  CQue base;
 #define CMT_LABEL 1
 #define CMT_JMP_TAB 2
 #define CMT_STRING 3
 #define CMT_FLOAT_CONST 4
 #define CMT_INT_CONST 5 // ARM has constraints on literals
 #define CMT_RELOC_U64 6
-#define CMT_STATIC_DATA 7 //integer is the offset(in the statics data) str/str_len is the data
+#define CMT_STATIC_DATA                                                        \
+  7 // integer is the offset(in the statics data) str/str_len is the data
 #define CMT_SHORT_ADDR 8
 #define CMF_DEFINED 1 // Used with Labels to tell if already defined
-#define CMF_JMP_TABLE_TAINTED 2 // Used with jump tables to tell if we tained the floating point registers
-	int32_t type, flags;
-	// These are used for jump tables
-	int64_t lo, hi;
-	char* str;
-	void* addr;
-	union {
-		struct CCodeMisc* dft_lab;
-		int64_t str_len;
-    };
-	void **patch_addr;
-	union {
-		struct CCodeMisc** jmp_tab;
-		double flt;
-		int64_t integer;
-	};
-  int32_t aot_before_hint; //See __HC_SetAOTRelocBeforeRIP
+#define CMF_JMP_TABLE_TAINTED                                                  \
+  2 // Used with jump tables to tell if we tained the floating point registers
+  int32_t type, flags;
+  // These are used for jump tables
+  int64_t lo, hi;
+  char *str;
+  void *addr;
+  union {
+    struct CCodeMisc *dft_lab;
+    int64_t str_len;
+  };
+  void **patch_addr;
+  union {
+    struct CCodeMisc **jmp_tab;
+    double flt;
+    int64_t integer;
+  };
+  int32_t aot_before_hint; // See __HC_SetAOTRelocBeforeRIP
   int32_t use_cnt;
-  //The bit is set if the floating point register is alive at this inst
+  // The bit is set if the floating point register is alive at this inst
   int64_t freg_alive_bmp;
   CCodeMiscRef *refs;
 } CCodeMisc;
 typedef struct CCmpCtrl {
-	CLexer* lex;
+  CLexer *lex;
 //
 // See PrsSwitch,this will make break statements turn into IC_SUB_RET
 //
@@ -417,22 +417,22 @@ typedef struct CCmpCtrl {
 #define CCF_STRINGS_ON_HEAP 0x2
 #define CCF_AOT_COMPILE 0x4
 #define CCF_ICMOV_NO_USE_RAX 0x8
-	int64_t flags;
-	CHashFun* cur_fun;
-	CCodeCtrl* code_ctrl;
-	int64_t backend_user_data0;
-	int64_t backend_user_data1;
-	int64_t backend_user_data2;
-	int64_t backend_user_data3;
-	int64_t backend_user_data4;
-	int64_t backend_user_data5;
-	int64_t backend_user_data6;
-	int64_t backend_user_data7;
-	int64_t backend_user_data8;
-	int64_t backend_user_data9;
-	int64_t backend_user_data10;
-  //Used for returns
-  CCodeMisc *epilog_label,*statics_label;
+  int64_t flags;
+  CHashFun *cur_fun;
+  CCodeCtrl *code_ctrl;
+  int64_t backend_user_data0;
+  int64_t backend_user_data1;
+  int64_t backend_user_data2;
+  int64_t backend_user_data3;
+  int64_t backend_user_data4;
+  int64_t backend_user_data5;
+  int64_t backend_user_data6;
+  int64_t backend_user_data7;
+  int64_t backend_user_data8;
+  int64_t backend_user_data9;
+  int64_t backend_user_data10;
+  // Used for returns
+  CCodeMisc *epilog_label, *statics_label;
   CHeapCtrl *hc;
 } CCmpCtrl;
 #define PRSF_CLASS 1
@@ -444,130 +444,131 @@ typedef struct CCmpCtrl {
 #define PRSF__IMPORT 0x40
 #define PRSF_STATIC 0x80
 enum {
-	IC_GOTO,
+  IC_GOTO,
   IC_GOTO_IF,
   IC_TO_I64,
   IC_TO_F64,
-	IC_LABEL,
-	IC_STATIC, //Just a pointer,integer is the pointer
-	IC_LOCAL,
-	IC_GLOBAL,
-	IC_NOP,
-	IC_PAREN,
-	IC_NEG,
-	IC_POS,
-	IC_NAME,
-	IC_STR, //->code_misc
-	IC_CHR,
-	IC_POW,
-	IC_ADD,
-	IC_EQ,
-	IC_SUB,
-	IC_DIV,
-	IC_MUL,
-	IC_DEREF,
-	IC_AND,
-	IC_ADDR_OF,
-	IC_XOR,
-	IC_MOD,
-	IC_OR,
-	IC_LT,
-	IC_GT,
-	IC_LNOT,
-	IC_BNOT,
-	IC_POST_INC, //->integer is amount
-	IC_POST_DEC, //->integer is amount
-	IC_PRE_INC, //->integer is amount
-	IC_PRE_DEC, //->integer is amount
-	IC_AND_AND,
-	IC_OR_OR,
-	IC_XOR_XOR,
-	IC_EQ_EQ,
-	IC_NE,
-	IC_LE,
-	IC_GE,
-	IC_LSH,
-	IC_RSH,
-	IC_ADD_EQ,
-	IC_SUB_EQ,
-	IC_MUL_EQ,
-	IC_DIV_EQ,
-	IC_LSH_EQ,
-	IC_RSH_EQ,
-	IC_AND_EQ,
-	IC_OR_EQ,
-	IC_XOR_EQ,
-	IC_ARROW,
-	IC_DOT,
-	IC_MOD_EQ,
-	IC_I64,
-	IC_F64,
-	IC_ARRAY_ACC,
-	IC_RET,
-	IC_CALL,
-	IC_COMMA,
-	IC_UNBOUNDED_SWITCH, //->length is body count
-	IC_BOUNDED_SWITCH, //->length is body count
-	IC_SUB_RET,
-	IC_SUB_PROLOG,
-	IC_SUB_CALL, //->code_misc is the label to IC_SUB_PROLOG
-	IC_TYPECAST, //->ir_dim/ir_fun point to the extra silly sauce type info
-	//
-	// Thes are used by Opt-pass
-	//
-	IC_BASE_PTR,
-	IC_IREG,
-	IC_FREG,
-	IC_LOAD,
-	IC_STORE,
-	//
-	// These are used by the HolyC side
-	//
-	__IC_VARGS, //This will create vargs for  __IC_CALL
-  __IC_ARG, //This will write an argument into a destination
+  IC_LABEL,
+  IC_STATIC, // Just a pointer,integer is the pointer
+  IC_LOCAL,
+  IC_GLOBAL,
+  IC_NOP,
+  IC_PAREN,
+  IC_NEG,
+  IC_POS,
+  IC_NAME,
+  IC_STR, //->code_misc
+  IC_CHR,
+  IC_POW,
+  IC_ADD,
+  IC_EQ,
+  IC_SUB,
+  IC_DIV,
+  IC_MUL,
+  IC_DEREF,
+  IC_AND,
+  IC_ADDR_OF,
+  IC_XOR,
+  IC_MOD,
+  IC_OR,
+  IC_LT,
+  IC_GT,
+  IC_LNOT,
+  IC_BNOT,
+  IC_POST_INC, //->integer is amount
+  IC_POST_DEC, //->integer is amount
+  IC_PRE_INC,  //->integer is amount
+  IC_PRE_DEC,  //->integer is amount
+  IC_AND_AND,
+  IC_OR_OR,
+  IC_XOR_XOR,
+  IC_EQ_EQ,
+  IC_NE,
+  IC_LE,
+  IC_GE,
+  IC_LSH,
+  IC_RSH,
+  IC_ADD_EQ,
+  IC_SUB_EQ,
+  IC_MUL_EQ,
+  IC_DIV_EQ,
+  IC_LSH_EQ,
+  IC_RSH_EQ,
+  IC_AND_EQ,
+  IC_OR_EQ,
+  IC_XOR_EQ,
+  IC_ARROW,
+  IC_DOT,
+  IC_MOD_EQ,
+  IC_I64,
+  IC_F64,
+  IC_ARRAY_ACC,
+  IC_RET,
+  IC_CALL,
+  IC_COMMA,
+  IC_UNBOUNDED_SWITCH, //->length is body count
+  IC_BOUNDED_SWITCH,   //->length is body count
+  IC_SUB_RET,
+  IC_SUB_PROLOG,
+  IC_SUB_CALL, //->code_misc is the label to IC_SUB_PROLOG
+  IC_TYPECAST, //->ir_dim/ir_fun point to the extra silly sauce type info
+  //
+  // Thes are used by Opt-pass
+  //
+  IC_BASE_PTR,
+  IC_IREG,
+  IC_FREG,
+  IC_LOAD,
+  IC_STORE,
+  //
+  // These are used by the HolyC side
+  //
+  __IC_VARGS, // This will create vargs for  __IC_CALL
+  __IC_ARG,   // This will write an argument into a destination
   __IC_SET_FRAME_SIZE,
   IC_RELOC,
-  __IC_CALL, //Doesnt do CHashFun specific checks,good for HolyC side
-  __IC_STATICS_SIZE, //Used from the HolyC part to allocate a chunk of static stuff
-  __IC_STATIC_REF, //Offset from static area,see __IC_STATICS_SIZE 
-  __IC_SET_STATIC_DATA, //CMT_STATIC_DATA will have the silly sauce
-  IC_SHORT_ADDR, //Like a IC_RELOC,but the jump is an AARCH64 short jump
-    //These are "optional"
-	IC_BT,
-	IC_BTC,
-	IC_BTS,
-	IC_BTR,
-	IC_LBTC,
-	IC_LBTS,
-	IC_LBTR,
-	IC_MAX_I64,
-	IC_MIN_I64,
-	IC_MAX_U64,
-	IC_MIN_U64,
-	IC_SIGN_I64,
-	IC_SQR_I64,
-	IC_SQR_U64,
-	IC_SQR,
-	IC_ABS,
-	IC_SQRT,
-	IC_SIN,
-	IC_COS,
-	IC_TAN,
-	IC_ATAN,
-	IC_RAW_BYTES,
-	IC_GET_VARGS_PTR, //Doing this sets the function as a VARGS function
-	IC_CNT, //MUST BE THE LAST ITEM
+  __IC_CALL,         // Doesnt do CHashFun specific checks,good for HolyC side
+  __IC_STATICS_SIZE, // Used from the HolyC part to allocate a chunk of static
+                     // stuff
+  __IC_STATIC_REF,   // Offset from static area,see __IC_STATICS_SIZE
+  __IC_SET_STATIC_DATA, // CMT_STATIC_DATA will have the silly sauce
+  IC_SHORT_ADDR,        // Like a IC_RELOC,but the jump is an AARCH64 short jump
+                        // These are "optional"
+  IC_BT,
+  IC_BTC,
+  IC_BTS,
+  IC_BTR,
+  IC_LBTC,
+  IC_LBTS,
+  IC_LBTR,
+  IC_MAX_I64,
+  IC_MIN_I64,
+  IC_MAX_U64,
+  IC_MIN_U64,
+  IC_SIGN_I64,
+  IC_SQR_I64,
+  IC_SQR_U64,
+  IC_SQR,
+  IC_ABS,
+  IC_SQRT,
+  IC_SIN,
+  IC_COS,
+  IC_TAN,
+  IC_ATAN,
+  IC_RAW_BYTES,
+  IC_GET_VARGS_PTR, // Doing this sets the function as a VARGS function
+  IC_CNT,           // MUST BE THE LAST ITEM
 };
 typedef struct CICArg {
-	// Feel free to define more in backend
+  // Feel free to define more in backend
 #define MD_NULL -1
-#define MD_REG 1 // raw_type==RT_F64 for flt register
-#define MD_FRAME 2 // ditto
-#define MD_PTR 3 // ditto
+#define MD_REG 1       // raw_type==RT_F64 for flt register
+#define MD_FRAME 2     // ditto
+#define MD_PTR 3       // ditto
 #define MD_INDIR_REG 4 // ditto
 #define MD_I64 5
 #define MD_F64 6
-#define MD_STATIC 7 //off points to start of function's code 
+#define MD_STATIC 7 // off points to start of function's code
 //
 // Here's the deal. Arm let's you shift like this (ldr dst,[a,b,lsl 3])
 //
@@ -578,106 +579,111 @@ typedef struct CICArg {
 // X86_64 SIB
 //
 #define __MD_X86_64_SIB 9
-//Like X86_64 but uses LEA
+// Like X86_64 but uses LEA
 #define __MD_X86_64_LEA_SIB 10
 #define MD_CODE_MISC_PTR 11
-	int32_t mode;
-	int32_t raw_type;
-	int8_t reg,reg2,fallback_reg;
-  //True on enter of things that want to set the flags
-  //True/False if the result of the thing set the flags or not
-	char set_flags;
-	//keep the value in a temp location,good for removing reundant stores
-	char keep_in_tmp;
-	union {
-		CCodeMisc *code_misc;
-		int64_t integer;
-		int64_t off;
-		double flt;
-	};
- 	int8_t __SIB_scale,pop_n_tmp_regs;
- 	CRPN *__sib_base_rpn,*__sib_idx_rpn;
+  int32_t mode;
+  int32_t raw_type;
+  int8_t reg, reg2, fallback_reg;
+  // True on enter of things that want to set the flags
+  // True/False if the result of the thing set the flags or not
+  char set_flags;
+  // keep the value in a temp location,good for removing reundant stores
+  char keep_in_tmp;
+  union {
+    CCodeMisc *code_misc;
+    int64_t integer;
+    int64_t off;
+    double flt;
+  };
+  int8_t __SIB_scale, pop_n_tmp_regs;
+  CRPN *__sib_base_rpn, *__sib_idx_rpn;
 } CICArg;
 enum {
-	ICF_SPILLED=1, // See PushSpilledTmp in XXX_backend.c
-	ICF_DEAD_CODE=2,
-	ICF_TMP_NO_UNDO=4,
-	ICF_PRECOMPUTED=8, //Doesnt re-compile a node,useful for putting in "dummy" values
-	ICF_SIB=16, //Has 2 registers (base and idnex)
-	ICF_INDIR_REG=32, //Has 1 registers (idnex)
-	ICF_STUFF_IN_REG=64, //Will stuff the result into a register(.stuff_in_reg) once result is computed
+  ICF_SPILLED = 1, // See PushSpilledTmp in XXX_backend.c
+  ICF_DEAD_CODE = 2,
+  ICF_TMP_NO_UNDO = 4,
+  ICF_PRECOMPUTED =
+      8,        // Doesnt re-compile a node,useful for putting in "dummy" values
+  ICF_SIB = 16, // Has 2 registers (base and idnex)
+  ICF_INDIR_REG = 32,    // Has 1 registers (idnex)
+  ICF_STUFF_IN_REG = 64, // Will stuff the result into a register(.stuff_in_reg)
+                         // once result is computed
 };
 struct CRPN {
-	CQue base;
+  CQue base;
 
-	int16_t type, length, raw_type, flags,ic_line;
-	CHashClass* ic_class;
-	CHashFun* ic_fun;
-	CArrayDim* ic_dim;
-	union {
-		double flt;
-		char *raw_bytes;
-		int64_t integer;
-		char* string;
-		CMemberLst* local_mem;
-		CHashGlblVar* global_var;
-		CCodeMisc* code_misc;
-		CCodeMisc* break_to;
-	};
-	CCodeMisc *code_misc2,*code_misc3,*code_misc4;
-	CICArg res;
-	CRPN *tree1,*tree2,*ic_fwd;
-	//Will be stored into this reg if ICF_STUFF_IN_REG is set
-	char stuff_in_reg;
+  int16_t type, length, raw_type, flags, ic_line;
+  CHashClass *ic_class;
+  CHashFun *ic_fun;
+  CArrayDim *ic_dim;
+  union {
+    double flt;
+    char *raw_bytes;
+    int64_t integer;
+    char *string;
+    CMemberLst *local_mem;
+    CHashGlblVar *global_var;
+    CCodeMisc *code_misc;
+    CCodeMisc *break_to;
+  };
+  CCodeMisc *code_misc2, *code_misc3, *code_misc4;
+  CICArg res;
+  CRPN *tree1, *tree2, *ic_fwd;
+  // Will be stored into this reg if ICF_STUFF_IN_REG is set
+  char stuff_in_reg;
 };
-extern char *Compile(struct CCmpCtrl *cctrl,int64_t *sz,char **dbg_info);
+extern char *Compile(struct CCmpCtrl *cctrl, int64_t *sz, char **dbg_info);
 extern __thread struct CTask *Fs;
 void AIWNIOS_throw(uint64_t code);
 #define throw AIWNIOS_throw
 void QueDel(CQue *f);
 int64_t QueCnt(CQue *head);
 void QueRem(CQue *a);
-void QueIns(CQue *a,CQue *to);
+void QueIns(CQue *a, CQue *to);
 void QueInit(CQue *i);
 
 void HashTableDel(CHashTable *table);
-int64_t HashRemDel(CHash *h,CHashTable *table,int64_t inst);
-void HashAdd(CHash *h,CHashTable *table);
-CHash **HashBucketFind(char *str,CHashTable *table);
-CHash *HashSingleTableFind(char *str,CHashTable *table,int64_t type,int64_t inst);
-CHash *HashFind(char *str,CHashTable *table,int64_t type,int64_t inst);
-CHashTable *HashTableNew(int64_t sz,void *task);
+int64_t HashRemDel(CHash *h, CHashTable *table, int64_t inst);
+void HashAdd(CHash *h, CHashTable *table);
+CHash **HashBucketFind(char *str, CHashTable *table);
+CHash *HashSingleTableFind(char *str, CHashTable *table, int64_t type,
+                           int64_t inst);
+CHash *HashFind(char *str, CHashTable *table, int64_t type, int64_t inst);
+CHashTable *HashTableNew(int64_t sz, void *task);
 void HashDel(CHash *h);
 int64_t HashStr(char *str);
 
-
-void PrsBindCSymbol(char *name,void *ptr,int64_t arity);
+void PrsBindCSymbol(char *name, void *ptr, int64_t arity);
 void ICFree(CRPN *ic);
 CHashClass *PrsClassNew();
-char *PrsArray(CCmpCtrl *ccmp,CHashClass *base,CArrayDim *dim,char *write_to);
-int64_t PrsFunArgs(CCmpCtrl *ccmp,CHashFun *fun);
-int64_t PrsArrayDim(CCmpCtrl *ccmp,CArrayDim *to);
+char *PrsArray(CCmpCtrl *ccmp, CHashClass *base, CArrayDim *dim,
+               char *write_to);
+int64_t PrsFunArgs(CCmpCtrl *ccmp, CHashFun *fun);
+int64_t PrsArrayDim(CCmpCtrl *ccmp, CArrayDim *to);
 double PrsF64(CCmpCtrl *ccmp);
 int64_t PrsI64(CCmpCtrl *ccmp);
 int64_t _PrsStmt(CCmpCtrl *ccmp);
-int64_t ParseWarn(CCmpCtrl *ctrl,char *fmt,...);
-int64_t ParseExpr(CCmpCtrl *ccmp,int64_t flags);
-int64_t AssignRawTypeToNode(CCmpCtrl *ccmp,CRPN *rpn);
-void SysSymImportsResolve(char *sym,int64_t flags);
-CRPN *ParserDumpIR(CRPN *rpn,int64_t indent);
-CRPN *ICArgN(CRPN *rpn,int64_t n);
+int64_t ParseWarn(CCmpCtrl *ctrl, char *fmt, ...);
+int64_t ParseExpr(CCmpCtrl *ccmp, int64_t flags);
+int64_t AssignRawTypeToNode(CCmpCtrl *ccmp, CRPN *rpn);
+void SysSymImportsResolve(char *sym, int64_t flags);
+CRPN *ParserDumpIR(CRPN *rpn, int64_t indent);
+CRPN *ICArgN(CRPN *rpn, int64_t n);
 CRPN *ICFwd(CRPN *rpn);
 CCmpCtrl *CmpCtrlNew(CLexer *lex);
-CMemberLst *MemberFind(char *needle,CHashClass *cls);
-CMemberLst *MemberFind(char *needle,CHashClass *cls);
-CHashClass *PrsClass(CCmpCtrl *cctrl,int64_t flags);
-CHashClass *PrsClass(CCmpCtrl *cctrl,int64_t _flags);
-int64_t PrsDecl(CCmpCtrl *ccmp,CHashClass *base,CHashClass *add_to,int64_t *is_func_decl,int64_t flags,char *import_name);
-int64_t PrsDecl(CCmpCtrl *ccmp,CHashClass *base,CHashClass *add_to,int64_t *is_func_decl,int64_t flags,char *import_name);
+CMemberLst *MemberFind(char *needle, CHashClass *cls);
+CMemberLst *MemberFind(char *needle, CHashClass *cls);
+CHashClass *PrsClass(CCmpCtrl *cctrl, int64_t flags);
+CHashClass *PrsClass(CCmpCtrl *cctrl, int64_t _flags);
+int64_t PrsDecl(CCmpCtrl *ccmp, CHashClass *base, CHashClass *add_to,
+                int64_t *is_func_decl, int64_t flags, char *import_name);
+int64_t PrsDecl(CCmpCtrl *ccmp, CHashClass *base, CHashClass *add_to,
+                int64_t *is_func_decl, int64_t flags, char *import_name);
 int64_t PrsTry(CCmpCtrl *cctrl);
 int64_t PrsTry(CCmpCtrl *cctrl);
-int64_t ParseErr(CCmpCtrl *ctrl,char *fmt,...);
-int64_t ParseErr(CCmpCtrl *ctrl,char *fmt,...);
+int64_t ParseErr(CCmpCtrl *ctrl, char *fmt, ...);
+int64_t ParseErr(CCmpCtrl *ctrl, char *fmt, ...);
 int64_t PrsReturn(CCmpCtrl *ccmp);
 int64_t PrsReturn(CCmpCtrl *ccmp);
 int64_t PrsGoto(CCmpCtrl *ccmp);
@@ -698,20 +704,23 @@ int64_t PrsIf(CCmpCtrl *ccmp);
 int64_t PrsIf(CCmpCtrl *ccmp);
 int64_t PrsStmt(CCmpCtrl *ccmp);
 int64_t PrsStmt(CCmpCtrl *ccmp);
-int64_t PrsKw(CCmpCtrl *ccmp,int64_t);
-int64_t PrsKw(CCmpCtrl *ccmp,int64_t kwt);
-CCodeMisc *CodeMiscNew(CCmpCtrl *ccmp,int64_t type);
-CHashClass *PrsType(CCmpCtrl *ccmp,CHashClass *base,char **name,CHashFun **fun,CArrayDim *dim);
-CHashClass *PrsType(CCmpCtrl *ccmp,CHashClass *base,char **name,CHashFun **fun,CArrayDim *dim);
+int64_t PrsKw(CCmpCtrl *ccmp, int64_t);
+int64_t PrsKw(CCmpCtrl *ccmp, int64_t kwt);
+CCodeMisc *CodeMiscNew(CCmpCtrl *ccmp, int64_t type);
+CHashClass *PrsType(CCmpCtrl *ccmp, CHashClass *base, char **name,
+                    CHashFun **fun, CArrayDim *dim);
+CHashClass *PrsType(CCmpCtrl *ccmp, CHashClass *base, char **name,
+                    CHashFun **fun, CArrayDim *dim);
 void PrsTests();
 
-void TaskInit(CTask *task,void *addr,int64_t stk_sz);
-struct CHeapCtrl *HeapCtrlInit(struct CHeapCtrl *ct,CTask *task,int64_t is_code_heap);
+void TaskInit(CTask *task, void *addr, int64_t stk_sz);
+struct CHeapCtrl *HeapCtrlInit(struct CHeapCtrl *ct, CTask *task,
+                               int64_t is_code_heap);
 void TaskExit();
 extern __thread struct CTask *HolyFs;
 extern __thread struct CTask *Fs;
 
-char *OptPassFinal(CCmpCtrl *cctrl,int64_t *res_sz,char **dbg_info);
+char *OptPassFinal(CCmpCtrl *cctrl, int64_t *res_sz, char **dbg_info);
 
 void AIWNIOS_ExitCatch();
 jmp_buf *__throw(uint64_t code);
@@ -721,253 +730,252 @@ jmp_buf *__enter_try();
 
 void LexTests();
 void LexerDump(CLexer *lex);
-CLexer *LexerNew(char *filename,char *text);
+CLexer *LexerNew(char *filename, char *text);
 int64_t Lex(CLexer *lex);
 int64_t LexAdvChr(CLexer *lex);
-char *LexSrcLink(CLexer *lex,void *task);
+char *LexSrcLink(CLexer *lex, void *task);
 
-
-char *__AIWNIOS_StrDup(char *str,void *t);
+char *__AIWNIOS_StrDup(char *str, void *t);
 void HeapCtrlDel(CHeapCtrl *ct);
-CHeapCtrl *HeapCtrlInit(CHeapCtrl *ct,CTask *task,int64_t code_heap);
-void *__AIWNIOS_CAlloc(int64_t cnt,void *t);
+CHeapCtrl *HeapCtrlInit(CHeapCtrl *ct, CTask *task, int64_t code_heap);
+void *__AIWNIOS_CAlloc(int64_t cnt, void *t);
 int64_t MSize(void *ptr);
 void __AIWNIOS_Free(void *ptr);
-void *__AIWNIOS_MAlloc(int64_t cnt,void *t);
+void *__AIWNIOS_MAlloc(int64_t cnt, void *t);
 
-
-extern int64_t Misc_Bt(void *ptr,int64_t);
-extern int64_t Misc_Btc(void *ptr,int64_t);
-extern int64_t Misc_Btr(void *ptr,int64_t);
-extern int64_t Misc_Bts(void *ptr,int64_t);
-extern int64_t Misc_LBt(void *ptr,int64_t);
-extern int64_t Misc_LBtc(void *ptr,int64_t);
-extern int64_t Misc_LBtr(void *ptr,int64_t);
-extern int64_t Misc_LBts(void *ptr,int64_t);
+extern int64_t Misc_Bt(void *ptr, int64_t);
+extern int64_t Misc_Btc(void *ptr, int64_t);
+extern int64_t Misc_Btr(void *ptr, int64_t);
+extern int64_t Misc_Bts(void *ptr, int64_t);
+extern int64_t Misc_LBt(void *ptr, int64_t);
+extern int64_t Misc_LBtc(void *ptr, int64_t);
+extern int64_t Misc_LBtr(void *ptr, int64_t);
+extern int64_t Misc_LBts(void *ptr, int64_t);
 extern int64_t Bsr(int64_t v);
 extern int64_t Bsf(int64_t v);
-
 
 void *Misc_Caller(int64_t c);
 uint64_t ToUpper(uint64_t ch);
 char *WhichFun(char *fptr);
-int64_t LBtc(char*,int64_t);
+int64_t LBtc(char *, int64_t);
 
 //
 // These are used by optpass
 //
 #if defined(__x86_64__)
 enum {
-	RAX = 0,
-	RCX = 1,
-	RDX = 2,
-	RBX = 3,
-	RSP = 4,
-	RBP = 5,
-	RSI = 6,
-	RDI = 7,
-	R8 = 8,
-	R9 = 9,
-	R10 = 10,
-	R11 = 11,
-	R12 = 12,
-	R13 = 13,
-	R14 = 14,
-	R15 = 15,
-	RIP = 16
+  RAX = 0,
+  RCX = 1,
+  RDX = 2,
+  RBX = 3,
+  RSP = 4,
+  RBP = 5,
+  RSI = 6,
+  RDI = 7,
+  R8 = 8,
+  R9 = 9,
+  R10 = 10,
+  R11 = 11,
+  R12 = 12,
+  R13 = 13,
+  R14 = 14,
+  R15 = 15,
+  RIP = 16
 };
-#define AIWNIOS_IREG_START 10
-#define AIWNIOS_IREG_CNT (15 - AIWNIOS_IREG_START + 1 -1 +2) //-1 for R13 as it is wierd,+2 for RSI/RDI
-#define AIWNIOS_REG_FP RBP
-#define AIWNIOS_REG_SP RSP
-#define AIWNIOS_TMP_IREG_POOP R8
-#define AIWNIOS_TMP_IREG_POOP2 RCX
-#define AIWNIOS_TMP_IREG_START 0
-#define AIWNIOS_TMP_IREG_CNT 2
-#define AIWNIOS_FREG_START 6
-#define AIWNIOS_FREG_CNT (15-6+1)
-#define AIWNIOS_TMP_FREG_START 3
-#define AIWNIOS_TMP_FREG_CNT (5-3+1)
+  #define AIWNIOS_IREG_START 10
+  #define AIWNIOS_IREG_CNT                                                     \
+    (15 - AIWNIOS_IREG_START + 1 - 1 +                                         \
+     2) //-1 for R13 as it is wierd,+2 for RSI/RDI
+  #define AIWNIOS_REG_FP RBP
+  #define AIWNIOS_REG_SP RSP
+  #define AIWNIOS_TMP_IREG_POOP R8
+  #define AIWNIOS_TMP_IREG_POOP2 RCX
+  #define AIWNIOS_TMP_IREG_START 0
+  #define AIWNIOS_TMP_IREG_CNT 2
+  #define AIWNIOS_FREG_START 6
+  #define AIWNIOS_FREG_CNT (15 - 6 + 1)
+  #define AIWNIOS_TMP_FREG_START 3
+  #define AIWNIOS_TMP_FREG_CNT (5 - 3 + 1)
 
-#elif (defined(__linux__) || defined (__FreeBSD__)) && (defined (_M_ARM64) || defined(__aarch64__))
-#define AIWNIOS_IREG_START 19
-#define AIWNIOS_IREG_CNT (28 - 19 + 1)
-#define AIWNIOS_REG_FP ARM_REG_FP
-#define AIWNIOS_REG_SP ARM_REG_SP
-#define AIWNIOS_TMP_IREG_POOP 18 //Platform register,I use it as a poo poo
-#define AIWNIOS_TMP_IREG_POOP2 17 //I use it as a second poo poo ALWAYS
-#define AIWNIOS_TMP_IREG_START 8
-#define AIWNIOS_TMP_IREG_CNT (16 - 8 + 1)
-#define AIWNIOS_FREG_START 8
-#define AIWNIOS_FREG_CNT (15 - 8 + 1)
-#define AIWNIOS_TMP_FREG_START 16
-#define AIWNIOS_TMP_FREG_CNT (31 - 16 + 1)
+#elif (defined(__linux__) || defined(__FreeBSD__)) &&                          \
+    (defined(_M_ARM64) || defined(__aarch64__))
+  #define AIWNIOS_IREG_START 19
+  #define AIWNIOS_IREG_CNT (28 - 19 + 1)
+  #define AIWNIOS_REG_FP ARM_REG_FP
+  #define AIWNIOS_REG_SP ARM_REG_SP
+  #define AIWNIOS_TMP_IREG_POOP 18  // Platform register,I use it as a poo poo
+  #define AIWNIOS_TMP_IREG_POOP2 17 // I use it as a second poo poo ALWAYS
+  #define AIWNIOS_TMP_IREG_START 8
+  #define AIWNIOS_TMP_IREG_CNT (16 - 8 + 1)
+  #define AIWNIOS_FREG_START 8
+  #define AIWNIOS_FREG_CNT (15 - 8 + 1)
+  #define AIWNIOS_TMP_FREG_START 16
+  #define AIWNIOS_TMP_FREG_CNT (31 - 16 + 1)
 #endif
 
-
-#if  defined(_WIN32)||defined(WIN32) 
-#define AIWNIOS_OSTREAM stdout
-#define AIWNIOS_TEMPLATE_DIR "TODO"
+#if defined(_WIN32) || defined(WIN32)
+  #define AIWNIOS_OSTREAM stdout
+  #define AIWNIOS_TEMPLATE_DIR "TODO"
 #else
-#define AIWNIOS_OSTREAM stderr
-#define AIWNIOS_TEMPLATE_DIR "/usr/share/aiwnios"
+  #define AIWNIOS_OSTREAM stderr
+  #define AIWNIOS_TEMPLATE_DIR "/usr/share/aiwnios"
 #endif
 
-#define try                                              \
-	{                                                    \
-		if (AIWNIOS_enter_try()) {
-#define catch(body)               \
-	} else                          \
-	{                             \
-		body; \
-    AIWNIOS_ExitCatch();                     \
-	}                             \
-	}
-int64_t ARM_fmovF64I64(int64_t d,int64_t s);
-int64_t ARM_fmovI64F64(int64_t d,int64_t s);
-int64_t ARM_ldrRegRegF64(int64_t d,int64_t n,int64_t m);
-int64_t ARM_strRegRegF64(int64_t d,int64_t n,int64_t m);
-int64_t ARM_ldrPreImmF64(int64_t d,int64_t p,int64_t off);
-int64_t ARM_strPreImmF64(int64_t d,int64_t p,int64_t off);
-int64_t ARM_ldrPostImmF64(int64_t d,int64_t p,int64_t off);
-int64_t ARM_strPostImmF64(int64_t d,int64_t p,int64_t off);
-int64_t ARM_movnImmX(int64_t d,int64_t i16,int64_t sh);
-int64_t ARM_movzImmX(int64_t d,int64_t i16,int64_t sh);
-int64_t ARM_asrvRegX(int64_t d,int64_t n,int64_t m);
-int64_t ARM_lsrvRegX(int64_t d,int64_t n,int64_t m);
-int64_t ARM_lslvRegX(int64_t d,int64_t n,int64_t m);
-int64_t ARM_sdivRegX(int64_t d,int64_t n,int64_t m);
-int64_t ARM_fcmp(int64_t a,int64_t b);
-int64_t ARM_fmovReg(int64_t d,int64_t s);
-int64_t ARM_fnegReg(int64_t d,int64_t s);
-int64_t ARM_strRegImmF64(int64_t r,int64_t n,uint64_t off);
-int64_t ARM_ldrRegImmF64(int64_t r,int64_t n,uint64_t off);
-int64_t ARM_ldpPostImmX(int64_t r,int64_t r2,int64_t b,int64_t off);
-int64_t ARM_ldpPostImm(int64_t r,int64_t r2,int64_t b,int64_t off);
-int64_t ARM_stpPostImmX(int64_t r,int64_t r2,int64_t b,int64_t off);
-int64_t ARM_stpPostImm(int64_t r,int64_t r2,int64_t b,int64_t off);
-int64_t ARM_ldpPreImmX(int64_t r,int64_t r2,int64_t b,int64_t off);
-int64_t ARM_ldpPreImm(int64_t r,int64_t r2,int64_t b,int64_t off);
-int64_t ARM_stpPreImmX(int64_t r,int64_t r2,int64_t b,int64_t off);
-int64_t ARM_stpPreImm(int64_t r,int64_t r2,int64_t b,int64_t off);
-int64_t ARM_ldrPreImmX(int64_t r,int64_t b,int64_t off);
-int64_t ARM_strPreImmX(int64_t r,int64_t b,int64_t off);
-int64_t ARM_ldrPostImmX(int64_t r,int64_t b,int64_t off);
-int64_t ARM_strPostImmX(int64_t r,int64_t b,int64_t off);
-int64_t ARM_ldrPreImm(int64_t r,int64_t b,int64_t off);
-int64_t ARM_strPreImm(int64_t r,int64_t b,int64_t off);
-int64_t ARM_ldrPostImm(int64_t r,int64_t b,int64_t off);
-int64_t ARM_strPostImm(int64_t r,int64_t b,int64_t off);
-int64_t ARM_ldrLabelF64(int64_t d,int64_t label);
-int64_t ARM_ldrLabelX(int64_t d,int64_t label);
-int64_t ARM_ldrLabel(int64_t d,int64_t label);
-int64_t ARM_fcvtzs(int64_t d,int64_t n);
-int64_t ARM_ucvtf(int64_t d,int64_t n);
-int64_t ARM_scvtf(int64_t d,int64_t n);
-int64_t ARM_fsubReg(int64_t d,int64_t n,int64_t m);
-int64_t ARM_faddReg(int64_t d,int64_t n,int64_t m);
-int64_t ARM_fdivReg(int64_t d,int64_t n,int64_t m);
-int64_t ARM_fmulReg(int64_t d,int64_t n,int64_t m);
-int64_t ARM_ldrRegRegX(int64_t r,int64_t a,int64_t b);
-int64_t ARM_strRegRegX(int64_t r,int64_t a,int64_t b);
-int64_t ARM_ldrRegImmX(int64_t r,int64_t n,int64_t off);
-int64_t ARM_strRegImmX(int64_t r,int64_t n,int64_t off);
-int64_t ARM_ldrRegImm(int64_t r,int64_t n,int64_t off);
-int64_t ARM_ldrRegReg(int64_t r,int64_t a,int64_t b);
-int64_t ARM_strRegReg(int64_t r,int64_t a,int64_t b);
-int64_t ARM_strRegImm(int64_t r,int64_t n,int64_t off);
-int64_t ARM_ldrhRegImm(int64_t r,int64_t n,int64_t off);
-int64_t ARM_ldrhRegReg(int64_t r,int64_t a,int64_t b);
-int64_t ARM_strhRegImm(int64_t r,int64_t n,int64_t off);
-int64_t ARM_strhRegReg(int64_t r,int64_t a,int64_t b);
-int64_t ARM_ldrbRegReg(int64_t r,int64_t a,int64_t b);
-int64_t ARM_ldrbRegImm(int64_t r,int64_t n,int64_t off);
-int64_t ARM_strbRegImm(int64_t r,int64_t n,int64_t off);
-int64_t ARM_strbRegReg(int64_t r,int64_t a,int64_t b);
-int64_t ARM_tbnz(int64_t rt,int64_t bit,int64_t label);
-int64_t ARM_tbz(int64_t rt,int64_t bit,int64_t label);
-int64_t ARM_cbnzX(int64_t r,int64_t label);
-int64_t ARM_cbnz(int64_t r,int64_t label);
-int64_t ARM_cbzX(int64_t r,int64_t label);
-int64_t ARM_cbz(int64_t r,int64_t label);
+#define try                                                                    \
+  {                                                                            \
+    if (AIWNIOS_enter_try()) {
+#define catch(body)                                                            \
+  }                                                                            \
+  else {                                                                       \
+    body;                                                                      \
+    AIWNIOS_ExitCatch();                                                       \
+  }                                                                            \
+  }
+int64_t ARM_fmovF64I64(int64_t d, int64_t s);
+int64_t ARM_fmovI64F64(int64_t d, int64_t s);
+int64_t ARM_ldrRegRegF64(int64_t d, int64_t n, int64_t m);
+int64_t ARM_strRegRegF64(int64_t d, int64_t n, int64_t m);
+int64_t ARM_ldrPreImmF64(int64_t d, int64_t p, int64_t off);
+int64_t ARM_strPreImmF64(int64_t d, int64_t p, int64_t off);
+int64_t ARM_ldrPostImmF64(int64_t d, int64_t p, int64_t off);
+int64_t ARM_strPostImmF64(int64_t d, int64_t p, int64_t off);
+int64_t ARM_movnImmX(int64_t d, int64_t i16, int64_t sh);
+int64_t ARM_movzImmX(int64_t d, int64_t i16, int64_t sh);
+int64_t ARM_asrvRegX(int64_t d, int64_t n, int64_t m);
+int64_t ARM_lsrvRegX(int64_t d, int64_t n, int64_t m);
+int64_t ARM_lslvRegX(int64_t d, int64_t n, int64_t m);
+int64_t ARM_sdivRegX(int64_t d, int64_t n, int64_t m);
+int64_t ARM_fcmp(int64_t a, int64_t b);
+int64_t ARM_fmovReg(int64_t d, int64_t s);
+int64_t ARM_fnegReg(int64_t d, int64_t s);
+int64_t ARM_strRegImmF64(int64_t r, int64_t n, uint64_t off);
+int64_t ARM_ldrRegImmF64(int64_t r, int64_t n, uint64_t off);
+int64_t ARM_ldpPostImmX(int64_t r, int64_t r2, int64_t b, int64_t off);
+int64_t ARM_ldpPostImm(int64_t r, int64_t r2, int64_t b, int64_t off);
+int64_t ARM_stpPostImmX(int64_t r, int64_t r2, int64_t b, int64_t off);
+int64_t ARM_stpPostImm(int64_t r, int64_t r2, int64_t b, int64_t off);
+int64_t ARM_ldpPreImmX(int64_t r, int64_t r2, int64_t b, int64_t off);
+int64_t ARM_ldpPreImm(int64_t r, int64_t r2, int64_t b, int64_t off);
+int64_t ARM_stpPreImmX(int64_t r, int64_t r2, int64_t b, int64_t off);
+int64_t ARM_stpPreImm(int64_t r, int64_t r2, int64_t b, int64_t off);
+int64_t ARM_ldrPreImmX(int64_t r, int64_t b, int64_t off);
+int64_t ARM_strPreImmX(int64_t r, int64_t b, int64_t off);
+int64_t ARM_ldrPostImmX(int64_t r, int64_t b, int64_t off);
+int64_t ARM_strPostImmX(int64_t r, int64_t b, int64_t off);
+int64_t ARM_ldrPreImm(int64_t r, int64_t b, int64_t off);
+int64_t ARM_strPreImm(int64_t r, int64_t b, int64_t off);
+int64_t ARM_ldrPostImm(int64_t r, int64_t b, int64_t off);
+int64_t ARM_strPostImm(int64_t r, int64_t b, int64_t off);
+int64_t ARM_ldrLabelF64(int64_t d, int64_t label);
+int64_t ARM_ldrLabelX(int64_t d, int64_t label);
+int64_t ARM_ldrLabel(int64_t d, int64_t label);
+int64_t ARM_fcvtzs(int64_t d, int64_t n);
+int64_t ARM_ucvtf(int64_t d, int64_t n);
+int64_t ARM_scvtf(int64_t d, int64_t n);
+int64_t ARM_fsubReg(int64_t d, int64_t n, int64_t m);
+int64_t ARM_faddReg(int64_t d, int64_t n, int64_t m);
+int64_t ARM_fdivReg(int64_t d, int64_t n, int64_t m);
+int64_t ARM_fmulReg(int64_t d, int64_t n, int64_t m);
+int64_t ARM_ldrRegRegX(int64_t r, int64_t a, int64_t b);
+int64_t ARM_strRegRegX(int64_t r, int64_t a, int64_t b);
+int64_t ARM_ldrRegImmX(int64_t r, int64_t n, int64_t off);
+int64_t ARM_strRegImmX(int64_t r, int64_t n, int64_t off);
+int64_t ARM_ldrRegImm(int64_t r, int64_t n, int64_t off);
+int64_t ARM_ldrRegReg(int64_t r, int64_t a, int64_t b);
+int64_t ARM_strRegReg(int64_t r, int64_t a, int64_t b);
+int64_t ARM_strRegImm(int64_t r, int64_t n, int64_t off);
+int64_t ARM_ldrhRegImm(int64_t r, int64_t n, int64_t off);
+int64_t ARM_ldrhRegReg(int64_t r, int64_t a, int64_t b);
+int64_t ARM_strhRegImm(int64_t r, int64_t n, int64_t off);
+int64_t ARM_strhRegReg(int64_t r, int64_t a, int64_t b);
+int64_t ARM_ldrbRegReg(int64_t r, int64_t a, int64_t b);
+int64_t ARM_ldrbRegImm(int64_t r, int64_t n, int64_t off);
+int64_t ARM_strbRegImm(int64_t r, int64_t n, int64_t off);
+int64_t ARM_strbRegReg(int64_t r, int64_t a, int64_t b);
+int64_t ARM_tbnz(int64_t rt, int64_t bit, int64_t label);
+int64_t ARM_tbz(int64_t rt, int64_t bit, int64_t label);
+int64_t ARM_cbnzX(int64_t r, int64_t label);
+int64_t ARM_cbnz(int64_t r, int64_t label);
+int64_t ARM_cbzX(int64_t r, int64_t label);
+int64_t ARM_cbz(int64_t r, int64_t label);
 int64_t ARM_bl(int64_t lab);
 int64_t ARM_b(int64_t lab);
-int64_t ARM_bcc(int64_t cond,int64_t lab);
+int64_t ARM_bcc(int64_t cond, int64_t lab);
 int64_t ARM_retReg(int64_t r);
 int64_t ARM_blr(int64_t r);
 int64_t ARM_br(int64_t r);
 int64_t ARM_eret();
 int64_t ARM_ret();
-int64_t ARM_lsrImmX(int64_t d,int64_t n,int64_t imm);
-int64_t ARM_lsrImm(int64_t d,int64_t n,int64_t imm);
-int64_t ARM_lslImmX(int64_t d,int64_t n,int64_t imm);
-int64_t ARM_lslImm(int64_t d,int64_t n,int64_t imm);
-int64_t ARM_asrImmX(int64_t d,int64_t n,int64_t imm);
-int64_t ARM_asrImm(int64_t d,int64_t n,int64_t imm);
-int64_t ARM_sxtwX(int64_t d,int64_t n);
-int64_t ARM_sxtw(int64_t d,int64_t n);
-int64_t ARM_sxthX(int64_t d,int64_t n);
-int64_t ARM_sxth(int64_t d,int64_t n);
-int64_t ARM_sxtbX(int64_t d,int64_t n);
-int64_t ARM_sxtb(int64_t d,int64_t n);
-int64_t ARM_uxtwX(int64_t d,int64_t n);
-int64_t ARM_uxthX(int64_t d,int64_t n);
-int64_t ARM_uxth(int64_t d,int64_t n);
-int64_t ARM_uxtbX(int64_t d,int64_t n);
-int64_t ARM_uxtb(int64_t d,int64_t n);
-int64_t ARM_mulRegX(int64_t d,int64_t n,int64_t m);
-int64_t ARM_csetX(int64_t d,int64_t cond);
-int64_t ARM_cset(int64_t d,int64_t cond);
-int64_t ARM_cselX(int64_t d,int64_t n,int64_t m,int64_t cond);
-int64_t ARM_csel(int64_t d,int64_t n,int64_t m,int64_t cond);
-int64_t ARM_cmpRegX(int64_t n,int64_t m);
-int64_t ARM_negsRegX(int64_t d,int64_t m);
-int64_t ARM_subRegX(int64_t d,int64_t n,int64_t m);
-int64_t ARM_addsRegX(int64_t d,int64_t n,int64_t m);
-int64_t ARM_addRegX(int64_t d,int64_t n,int64_t m);
-int64_t ARM_movRegX(int64_t d,int64_t n);
-int64_t ARM_movReg(int64_t d,int64_t n);
-int64_t ARM_andsRegX(int64_t rd,int64_t rn,int64_t rm);
-int64_t ARM_eorRegX(int64_t rd,int64_t rn,int64_t rm);
-int64_t ARM_eorShiftX(int64_t rd,int64_t rn,int64_t rm,int64_t shmod,int64_t sh);
-int64_t ARM_mvnRegX(int64_t rd,int64_t rm);
-int64_t ARM_mvnReg(int64_t rd,int64_t rm);
-int64_t ARM_mvnShiftX(int64_t rd,int64_t rm,int64_t shmod,int64_t sh);
-int64_t ARM_mvnShift(int64_t rd,int64_t rm,int64_t shmod,int64_t sh);
-int64_t ARM_orrRegX(int64_t rd,int64_t rn,int64_t rm);
-int64_t ARM_andRegX(int64_t rd,int64_t rn,int64_t rm);
-int64_t ARM_cmpImmX(int64_t n,int64_t imm);
-int64_t ARM_subImmX(int64_t d,int64_t n,int64_t imm);
-int64_t ARM_addImmX(int64_t d,int64_t n,int64_t imm);
-int64_t ARM_adrX(int64_t d,int64_t pc_off);
-int64_t ARM_strbRegRegShift(int64_t a,int64_t n,int64_t m);
-int64_t ARM_ldrbRegRegShift(int64_t a,int64_t n,int64_t m);
-int64_t ARM_strbRegRegShift(int64_t a,int64_t n,int64_t m);
-int64_t ARM_ldrhRegRegShift(int64_t a,int64_t n,int64_t m);
-int64_t ARM_strhRegRegShift(int64_t a,int64_t n,int64_t m);
-int64_t ARM_ldrRegRegShift(int64_t a,int64_t n,int64_t m);
-int64_t ARM_strRegRegShift(int64_t a,int64_t n,int64_t m);
-int64_t ARM_ldrRegRegShiftX(int64_t a,int64_t n,int64_t m);
-int64_t ARM_strRegRegShiftX(int64_t a,int64_t n,int64_t m);
-int64_t ARM_ldpImmX(int64_t r1,int64_t r2,int64_t ra,int64_t off);
-int64_t ARM_stpImmX(int64_t r1,int64_t r2,int64_t ra,int64_t off);
-CCodeCtrl *CodeCtrlPush(CCmpCtrl* ccmp);
-void CodeCtrlDel(CCodeCtrl* ctrl);
-void CodeCtrlPop(CCmpCtrl* ccmp);
-CRPN *__HC_ICAdd_Typecast(CCodeCtrl *cc,int64_t rt,int64_t ptr_cnt);
-CRPN *__HC_ICAdd_SubCall(CCodeCtrl *cc,CCodeMisc *cm);
+int64_t ARM_lsrImmX(int64_t d, int64_t n, int64_t imm);
+int64_t ARM_lsrImm(int64_t d, int64_t n, int64_t imm);
+int64_t ARM_lslImmX(int64_t d, int64_t n, int64_t imm);
+int64_t ARM_lslImm(int64_t d, int64_t n, int64_t imm);
+int64_t ARM_asrImmX(int64_t d, int64_t n, int64_t imm);
+int64_t ARM_asrImm(int64_t d, int64_t n, int64_t imm);
+int64_t ARM_sxtwX(int64_t d, int64_t n);
+int64_t ARM_sxtw(int64_t d, int64_t n);
+int64_t ARM_sxthX(int64_t d, int64_t n);
+int64_t ARM_sxth(int64_t d, int64_t n);
+int64_t ARM_sxtbX(int64_t d, int64_t n);
+int64_t ARM_sxtb(int64_t d, int64_t n);
+int64_t ARM_uxtwX(int64_t d, int64_t n);
+int64_t ARM_uxthX(int64_t d, int64_t n);
+int64_t ARM_uxth(int64_t d, int64_t n);
+int64_t ARM_uxtbX(int64_t d, int64_t n);
+int64_t ARM_uxtb(int64_t d, int64_t n);
+int64_t ARM_mulRegX(int64_t d, int64_t n, int64_t m);
+int64_t ARM_csetX(int64_t d, int64_t cond);
+int64_t ARM_cset(int64_t d, int64_t cond);
+int64_t ARM_cselX(int64_t d, int64_t n, int64_t m, int64_t cond);
+int64_t ARM_csel(int64_t d, int64_t n, int64_t m, int64_t cond);
+int64_t ARM_cmpRegX(int64_t n, int64_t m);
+int64_t ARM_negsRegX(int64_t d, int64_t m);
+int64_t ARM_subRegX(int64_t d, int64_t n, int64_t m);
+int64_t ARM_addsRegX(int64_t d, int64_t n, int64_t m);
+int64_t ARM_addRegX(int64_t d, int64_t n, int64_t m);
+int64_t ARM_movRegX(int64_t d, int64_t n);
+int64_t ARM_movReg(int64_t d, int64_t n);
+int64_t ARM_andsRegX(int64_t rd, int64_t rn, int64_t rm);
+int64_t ARM_eorRegX(int64_t rd, int64_t rn, int64_t rm);
+int64_t ARM_eorShiftX(int64_t rd, int64_t rn, int64_t rm, int64_t shmod,
+                      int64_t sh);
+int64_t ARM_mvnRegX(int64_t rd, int64_t rm);
+int64_t ARM_mvnReg(int64_t rd, int64_t rm);
+int64_t ARM_mvnShiftX(int64_t rd, int64_t rm, int64_t shmod, int64_t sh);
+int64_t ARM_mvnShift(int64_t rd, int64_t rm, int64_t shmod, int64_t sh);
+int64_t ARM_orrRegX(int64_t rd, int64_t rn, int64_t rm);
+int64_t ARM_andRegX(int64_t rd, int64_t rn, int64_t rm);
+int64_t ARM_cmpImmX(int64_t n, int64_t imm);
+int64_t ARM_subImmX(int64_t d, int64_t n, int64_t imm);
+int64_t ARM_addImmX(int64_t d, int64_t n, int64_t imm);
+int64_t ARM_adrX(int64_t d, int64_t pc_off);
+int64_t ARM_strbRegRegShift(int64_t a, int64_t n, int64_t m);
+int64_t ARM_ldrbRegRegShift(int64_t a, int64_t n, int64_t m);
+int64_t ARM_strbRegRegShift(int64_t a, int64_t n, int64_t m);
+int64_t ARM_ldrhRegRegShift(int64_t a, int64_t n, int64_t m);
+int64_t ARM_strhRegRegShift(int64_t a, int64_t n, int64_t m);
+int64_t ARM_ldrRegRegShift(int64_t a, int64_t n, int64_t m);
+int64_t ARM_strRegRegShift(int64_t a, int64_t n, int64_t m);
+int64_t ARM_ldrRegRegShiftX(int64_t a, int64_t n, int64_t m);
+int64_t ARM_strRegRegShiftX(int64_t a, int64_t n, int64_t m);
+int64_t ARM_ldpImmX(int64_t r1, int64_t r2, int64_t ra, int64_t off);
+int64_t ARM_stpImmX(int64_t r1, int64_t r2, int64_t ra, int64_t off);
+CCodeCtrl *CodeCtrlPush(CCmpCtrl *ccmp);
+void CodeCtrlDel(CCodeCtrl *ctrl);
+void CodeCtrlPop(CCmpCtrl *ccmp);
+CRPN *__HC_ICAdd_Typecast(CCodeCtrl *cc, int64_t rt, int64_t ptr_cnt);
+CRPN *__HC_ICAdd_SubCall(CCodeCtrl *cc, CCodeMisc *cm);
 CRPN *__HC_ICAdd_SubProlog(CCodeCtrl *cc);
 CRPN *__HC_ICAdd_SubRet(CCodeCtrl *cc);
-CRPN *__HC_ICAdd_UnboundedSwitch(CCodeCtrl *cc,CCodeMisc *misc);
-CRPN *__HC_ICAdd_PreInc(CCodeCtrl *cc,int64_t amt);
-CRPN *__HC_ICAdd_Call(CCodeCtrl *cc,int64_t arity,int64_t rt,int64_t ptrs);
-CRPN *__HC_ICAdd_F64(CCodeCtrl *cc,double f);
-CRPN *__HC_ICAdd_I64(CCodeCtrl *cc,int64_t integer);
-CRPN *__HC_ICAdd_PreDec(CCodeCtrl *cc,int64_t amt);
-CRPN *__HC_ICAdd_PostDec(CCodeCtrl *cc,int64_t amt);
-CRPN *__HC_ICAdd_PostInc(CCodeCtrl *cc,int64_t amt);
-#define HC_IC_BINDINGH(name) \
-  CRPN *__##name(CCodeCtrl *cc);
+CRPN *__HC_ICAdd_UnboundedSwitch(CCodeCtrl *cc, CCodeMisc *misc);
+CRPN *__HC_ICAdd_PreInc(CCodeCtrl *cc, int64_t amt);
+CRPN *__HC_ICAdd_Call(CCodeCtrl *cc, int64_t arity, int64_t rt, int64_t ptrs);
+CRPN *__HC_ICAdd_F64(CCodeCtrl *cc, double f);
+CRPN *__HC_ICAdd_I64(CCodeCtrl *cc, int64_t integer);
+CRPN *__HC_ICAdd_PreDec(CCodeCtrl *cc, int64_t amt);
+CRPN *__HC_ICAdd_PostDec(CCodeCtrl *cc, int64_t amt);
+CRPN *__HC_ICAdd_PostInc(CCodeCtrl *cc, int64_t amt);
+#define HC_IC_BINDINGH(name) CRPN *__##name(CCodeCtrl *cc);
 HC_IC_BINDINGH(HC_ICAdd_Pow)
 HC_IC_BINDINGH(HC_ICAdd_Eq)
 HC_IC_BINDINGH(HC_ICAdd_Div)
@@ -1030,54 +1038,59 @@ HC_IC_BINDINGH(HC_ICAdd_SIN)
 HC_IC_BINDINGH(HC_ICAdd_COS)
 HC_IC_BINDINGH(HC_ICAdd_TAN)
 HC_IC_BINDINGH(HC_ICAdd_ATAN)
-CRPN *__HC_ICAdd_FReg(CCodeCtrl *cc,int64_t r);
-CRPN *__HC_ICAdd_IReg(CCodeCtrl *cc,int64_t r,int64_t rt,int64_t ptr_cnt);
-CRPN *__HC_ICAdd_Frame(CCodeCtrl *cc,int64_t off,int64_t rt,int64_t ptr_cnt);
-CCodeMisc *__HC_CodeMiscJmpTableNew(CCmpCtrl *ccmp,CCodeMisc *labels,void **table_address,int64_t hi);
-CCodeMisc *__HC_CodeMiscStrNew(CCmpCtrl *ccmp,char *str,int64_t sz);
-CCodeMisc *__HC_CodeMiscLabelNew(CCmpCtrl *ccmp,void **);
+CRPN *__HC_ICAdd_FReg(CCodeCtrl *cc, int64_t r);
+CRPN *__HC_ICAdd_IReg(CCodeCtrl *cc, int64_t r, int64_t rt, int64_t ptr_cnt);
+CRPN *__HC_ICAdd_Frame(CCodeCtrl *cc, int64_t off, int64_t rt, int64_t ptr_cnt);
+CCodeMisc *__HC_CodeMiscJmpTableNew(CCmpCtrl *ccmp, CCodeMisc *labels,
+                                    void **table_address, int64_t hi);
+CCodeMisc *__HC_CodeMiscStrNew(CCmpCtrl *ccmp, char *str, int64_t sz);
+CCodeMisc *__HC_CodeMiscLabelNew(CCmpCtrl *ccmp, void **);
 CCmpCtrl *__HC_CmpCtrlNew();
 CCodeCtrl *__HC_CodeCtrlPush(CCmpCtrl *ccmp);
 CCodeCtrl *__HC_CodeCtrlPop(CCmpCtrl *ccmp);
-char *__HC_Compile(CCmpCtrl *ccmp,int64_t *sz,char **dbg_info);
-CRPN *__HC_ICAdd_Goto(CCodeCtrl* cc,CCodeMisc *cm);
-CRPN *__HC_ICAdd_GotoIf(CCodeCtrl* cc,CCodeMisc *cm);
-CRPN *__HC_ICAdd_Str(CCodeCtrl* cc,CCodeMisc *cm);
-CRPN *__HC_ICAdd_Label(CCodeCtrl *cc,CCodeMisc *misc);
-CRPN *__HC_ICAdd_Arg(CCodeCtrl *cc,int64_t arg);
-CRPN *__HC_ICAdd_SetFrameSize(CCodeCtrl *cc,int64_t arg);
-CRPN *__HC_ICAdd_Reloc(CCmpCtrl *cmpc,CCodeCtrl* cc, int64_t *pat_addr,char *sym,int64_t rt,int64_t ptrs);
-CCodeMisc* AddRelocMisc(CCmpCtrl* cctrl, char* name);
-CRPN *__HC_ICAdd_Deref(CCodeCtrl* cc, int64_t rt, int64_t ptr_cnt);
-void __HC_ICSetLine(CRPN *r,int64_t ln);
-CRPN *__HC_ICAdd_Switch(CCodeCtrl *cc,CCodeMisc *misc,CCodeMisc *dft);
-CRPN* __HC_ICAdd_Vargs(CCodeCtrl* cc, int64_t arity);
-CRPN *__HC_ICAdd_StaticData(CCmpCtrl *cmp,CCodeCtrl* cc,int64_t at,char *d,int64_t len);
-CRPN *__HC_ICAdd_StaticRef(CCodeCtrl* cc,int64_t off,int64_t rt,int64_t ptrs);
-CRPN *__HC_ICAdd_SetStaticsSize(CCodeCtrl* cc,int64_t len);
-char* Load(char* filename);
-CRPN *__HC_ICAdd_ShortAddr(CCmpCtrl *,CCodeCtrl* cc,char *name,CCodeMisc *ptr);
-//TODO remove
-char *FileRead(char *fn,int64_t *sz);
-void FileWrite(char *fn,char *data,int64_t sz);
+char *__HC_Compile(CCmpCtrl *ccmp, int64_t *sz, char **dbg_info);
+CRPN *__HC_ICAdd_Goto(CCodeCtrl *cc, CCodeMisc *cm);
+CRPN *__HC_ICAdd_GotoIf(CCodeCtrl *cc, CCodeMisc *cm);
+CRPN *__HC_ICAdd_Str(CCodeCtrl *cc, CCodeMisc *cm);
+CRPN *__HC_ICAdd_Label(CCodeCtrl *cc, CCodeMisc *misc);
+CRPN *__HC_ICAdd_Arg(CCodeCtrl *cc, int64_t arg);
+CRPN *__HC_ICAdd_SetFrameSize(CCodeCtrl *cc, int64_t arg);
+CRPN *__HC_ICAdd_Reloc(CCmpCtrl *cmpc, CCodeCtrl *cc, int64_t *pat_addr,
+                       char *sym, int64_t rt, int64_t ptrs);
+CCodeMisc *AddRelocMisc(CCmpCtrl *cctrl, char *name);
+CRPN *__HC_ICAdd_Deref(CCodeCtrl *cc, int64_t rt, int64_t ptr_cnt);
+void __HC_ICSetLine(CRPN *r, int64_t ln);
+CRPN *__HC_ICAdd_Switch(CCodeCtrl *cc, CCodeMisc *misc, CCodeMisc *dft);
+CRPN *__HC_ICAdd_Vargs(CCodeCtrl *cc, int64_t arity);
+CRPN *__HC_ICAdd_StaticData(CCmpCtrl *cmp, CCodeCtrl *cc, int64_t at, char *d,
+                            int64_t len);
+CRPN *__HC_ICAdd_StaticRef(CCodeCtrl *cc, int64_t off, int64_t rt,
+                           int64_t ptrs);
+CRPN *__HC_ICAdd_SetStaticsSize(CCodeCtrl *cc, int64_t len);
+char *Load(char *filename);
+CRPN *__HC_ICAdd_ShortAddr(CCmpCtrl *, CCodeCtrl *cc, char *name,
+                           CCodeMisc *ptr);
+// TODO remove
+char *FileRead(char *fn, int64_t *sz);
+void FileWrite(char *fn, char *data, int64_t sz);
 
 void VFsThrdInit();
 void VFsSetDrv(char d);
-int VFsCd(char *to,int flags);
+int VFsCd(char *to, int flags);
 int64_t VFsDel(char *p);
 char *__VFsFileNameAbs(char *name);
 int64_t VFsUnixTime(char *name);
 int64_t VFsFSize(char *name);
-int64_t VFsFileWrite(char *name,char *data,int64_t len);
-int64_t VFsFileRead(char *name,int64_t *len);
+int64_t VFsFileWrite(char *name, char *data, int64_t len);
+int64_t VFsFileRead(char *name, int64_t *len);
 int VFsFileExists(char *path);
-int VFsMountDrive(char let,char *path);
-FILE *VFsFOpen(char *path,char *m);
+int VFsMountDrive(char let, char *path);
+FILE *VFsFOpen(char *path, char *m);
 int64_t VFsFClose(FILE *f);
-int64_t VFsTrunc(char *fn,int64_t sz);
-int64_t VFsFBlkRead(void *d,int64_t n, int64_t sz,FILE *f);
-int64_t VFsFBlkWrite(void *d,int64_t n, int64_t sz,FILE *f);
-int64_t VFsFSeek(int64_t off,FILE *f);
+int64_t VFsTrunc(char *fn, int64_t sz);
+int64_t VFsFBlkRead(void *d, int64_t n, int64_t sz, FILE *f);
+int64_t VFsFBlkWrite(void *d, int64_t n, int64_t sz, FILE *f);
+int64_t VFsFSeek(int64_t off, FILE *f);
 FILE *VFsFOpenW(char *f);
 FILE *VFsFOpenR(char *f);
 void VFsSetPwd(char *pwd);
@@ -1086,19 +1099,19 @@ char **VFsDir(char *fn);
 int64_t VFsIsDir(char *name);
 
 void DrawWindowNew();
-void UpdateScreen(char *px,int64_t w,int64_t h,int64_t wi);
-void GrPaletteColorSet(int64_t i,uint64_t bgr48);
+void UpdateScreen(char *px, int64_t w, int64_t h, int64_t wi);
+void GrPaletteColorSet(int64_t i, uint64_t bgr48);
 
-void LaunchSDL(void (*boot_ptr)(void *data),void *data);
+void LaunchSDL(void (*boot_ptr)(void *data), void *data);
 void WaitForSDLQuit();
 void SetKBCallback(void *fptr);
 void SetMSCallback(void *fptr);
 
-void ImportSymbolsToHolyC(void(*cb)(char *name,void *addr));
-int64_t ARM_eorImmX(int64_t d,int64_t s,int64_t i);
-int64_t ARM_orrImmX(int64_t d,int64_t s,int64_t i);
-int64_t ARM_andImmX(int64_t d,int64_t s,int64_t i);
-CCmpCtrl* CmpCtrlDel(CCmpCtrl *d);
+void ImportSymbolsToHolyC(void (*cb)(char *name, void *addr));
+int64_t ARM_eorImmX(int64_t d, int64_t s, int64_t i);
+int64_t ARM_orrImmX(int64_t d, int64_t s, int64_t i);
+int64_t ARM_andImmX(int64_t d, int64_t s, int64_t i);
+CCmpCtrl *CmpCtrlDel(CCmpCtrl *d);
 void SndFreq(int64_t f);
 void InitSound();
 int64_t IsValidPtr(char *chk);
@@ -1106,65 +1119,66 @@ void InstallDbgSignalsForThread();
 void *GetHolyGs();
 void SetHolyGs(void *);
 int64_t mp_cnt();
-void SpawnCore(void(*fp)(),void *gs,int64_t core);
+void SpawnCore(void (*fp)(), void *gs, int64_t core);
 void MPSleepHP(int64_t ns);
 void MPAwake(int64_t core);
 extern int64_t user_ev_num;
-int64_t Btr(void *,int64_t);
-int64_t Bts(void *,int64_t);
-int64_t ARM_andsImmX(int64_t d,int64_t n,int64_t imm);
+int64_t Btr(void *, int64_t);
+int64_t Bts(void *, int64_t);
+int64_t ARM_andsImmX(int64_t d, int64_t n, int64_t imm);
 void __HC_CmpCtrl_SetAOT(CCmpCtrl *cc);
-int64_t ARM_udivX(int64_t d,int64_t n,int64_t m);
-int64_t ARM_umullX(int64_t d,int64_t n,int64_t m);
+int64_t ARM_udivX(int64_t d, int64_t n, int64_t m);
+int64_t ARM_umullX(int64_t d, int64_t n, int64_t m);
 void InteruptCore(int64_t core);
 extern CHashTable *glbl_table;
-//Sets how many bytes before function start a symbol starts at
-//Symbol    <=====RIP-off
-//some...code
-//Fun Start <==== RIP
-void __HC_SetAOTRelocBeforeRIP(CRPN *r,int64_t off);
+// Sets how many bytes before function start a symbol starts at
+// Symbol    <=====RIP-off
+// some...code
+// Fun Start <==== RIP
+void __HC_SetAOTRelocBeforeRIP(CRPN *r, int64_t off);
 int64_t __HC_CodeMiscIsUsed(CCodeMisc *cm);
 
-extern void AIWNIOS_setcontext(void*);
-extern int64_t AIWNIOS_getcontext(void*);
-extern int64_t AIWNIOS_makecontext(void*,void*,void*);
-extern CCodeMiscRef *CodeMiscAddRef(CCodeMisc* misc, int32_t* addr);
-extern void __HC_CodeMiscInterateThroughRefs(CCodeMisc *cm,void(*fptr)(void *addr,void *user_data), void *user_data) ;
+extern void AIWNIOS_setcontext(void *);
+extern int64_t AIWNIOS_getcontext(void *);
+extern int64_t AIWNIOS_makecontext(void *, void *, void *);
+extern CCodeMiscRef *CodeMiscAddRef(CCodeMisc *misc, int32_t *addr);
+extern void __HC_CodeMiscInterateThroughRefs(
+    CCodeMisc *cm, void (*fptr)(void *addr, void *user_data), void *user_data);
 
 #define USE_TEMPLEOS_ABI 1
 extern int64_t FFI_CALL_TOS_0(void *fptr);
-extern int64_t FFI_CALL_TOS_1(void *fptr,int64_t);
-extern int64_t FFI_CALL_TOS_2(void *fptr,int64_t,int64_t);
-extern int64_t FFI_CALL_TOS_3(void *fptr,int64_t,int64_t,int64_t);
-extern int64_t FFI_CALL_TOS_4(void *fptr,int64_t,int64_t,int64_t,int64_t);
-extern void *GenFFIBinding(void *fptr,int64_t arity);
-extern void *GenFFIBindingNaked(void *fptr,int64_t arity);
-extern void PrsBindCSymbolNaked(char *name,void *ptr,int64_t arity);
+extern int64_t FFI_CALL_TOS_1(void *fptr, int64_t);
+extern int64_t FFI_CALL_TOS_2(void *fptr, int64_t, int64_t);
+extern int64_t FFI_CALL_TOS_3(void *fptr, int64_t, int64_t, int64_t);
+extern int64_t FFI_CALL_TOS_4(void *fptr, int64_t, int64_t, int64_t, int64_t);
+extern void *GenFFIBinding(void *fptr, int64_t arity);
+extern void *GenFFIBindingNaked(void *fptr, int64_t arity);
+extern void PrsBindCSymbolNaked(char *name, void *ptr, int64_t arity);
 void CmpCtrlCacheArgTrees(CCmpCtrl *cctrl);
-const char *ResolveBootDir(char *use,int overwrite,int make_new_dir);
+const char *ResolveBootDir(char *use, int overwrite, int make_new_dir);
 
-//Uses TempleOS ABI
-int64_t TempleOS_CallN(void (*fptr),int64_t argc,int64_t *argv);
-CRPN* __HC_ICAdd_RawBytes(CCodeCtrl* cc,char *bytes,int64_t cnt);
+// Uses TempleOS ABI
+int64_t TempleOS_CallN(void(*fptr), int64_t argc, int64_t *argv);
+CRPN *__HC_ICAdd_RawBytes(CCodeCtrl *cc, char *bytes, int64_t cnt);
 
 extern int64_t bc_enable;
-//Returns good region if good,else NULL and after is set how many bytes OOB
-//Returns INVALID_PTR on error
-extern void *BoundsCheck(void *ptr,int64_t *after);
-//f is delay in nano seconds
-extern void MPSetProfilerInt(void *fp,int c,int64_t f);
-extern void* GetHolyFs();
+// Returns good region if good,else NULL and after is set how many bytes OOB
+// Returns INVALID_PTR on error
+extern void *BoundsCheck(void *ptr, int64_t *after);
+// f is delay in nano seconds
+extern void MPSetProfilerInt(void *fp, int c, int64_t f);
+extern void *GetHolyFs();
 
 struct CNetAddr;
-extern int64_t NetPollForHangup(int64_t argc,int64_t *argv);
-extern int64_t NetPollForWrite(int64_t argc,int64_t *argv);
-extern int64_t NetPollForRead(int64_t argc,int64_t *argv);
-extern int64_t NetWrite(int64_t s,char *data,int64_t len);
-extern int64_t NetRead(int64_t s,char *data,int64_t len) ;
+extern int64_t NetPollForHangup(int64_t argc, int64_t *argv);
+extern int64_t NetPollForWrite(int64_t argc, int64_t *argv);
+extern int64_t NetPollForRead(int64_t argc, int64_t *argv);
+extern int64_t NetWrite(int64_t s, char *data, int64_t len);
+extern int64_t NetRead(int64_t s, char *data, int64_t len);
 extern void NetClose(int64_t s);
-extern int64_t NetAccept(int64_t socket,struct CNetAddr **addr);
-extern void NetListen(int64_t socket,int64_t max);
-extern void NetBindIn(int64_t socket,struct CNetAddr *);
+extern int64_t NetAccept(int64_t socket, struct CNetAddr **addr);
+extern void NetListen(int64_t socket, int64_t max);
+extern void NetBindIn(int64_t socket, struct CNetAddr *);
 extern int64_t NetSocketNew();
-extern struct CNetAddr *NetAddrNew(char *host,int64_t port);
-extern void NetAddrDel(struct CNetAddr*);
+extern struct CNetAddr *NetAddrNew(char *host, int64_t port);
+extern void NetAddrDel(struct CNetAddr *);

--- a/argtable3.c
+++ b/argtable3.c
@@ -65,82 +65,90 @@
  ******************************************************************************/
 
 #ifndef ARG_UTILS_H
-#define ARG_UTILS_H
+  #define ARG_UTILS_H
 
-#include <stdlib.h>
+  #include <stdlib.h>
 
-#define ARG_ENABLE_TRACE 0
-#define ARG_ENABLE_LOG 1
+  #define ARG_ENABLE_TRACE 0
+  #define ARG_ENABLE_LOG 1
 
-#ifdef __cplusplus
+  #ifdef __cplusplus
 extern "C" {
-#endif
+  #endif
 
-enum { ARG_ERR_MINCOUNT = 1, ARG_ERR_MAXCOUNT, ARG_ERR_BADINT, ARG_ERR_OVERFLOW, ARG_ERR_BADDOUBLE, ARG_ERR_BADDATE, ARG_ERR_REGNOMATCH };
+enum {
+  ARG_ERR_MINCOUNT = 1,
+  ARG_ERR_MAXCOUNT,
+  ARG_ERR_BADINT,
+  ARG_ERR_OVERFLOW,
+  ARG_ERR_BADDOUBLE,
+  ARG_ERR_BADDATE,
+  ARG_ERR_REGNOMATCH
+};
 
-typedef void(arg_panicfn)(const char* fmt, ...);
+typedef void(arg_panicfn)(const char *fmt, ...);
 
-#if defined(_MSC_VER)
-#define ARG_TRACE(x)                                               \
-    __pragma(warning(push)) __pragma(warning(disable : 4127)) do { \
-        if (ARG_ENABLE_TRACE)                                      \
-            dbg_printf x;                                          \
-    }                                                              \
-    while (0)                                                      \
-    __pragma(warning(pop))
+  #if defined(_MSC_VER)
+    #define ARG_TRACE(x)                                                       \
+      __pragma(warning(push)) __pragma(warning(disable : 4127)) do {           \
+        if (ARG_ENABLE_TRACE)                                                  \
+          dbg_printf x;                                                        \
+      }                                                                        \
+      while (0)                                                                \
+      __pragma(warning(pop))
 
-#define ARG_LOG(x)                                                 \
-    __pragma(warning(push)) __pragma(warning(disable : 4127)) do { \
-        if (ARG_ENABLE_LOG)                                        \
-            dbg_printf x;                                          \
-    }                                                              \
-    while (0)                                                      \
-    __pragma(warning(pop))
-#else
-#define ARG_TRACE(x)          \
-    do {                      \
-        if (ARG_ENABLE_TRACE) \
-            dbg_printf x;     \
-    } while (0)
+    #define ARG_LOG(x)                                                         \
+      __pragma(warning(push)) __pragma(warning(disable : 4127)) do {           \
+        if (ARG_ENABLE_LOG)                                                    \
+          dbg_printf x;                                                        \
+      }                                                                        \
+      while (0)                                                                \
+      __pragma(warning(pop))
+  #else
+    #define ARG_TRACE(x)                                                       \
+      do {                                                                     \
+        if (ARG_ENABLE_TRACE)                                                  \
+          dbg_printf x;                                                        \
+      } while (0)
 
-#define ARG_LOG(x)          \
-    do {                    \
-        if (ARG_ENABLE_LOG) \
-            dbg_printf x;   \
-    } while (0)
-#endif
+    #define ARG_LOG(x)                                                         \
+      do {                                                                     \
+        if (ARG_ENABLE_LOG)                                                    \
+          dbg_printf x;                                                        \
+      } while (0)
+  #endif
 
-/*
- * Rename a few generic names to unique names.
- * They can be a problem for the platforms like NuttX, where
- * the namespace is flat for everything including apps and libraries.
- */
-#define	xmalloc argtable3_xmalloc
-#define	xcalloc argtable3_xcalloc
-#define	xrealloc argtable3_xrealloc
-#define	xfree argtable3_xfree
+  /*
+   * Rename a few generic names to unique names.
+   * They can be a problem for the platforms like NuttX, where
+   * the namespace is flat for everything including apps and libraries.
+   */
+  #define xmalloc argtable3_xmalloc
+  #define xcalloc argtable3_xcalloc
+  #define xrealloc argtable3_xrealloc
+  #define xfree argtable3_xfree
 
-extern void dbg_printf(const char* fmt, ...);
-extern void arg_set_panic(arg_panicfn* proc);
-extern void* xmalloc(size_t size);
-extern void* xcalloc(size_t count, size_t size);
-extern void* xrealloc(void* ptr, size_t size);
-extern void xfree(void* ptr);
+extern void dbg_printf(const char *fmt, ...);
+extern void arg_set_panic(arg_panicfn *proc);
+extern void *xmalloc(size_t size);
+extern void *xcalloc(size_t count, size_t size);
+extern void *xrealloc(void *ptr, size_t size);
+extern void xfree(void *ptr);
 
 struct arg_hashtable_entry {
-    void *k, *v;
-    unsigned int h;
-    struct arg_hashtable_entry* next;
+  void *k, *v;
+  unsigned int h;
+  struct arg_hashtable_entry *next;
 };
 
 typedef struct arg_hashtable {
-    unsigned int tablelength;
-    struct arg_hashtable_entry** table;
-    unsigned int entrycount;
-    unsigned int loadlimit;
-    unsigned int primeindex;
-    unsigned int (*hashfn)(const void* k);
-    int (*eqfn)(const void* k1, const void* k2);
+  unsigned int tablelength;
+  struct arg_hashtable_entry **table;
+  unsigned int entrycount;
+  unsigned int loadlimit;
+  unsigned int primeindex;
+  unsigned int (*hashfn)(const void *k);
+  int (*eqfn)(const void *k1, const void *k2);
 } arg_hashtable_t;
 
 /**
@@ -151,11 +159,13 @@ typedef struct arg_hashtable {
  * @param   eqfn      function for determining key equality
  * @return            newly created hash table or NULL on failure
  */
-arg_hashtable_t* arg_hashtable_create(unsigned int minsize, unsigned int (*hashfn)(const void*), int (*eqfn)(const void*, const void*));
+arg_hashtable_t *arg_hashtable_create(unsigned int minsize,
+                                      unsigned int (*hashfn)(const void *),
+                                      int (*eqfn)(const void *, const void *));
 
 /**
- * @brief This function will cause the table to expand if the insertion would take
- * the ratio of entries to table size over the maximum load factor.
+ * @brief This function will cause the table to expand if the insertion would
+ * take the ratio of entries to table size over the maximum load factor.
  *
  * This function does not check for repeated insertions with a duplicate key.
  * The value returned when using a duplicate key is undefined -- when
@@ -168,10 +178,12 @@ arg_hashtable_t* arg_hashtable_create(unsigned int minsize, unsigned int (*hashf
  * @param   v   the value - does not claim ownership
  * @return      non-zero for successful insertion
  */
-void arg_hashtable_insert(arg_hashtable_t* h, void* k, void* v);
+void arg_hashtable_insert(arg_hashtable_t *h, void *k, void *v);
 
-#define ARG_DEFINE_HASHTABLE_INSERT(fnname, keytype, valuetype) \
-    int fnname(arg_hashtable_t* h, keytype* k, valuetype* v) { return arg_hashtable_insert(h, k, v); }
+  #define ARG_DEFINE_HASHTABLE_INSERT(fnname, keytype, valuetype)              \
+    int fnname(arg_hashtable_t *h, keytype *k, valuetype *v) {                 \
+      return arg_hashtable_insert(h, k, v);                                    \
+    }
 
 /**
  * @brief Search the specified key in the hash table.
@@ -180,10 +192,12 @@ void arg_hashtable_insert(arg_hashtable_t* h, void* k, void* v);
  * @param   k   the key to search for  - does not claim ownership
  * @return      the value associated with the key, or NULL if none found
  */
-void* arg_hashtable_search(arg_hashtable_t* h, const void* k);
+void *arg_hashtable_search(arg_hashtable_t *h, const void *k);
 
-#define ARG_DEFINE_HASHTABLE_SEARCH(fnname, keytype, valuetype) \
-    valuetype* fnname(arg_hashtable_t* h, keytype* k) { return (valuetype*)(arg_hashtable_search(h, k)); }
+  #define ARG_DEFINE_HASHTABLE_SEARCH(fnname, keytype, valuetype)              \
+    valuetype *fnname(arg_hashtable_t *h, keytype *k) {                        \
+      return (valuetype *)(arg_hashtable_search(h, k));                        \
+    }
 
 /**
  * @brief Remove the specified key from the hash table.
@@ -191,10 +205,10 @@ void* arg_hashtable_search(arg_hashtable_t* h, const void* k);
  * @param   h   the hash table to remove the item from
  * @param   k   the key to search for  - does not claim ownership
  */
-void arg_hashtable_remove(arg_hashtable_t* h, const void* k);
+void arg_hashtable_remove(arg_hashtable_t *h, const void *k);
 
-#define ARG_DEFINE_HASHTABLE_REMOVE(fnname, keytype, valuetype) \
-    void fnname(arg_hashtable_t* h, keytype* k) { arg_hashtable_remove(h, k); }
+  #define ARG_DEFINE_HASHTABLE_REMOVE(fnname, keytype, valuetype)              \
+    void fnname(arg_hashtable_t *h, keytype *k) { arg_hashtable_remove(h, k); }
 
 /**
  * @brief Return the number of keys in the hash table.
@@ -202,7 +216,7 @@ void arg_hashtable_remove(arg_hashtable_t* h, const void* k);
  * @param   h   the hash table
  * @return      the number of items stored in the hash table
  */
-unsigned int arg_hashtable_count(arg_hashtable_t* h);
+unsigned int arg_hashtable_count(arg_hashtable_t *h);
 
 /**
  * @brief Change the value associated with the key.
@@ -216,7 +230,7 @@ unsigned int arg_hashtable_count(arg_hashtable_t* h);
  * @param       key
  * @param       value
  */
-int arg_hashtable_change(arg_hashtable_t* h, void* k, void* v);
+int arg_hashtable_change(arg_hashtable_t *h, void *k, void *v);
 
 /**
  * @brief Free the hash table and the memory allocated for each key-value pair.
@@ -224,52 +238,57 @@ int arg_hashtable_change(arg_hashtable_t* h, void* k, void* v);
  * @param   h            the hash table
  * @param   free_values  whether to call 'free' on the remaining values
  */
-void arg_hashtable_destroy(arg_hashtable_t* h, int free_values);
+void arg_hashtable_destroy(arg_hashtable_t *h, int free_values);
 
 typedef struct arg_hashtable_itr {
-    arg_hashtable_t* h;
-    struct arg_hashtable_entry* e;
-    struct arg_hashtable_entry* parent;
-    unsigned int index;
+  arg_hashtable_t *h;
+  struct arg_hashtable_entry *e;
+  struct arg_hashtable_entry *parent;
+  unsigned int index;
 } arg_hashtable_itr_t;
 
-arg_hashtable_itr_t* arg_hashtable_itr_create(arg_hashtable_t* h);
+arg_hashtable_itr_t *arg_hashtable_itr_create(arg_hashtable_t *h);
 
-void arg_hashtable_itr_destroy(arg_hashtable_itr_t* itr);
-
-/**
- * @brief Return the value of the (key,value) pair at the current position.
- */
-extern void* arg_hashtable_itr_key(arg_hashtable_itr_t* i);
+void arg_hashtable_itr_destroy(arg_hashtable_itr_t *itr);
 
 /**
  * @brief Return the value of the (key,value) pair at the current position.
  */
-extern void* arg_hashtable_itr_value(arg_hashtable_itr_t* i);
+extern void *arg_hashtable_itr_key(arg_hashtable_itr_t *i);
 
 /**
- * @brief Advance the iterator to the next element. Returns zero if advanced to end of table.
+ * @brief Return the value of the (key,value) pair at the current position.
  */
-int arg_hashtable_itr_advance(arg_hashtable_itr_t* itr);
+extern void *arg_hashtable_itr_value(arg_hashtable_itr_t *i);
+
+/**
+ * @brief Advance the iterator to the next element. Returns zero if advanced to
+ * end of table.
+ */
+int arg_hashtable_itr_advance(arg_hashtable_itr_t *itr);
 
 /**
  * @brief Remove current element and advance the iterator to the next element.
  */
-int arg_hashtable_itr_remove(arg_hashtable_itr_t* itr);
+int arg_hashtable_itr_remove(arg_hashtable_itr_t *itr);
 
 /**
- * @brief Search and overwrite the supplied iterator, to point to the entry matching the supplied key.
+ * @brief Search and overwrite the supplied iterator, to point to the entry
+ * matching the supplied key.
  *
  * @return  Zero if not found.
  */
-int arg_hashtable_itr_search(arg_hashtable_itr_t* itr, arg_hashtable_t* h, void* k);
+int arg_hashtable_itr_search(arg_hashtable_itr_t *itr, arg_hashtable_t *h,
+                             void *k);
 
-#define ARG_DEFINE_HASHTABLE_ITERATOR_SEARCH(fnname, keytype) \
-    int fnname(arg_hashtable_itr_t* i, arg_hashtable_t* h, keytype* k) { return (arg_hashtable_iterator_search(i, h, k)); }
+  #define ARG_DEFINE_HASHTABLE_ITERATOR_SEARCH(fnname, keytype)                \
+    int fnname(arg_hashtable_itr_t *i, arg_hashtable_t *h, keytype *k) {       \
+      return (arg_hashtable_iterator_search(i, h, k));                         \
+    }
 
-#ifdef __cplusplus
+  #ifdef __cplusplus
 }
-#endif
+  #endif
 
 #endif
 /*******************************************************************************
@@ -307,7 +326,7 @@ int arg_hashtable_itr_search(arg_hashtable_itr_t* itr, arg_hashtable_t* h, void*
 #include "argtable3.h"
 
 #ifndef ARG_AMALGAMATION
-#include "argtable3_private.h"
+  #include "argtable3_private.h"
 #endif
 
 #include <stdarg.h>
@@ -315,140 +334,142 @@ int arg_hashtable_itr_search(arg_hashtable_itr_t* itr, arg_hashtable_t* h, void*
 #include <stdlib.h>
 #include <string.h>
 
-static void panic(const char* fmt, ...);
-static arg_panicfn* s_panic = panic;
+static void panic(const char *fmt, ...);
+static arg_panicfn *s_panic = panic;
 
-void dbg_printf(const char* fmt, ...) {
-    va_list args;
-    va_start(args, fmt);
-    vfprintf(stderr, fmt, args);
-    va_end(args);
+void dbg_printf(const char *fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+  vfprintf(stderr, fmt, args);
+  va_end(args);
 }
 
-static void panic(const char* fmt, ...) {
-    va_list args;
-    char* s;
+static void panic(const char *fmt, ...) {
+  va_list args;
+  char *s;
 
-    va_start(args, fmt);
-    vfprintf(stderr, fmt, args);
-    va_end(args);
+  va_start(args, fmt);
+  vfprintf(stderr, fmt, args);
+  va_end(args);
 
 #if defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 4996)
+  #pragma warning(push)
+  #pragma warning(disable : 4996)
 #endif
-    s = getenv("EF_DUMPCORE");
+  s = getenv("EF_DUMPCORE");
 #if defined(_MSC_VER)
-#pragma warning(pop)
+  #pragma warning(pop)
 #endif
 
-    if (s != NULL && *s != '\0') {
-        abort();
+  if (s != NULL && *s != '\0') {
+    abort();
+  } else {
+    exit(EXIT_FAILURE);
+  }
+}
+
+void arg_set_panic(arg_panicfn *proc) {
+  s_panic = proc;
+}
+
+void *xmalloc(size_t size) {
+  void *ret = malloc(size);
+  if (!ret) {
+    s_panic("Out of memory!\n");
+  }
+  return ret;
+}
+
+void *xcalloc(size_t count, size_t size) {
+  size_t allocated_count = count && size ? count : 1;
+  size_t allocated_size = count && size ? size : 1;
+  void *ret = calloc(allocated_count, allocated_size);
+  if (!ret) {
+    s_panic("Out of memory!\n");
+  }
+  return ret;
+}
+
+void *xrealloc(void *ptr, size_t size) {
+  size_t allocated_size = size ? size : 1;
+  void *ret = realloc(ptr, allocated_size);
+  if (!ret) {
+    s_panic("Out of memory!\n");
+  }
+  return ret;
+}
+
+void xfree(void *ptr) {
+  free(ptr);
+}
+
+static void merge(void *data, int esize, int i, int j, int k,
+                  arg_comparefn *comparefn) {
+  char *a = (char *)data;
+  char *m;
+  int ipos, jpos, mpos;
+
+  /* Initialize the counters used in merging. */
+  ipos = i;
+  jpos = j + 1;
+  mpos = 0;
+
+  /* Allocate storage for the merged elements. */
+  m = (char *)xmalloc((size_t)(esize * ((k - i) + 1)));
+
+  /* Continue while either division has elements to merge. */
+  while (ipos <= j || jpos <= k) {
+    if (ipos > j) {
+      /* The left division has no more elements to merge. */
+      while (jpos <= k) {
+        memcpy(&m[mpos * esize], &a[jpos * esize], (size_t)esize);
+        jpos++;
+        mpos++;
+      }
+
+      continue;
+    } else if (jpos > k) {
+      /* The right division has no more elements to merge. */
+      while (ipos <= j) {
+        memcpy(&m[mpos * esize], &a[ipos * esize], (size_t)esize);
+        ipos++;
+        mpos++;
+      }
+
+      continue;
+    }
+
+    /* Append the next ordered element to the merged elements. */
+    if (comparefn(&a[ipos * esize], &a[jpos * esize]) < 0) {
+      memcpy(&m[mpos * esize], &a[ipos * esize], (size_t)esize);
+      ipos++;
+      mpos++;
     } else {
-        exit(EXIT_FAILURE);
+      memcpy(&m[mpos * esize], &a[jpos * esize], (size_t)esize);
+      jpos++;
+      mpos++;
     }
+  }
+
+  /* Prepare to pass back the merged data. */
+  memcpy(&a[i * esize], m, (size_t)(esize * ((k - i) + 1)));
+  xfree(m);
 }
 
-void arg_set_panic(arg_panicfn* proc) {
-    s_panic = proc;
-}
+void arg_mgsort(void *data, int size, int esize, int i, int k,
+                arg_comparefn *comparefn) {
+  int j;
 
-void* xmalloc(size_t size) {
-    void* ret = malloc(size);
-    if (!ret) {
-        s_panic("Out of memory!\n");
-    }
-    return ret;
-}
+  /* Stop the recursion when no more divisions can be made. */
+  if (i < k) {
+    /* Determine where to divide the elements. */
+    j = (int)(((i + k - 1)) / 2);
 
-void* xcalloc(size_t count, size_t size) {
-    size_t allocated_count = count && size ? count : 1;
-    size_t allocated_size = count && size ? size : 1;
-    void* ret = calloc(allocated_count, allocated_size);
-    if (!ret) {
-        s_panic("Out of memory!\n");
-    }
-    return ret;
-}
-
-void* xrealloc(void* ptr, size_t size) {
-    size_t allocated_size = size ? size : 1;
-    void* ret = realloc(ptr, allocated_size);
-    if (!ret) {
-        s_panic("Out of memory!\n");
-    }
-    return ret;
-}
-
-void xfree(void* ptr) {
-    free(ptr);
-}
-
-static void merge(void* data, int esize, int i, int j, int k, arg_comparefn* comparefn) {
-    char* a = (char*)data;
-    char* m;
-    int ipos, jpos, mpos;
-
-    /* Initialize the counters used in merging. */
-    ipos = i;
-    jpos = j + 1;
-    mpos = 0;
-
-    /* Allocate storage for the merged elements. */
-    m = (char*)xmalloc((size_t)(esize * ((k - i) + 1)));
-
-    /* Continue while either division has elements to merge. */
-    while (ipos <= j || jpos <= k) {
-        if (ipos > j) {
-            /* The left division has no more elements to merge. */
-            while (jpos <= k) {
-                memcpy(&m[mpos * esize], &a[jpos * esize], (size_t)esize);
-                jpos++;
-                mpos++;
-            }
-
-            continue;
-        } else if (jpos > k) {
-            /* The right division has no more elements to merge. */
-            while (ipos <= j) {
-                memcpy(&m[mpos * esize], &a[ipos * esize], (size_t)esize);
-                ipos++;
-                mpos++;
-            }
-
-            continue;
-        }
-
-        /* Append the next ordered element to the merged elements. */
-        if (comparefn(&a[ipos * esize], &a[jpos * esize]) < 0) {
-            memcpy(&m[mpos * esize], &a[ipos * esize], (size_t)esize);
-            ipos++;
-            mpos++;
-        } else {
-            memcpy(&m[mpos * esize], &a[jpos * esize], (size_t)esize);
-            jpos++;
-            mpos++;
-        }
-    }
-
-    /* Prepare to pass back the merged data. */
-    memcpy(&a[i * esize], m, (size_t)(esize * ((k - i) + 1)));
-    xfree(m);
-}
-
-void arg_mgsort(void* data, int size, int esize, int i, int k, arg_comparefn* comparefn) {
-    int j;
-
-    /* Stop the recursion when no more divisions can be made. */
-    if (i < k) {
-        /* Determine where to divide the elements. */
-        j = (int)(((i + k - 1)) / 2);
-
-        /* Recursively sort the two divisions. */
-        arg_mgsort(data, size, esize, i, j, comparefn);
-        arg_mgsort(data, size, esize, j + 1, k, comparefn);
-        merge(data, esize, i, j, k, comparefn);
-    }
+    /* Recursively sort the two divisions. */
+    arg_mgsort(data, size, esize, i, j, comparefn);
+    arg_mgsort(data, size, esize, j + 1, k, comparefn);
+    merge(data, esize, i, j, k, comparefn);
+  }
 }
 /*******************************************************************************
  * arg_hashtable: Implements the hash table utilities
@@ -483,7 +504,7 @@ void arg_mgsort(void* data, int size, int esize, int i, int k, arg_comparefn* co
  ******************************************************************************/
 
 #ifndef ARG_AMALGAMATION
-#include "argtable3_private.h"
+  #include "argtable3_private.h"
 #endif
 
 #include <math.h>
@@ -532,346 +553,355 @@ void arg_mgsort(void* data, int size, int esize, int i, int k, arg_comparefn* co
  * http://br.endernet.org/~akrowne/
  * http://planetmath.org/encyclopedia/GoodHashTablePrimes.html
  */
-static const unsigned int primes[] = {53,       97,       193,      389,       769,       1543,      3079,      6151,      12289,
-                                      24593,    49157,    98317,    196613,    393241,    786433,    1572869,   3145739,   6291469,
-                                      12582917, 25165843, 50331653, 100663319, 201326611, 402653189, 805306457, 1610612741};
+static const unsigned int primes[] = {
+    53,        97,        193,       389,       769,       1543,     3079,
+    6151,      12289,     24593,     49157,     98317,     196613,   393241,
+    786433,    1572869,   3145739,   6291469,   12582917,  25165843, 50331653,
+    100663319, 201326611, 402653189, 805306457, 1610612741};
 const unsigned int prime_table_length = sizeof(primes) / sizeof(primes[0]);
 const float max_load_factor = (float)0.65;
 
-static unsigned int enhanced_hash(arg_hashtable_t* h, const void* k) {
-    /*
-     * Aim to protect against poor hash functions by adding logic here.
-     * The logic is taken from Java 1.4 hash table source.
-     */
-    unsigned int i = h->hashfn(k);
-    i += ~(i << 9);
-    i ^= ((i >> 14) | (i << 18)); /* >>> */
-    i += (i << 4);
-    i ^= ((i >> 10) | (i << 22)); /* >>> */
-    return i;
+static unsigned int enhanced_hash(arg_hashtable_t *h, const void *k) {
+  /*
+   * Aim to protect against poor hash functions by adding logic here.
+   * The logic is taken from Java 1.4 hash table source.
+   */
+  unsigned int i = h->hashfn(k);
+  i += ~(i << 9);
+  i ^= ((i >> 14) | (i << 18)); /* >>> */
+  i += (i << 4);
+  i ^= ((i >> 10) | (i << 22)); /* >>> */
+  return i;
 }
 
-static unsigned int index_for(unsigned int tablelength, unsigned int hashvalue) {
-    return (hashvalue % tablelength);
+static unsigned int index_for(unsigned int tablelength,
+                              unsigned int hashvalue) {
+  return (hashvalue % tablelength);
 }
 
-arg_hashtable_t* arg_hashtable_create(unsigned int minsize, unsigned int (*hashfn)(const void*), int (*eqfn)(const void*, const void*)) {
-    arg_hashtable_t* h;
-    unsigned int pindex;
-    unsigned int size = primes[0];
+arg_hashtable_t *arg_hashtable_create(unsigned int minsize,
+                                      unsigned int (*hashfn)(const void *),
+                                      int (*eqfn)(const void *, const void *)) {
+  arg_hashtable_t *h;
+  unsigned int pindex;
+  unsigned int size = primes[0];
 
-    /* Check requested hash table isn't too large */
-    if (minsize > (1u << 30))
-        return NULL;
-
-    /*
-     * Enforce size as prime. The reason is to avoid clustering of values
-     * into a small number of buckets (yes, distribution). A more even
-     *  distributed hash table will perform more consistently.
-     */
-    for (pindex = 0; pindex < prime_table_length; pindex++) {
-        if (primes[pindex] > minsize) {
-            size = primes[pindex];
-            break;
-        }
-    }
-
-    h = (arg_hashtable_t*)xmalloc(sizeof(arg_hashtable_t));
-    h->table = (struct arg_hashtable_entry**)xmalloc(sizeof(struct arg_hashtable_entry*) * size);
-    memset(h->table, 0, size * sizeof(struct arg_hashtable_entry*));
-    h->tablelength = size;
-    h->primeindex = pindex;
-    h->entrycount = 0;
-    h->hashfn = hashfn;
-    h->eqfn = eqfn;
-    h->loadlimit = (unsigned int)ceil(size * (double)max_load_factor);
-    return h;
-}
-
-static int arg_hashtable_expand(arg_hashtable_t* h) {
-    /* Double the size of the table to accommodate more entries */
-    struct arg_hashtable_entry** newtable;
-    struct arg_hashtable_entry* e;
-    unsigned int newsize;
-    unsigned int i;
-    unsigned int index;
-
-    /* Check we're not hitting max capacity */
-    if (h->primeindex == (prime_table_length - 1))
-        return 0;
-    newsize = primes[++(h->primeindex)];
-
-    newtable = (struct arg_hashtable_entry**)xmalloc(sizeof(struct arg_hashtable_entry*) * newsize);
-    memset(newtable, 0, newsize * sizeof(struct arg_hashtable_entry*));
-    /*
-     * This algorithm is not 'stable': it reverses the list
-     * when it transfers entries between the tables
-     */
-    for (i = 0; i < h->tablelength; i++) {
-        while (NULL != (e = h->table[i])) {
-            h->table[i] = e->next;
-            index = index_for(newsize, e->h);
-            e->next = newtable[index];
-            newtable[index] = e;
-        }
-    }
-
-    xfree(h->table);
-    h->table = newtable;
-    h->tablelength = newsize;
-    h->loadlimit = (unsigned int)ceil(newsize * (double)max_load_factor);
-    return -1;
-}
-
-unsigned int arg_hashtable_count(arg_hashtable_t* h) {
-    return h->entrycount;
-}
-
-void arg_hashtable_insert(arg_hashtable_t* h, void* k, void* v) {
-    /* This method allows duplicate keys - but they shouldn't be used */
-    unsigned int index;
-    struct arg_hashtable_entry* e;
-    if ((h->entrycount + 1) > h->loadlimit) {
-        /*
-         * Ignore the return value. If expand fails, we should
-         * still try cramming just this value into the existing table
-         * -- we may not have memory for a larger table, but one more
-         * element may be ok. Next time we insert, we'll try expanding again.
-         */
-        arg_hashtable_expand(h);
-    }
-    e = (struct arg_hashtable_entry*)xmalloc(sizeof(struct arg_hashtable_entry));
-    e->h = enhanced_hash(h, k);
-    index = index_for(h->tablelength, e->h);
-    e->k = k;
-    e->v = v;
-    e->next = h->table[index];
-    h->table[index] = e;
-    h->entrycount++;
-}
-
-void* arg_hashtable_search(arg_hashtable_t* h, const void* k) {
-    struct arg_hashtable_entry* e;
-    unsigned int hashvalue;
-    unsigned int index;
-
-    hashvalue = enhanced_hash(h, k);
-    index = index_for(h->tablelength, hashvalue);
-    e = h->table[index];
-    while (e != NULL) {
-        /* Check hash value to short circuit heavier comparison */
-        if ((hashvalue == e->h) && (h->eqfn(k, e->k)))
-            return e->v;
-        e = e->next;
-    }
+  /* Check requested hash table isn't too large */
+  if (minsize > (1u << 30))
     return NULL;
+
+  /*
+   * Enforce size as prime. The reason is to avoid clustering of values
+   * into a small number of buckets (yes, distribution). A more even
+   *  distributed hash table will perform more consistently.
+   */
+  for (pindex = 0; pindex < prime_table_length; pindex++) {
+    if (primes[pindex] > minsize) {
+      size = primes[pindex];
+      break;
+    }
+  }
+
+  h = (arg_hashtable_t *)xmalloc(sizeof(arg_hashtable_t));
+  h->table = (struct arg_hashtable_entry **)xmalloc(
+      sizeof(struct arg_hashtable_entry *) * size);
+  memset(h->table, 0, size * sizeof(struct arg_hashtable_entry *));
+  h->tablelength = size;
+  h->primeindex = pindex;
+  h->entrycount = 0;
+  h->hashfn = hashfn;
+  h->eqfn = eqfn;
+  h->loadlimit = (unsigned int)ceil(size * (double)max_load_factor);
+  return h;
 }
 
-void arg_hashtable_remove(arg_hashtable_t* h, const void* k) {
+static int arg_hashtable_expand(arg_hashtable_t *h) {
+  /* Double the size of the table to accommodate more entries */
+  struct arg_hashtable_entry **newtable;
+  struct arg_hashtable_entry *e;
+  unsigned int newsize;
+  unsigned int i;
+  unsigned int index;
+
+  /* Check we're not hitting max capacity */
+  if (h->primeindex == (prime_table_length - 1))
+    return 0;
+  newsize = primes[++(h->primeindex)];
+
+  newtable = (struct arg_hashtable_entry **)xmalloc(
+      sizeof(struct arg_hashtable_entry *) * newsize);
+  memset(newtable, 0, newsize * sizeof(struct arg_hashtable_entry *));
+  /*
+   * This algorithm is not 'stable': it reverses the list
+   * when it transfers entries between the tables
+   */
+  for (i = 0; i < h->tablelength; i++) {
+    while (NULL != (e = h->table[i])) {
+      h->table[i] = e->next;
+      index = index_for(newsize, e->h);
+      e->next = newtable[index];
+      newtable[index] = e;
+    }
+  }
+
+  xfree(h->table);
+  h->table = newtable;
+  h->tablelength = newsize;
+  h->loadlimit = (unsigned int)ceil(newsize * (double)max_load_factor);
+  return -1;
+}
+
+unsigned int arg_hashtable_count(arg_hashtable_t *h) {
+  return h->entrycount;
+}
+
+void arg_hashtable_insert(arg_hashtable_t *h, void *k, void *v) {
+  /* This method allows duplicate keys - but they shouldn't be used */
+  unsigned int index;
+  struct arg_hashtable_entry *e;
+  if ((h->entrycount + 1) > h->loadlimit) {
     /*
-     * TODO: consider compacting the table when the load factor drops enough,
-     *       or provide a 'compact' method.
+     * Ignore the return value. If expand fails, we should
+     * still try cramming just this value into the existing table
+     * -- we may not have memory for a larger table, but one more
+     * element may be ok. Next time we insert, we'll try expanding again.
      */
+    arg_hashtable_expand(h);
+  }
+  e = (struct arg_hashtable_entry *)xmalloc(sizeof(struct arg_hashtable_entry));
+  e->h = enhanced_hash(h, k);
+  index = index_for(h->tablelength, e->h);
+  e->k = k;
+  e->v = v;
+  e->next = h->table[index];
+  h->table[index] = e;
+  h->entrycount++;
+}
 
-    struct arg_hashtable_entry* e;
-    struct arg_hashtable_entry** pE;
-    unsigned int hashvalue;
-    unsigned int index;
+void *arg_hashtable_search(arg_hashtable_t *h, const void *k) {
+  struct arg_hashtable_entry *e;
+  unsigned int hashvalue;
+  unsigned int index;
 
-    hashvalue = enhanced_hash(h, k);
-    index = index_for(h->tablelength, hashvalue);
-    pE = &(h->table[index]);
-    e = *pE;
-    while (NULL != e) {
-        /* Check hash value to short circuit heavier comparison */
-        if ((hashvalue == e->h) && (h->eqfn(k, e->k))) {
-            *pE = e->next;
-            h->entrycount--;
-            xfree(e->k);
-            xfree(e->v);
-            xfree(e);
-            return;
-        }
-        pE = &(e->next);
+  hashvalue = enhanced_hash(h, k);
+  index = index_for(h->tablelength, hashvalue);
+  e = h->table[index];
+  while (e != NULL) {
+    /* Check hash value to short circuit heavier comparison */
+    if ((hashvalue == e->h) && (h->eqfn(k, e->k)))
+      return e->v;
+    e = e->next;
+  }
+  return NULL;
+}
+
+void arg_hashtable_remove(arg_hashtable_t *h, const void *k) {
+  /*
+   * TODO: consider compacting the table when the load factor drops enough,
+   *       or provide a 'compact' method.
+   */
+
+  struct arg_hashtable_entry *e;
+  struct arg_hashtable_entry **pE;
+  unsigned int hashvalue;
+  unsigned int index;
+
+  hashvalue = enhanced_hash(h, k);
+  index = index_for(h->tablelength, hashvalue);
+  pE = &(h->table[index]);
+  e = *pE;
+  while (NULL != e) {
+    /* Check hash value to short circuit heavier comparison */
+    if ((hashvalue == e->h) && (h->eqfn(k, e->k))) {
+      *pE = e->next;
+      h->entrycount--;
+      xfree(e->k);
+      xfree(e->v);
+      xfree(e);
+      return;
+    }
+    pE = &(e->next);
+    e = e->next;
+  }
+}
+
+void arg_hashtable_destroy(arg_hashtable_t *h, int free_values) {
+  unsigned int i;
+  struct arg_hashtable_entry *e, *f;
+  struct arg_hashtable_entry **table = h->table;
+  if (free_values) {
+    for (i = 0; i < h->tablelength; i++) {
+      e = table[i];
+      while (NULL != e) {
+        f = e;
         e = e->next;
+        xfree(f->k);
+        xfree(f->v);
+        xfree(f);
+      }
     }
+  } else {
+    for (i = 0; i < h->tablelength; i++) {
+      e = table[i];
+      while (NULL != e) {
+        f = e;
+        e = e->next;
+        xfree(f->k);
+        xfree(f);
+      }
+    }
+  }
+  xfree(h->table);
+  xfree(h);
 }
 
-void arg_hashtable_destroy(arg_hashtable_t* h, int free_values) {
-    unsigned int i;
-    struct arg_hashtable_entry *e, *f;
-    struct arg_hashtable_entry** table = h->table;
-    if (free_values) {
-        for (i = 0; i < h->tablelength; i++) {
-            e = table[i];
-            while (NULL != e) {
-                f = e;
-                e = e->next;
-                xfree(f->k);
-                xfree(f->v);
-                xfree(f);
-            }
-        }
-    } else {
-        for (i = 0; i < h->tablelength; i++) {
-            e = table[i];
-            while (NULL != e) {
-                f = e;
-                e = e->next;
-                xfree(f->k);
-                xfree(f);
-            }
-        }
-    }
-    xfree(h->table);
-    xfree(h);
-}
+arg_hashtable_itr_t *arg_hashtable_itr_create(arg_hashtable_t *h) {
+  unsigned int i;
+  unsigned int tablelength;
 
-arg_hashtable_itr_t* arg_hashtable_itr_create(arg_hashtable_t* h) {
-    unsigned int i;
-    unsigned int tablelength;
-
-    arg_hashtable_itr_t* itr = (arg_hashtable_itr_t*)xmalloc(sizeof(arg_hashtable_itr_t));
-    itr->h = h;
-    itr->e = NULL;
-    itr->parent = NULL;
-    tablelength = h->tablelength;
-    itr->index = tablelength;
-    if (0 == h->entrycount)
-        return itr;
-
-    for (i = 0; i < tablelength; i++) {
-        if (h->table[i] != NULL) {
-            itr->e = h->table[i];
-            itr->index = i;
-            break;
-        }
-    }
+  arg_hashtable_itr_t *itr =
+      (arg_hashtable_itr_t *)xmalloc(sizeof(arg_hashtable_itr_t));
+  itr->h = h;
+  itr->e = NULL;
+  itr->parent = NULL;
+  tablelength = h->tablelength;
+  itr->index = tablelength;
+  if (0 == h->entrycount)
     return itr;
-}
 
-void arg_hashtable_itr_destroy(arg_hashtable_itr_t* itr) {
-    xfree(itr);
-}
-
-void* arg_hashtable_itr_key(arg_hashtable_itr_t* i) {
-    return i->e->k;
-}
-
-void* arg_hashtable_itr_value(arg_hashtable_itr_t* i) {
-    return i->e->v;
-}
-
-int arg_hashtable_itr_advance(arg_hashtable_itr_t* itr) {
-    unsigned int j;
-    unsigned int tablelength;
-    struct arg_hashtable_entry** table;
-    struct arg_hashtable_entry* next;
-
-    if (itr->e == NULL)
-        return 0; /* stupidity check */
-
-    next = itr->e->next;
-    if (NULL != next) {
-        itr->parent = itr->e;
-        itr->e = next;
-        return -1;
+  for (i = 0; i < tablelength; i++) {
+    if (h->table[i] != NULL) {
+      itr->e = h->table[i];
+      itr->index = i;
+      break;
     }
+  }
+  return itr;
+}
 
-    tablelength = itr->h->tablelength;
-    itr->parent = NULL;
-    if (tablelength <= (j = ++(itr->index))) {
-        itr->e = NULL;
-        return 0;
-    }
+void arg_hashtable_itr_destroy(arg_hashtable_itr_t *itr) {
+  xfree(itr);
+}
 
-    table = itr->h->table;
-    while (NULL == (next = table[j])) {
-        if (++j >= tablelength) {
-            itr->index = tablelength;
-            itr->e = NULL;
-            return 0;
-        }
-    }
+void *arg_hashtable_itr_key(arg_hashtable_itr_t *i) {
+  return i->e->k;
+}
 
-    itr->index = j;
+void *arg_hashtable_itr_value(arg_hashtable_itr_t *i) {
+  return i->e->v;
+}
+
+int arg_hashtable_itr_advance(arg_hashtable_itr_t *itr) {
+  unsigned int j;
+  unsigned int tablelength;
+  struct arg_hashtable_entry **table;
+  struct arg_hashtable_entry *next;
+
+  if (itr->e == NULL)
+    return 0; /* stupidity check */
+
+  next = itr->e->next;
+  if (NULL != next) {
+    itr->parent = itr->e;
     itr->e = next;
     return -1;
-}
+  }
 
-int arg_hashtable_itr_remove(arg_hashtable_itr_t* itr) {
-    struct arg_hashtable_entry* remember_e;
-    struct arg_hashtable_entry* remember_parent;
-    int ret;
-
-    /* Do the removal */
-    if ((itr->parent) == NULL) {
-        /* element is head of a chain */
-        itr->h->table[itr->index] = itr->e->next;
-    } else {
-        /* element is mid-chain */
-        itr->parent->next = itr->e->next;
-    }
-    /* itr->e is now outside the hashtable */
-    remember_e = itr->e;
-    itr->h->entrycount--;
-    xfree(remember_e->k);
-    xfree(remember_e->v);
-
-    /* Advance the iterator, correcting the parent */
-    remember_parent = itr->parent;
-    ret = arg_hashtable_itr_advance(itr);
-    if (itr->parent == remember_e) {
-        itr->parent = remember_parent;
-    }
-    xfree(remember_e);
-    return ret;
-}
-
-int arg_hashtable_itr_search(arg_hashtable_itr_t* itr, arg_hashtable_t* h, void* k) {
-    struct arg_hashtable_entry* e;
-    struct arg_hashtable_entry* parent;
-    unsigned int hashvalue;
-    unsigned int index;
-
-    hashvalue = enhanced_hash(h, k);
-    index = index_for(h->tablelength, hashvalue);
-
-    e = h->table[index];
-    parent = NULL;
-    while (e != NULL) {
-        /* Check hash value to short circuit heavier comparison */
-        if ((hashvalue == e->h) && (h->eqfn(k, e->k))) {
-            itr->index = index;
-            itr->e = e;
-            itr->parent = parent;
-            itr->h = h;
-            return -1;
-        }
-        parent = e;
-        e = e->next;
-    }
+  tablelength = itr->h->tablelength;
+  itr->parent = NULL;
+  if (tablelength <= (j = ++(itr->index))) {
+    itr->e = NULL;
     return 0;
+  }
+
+  table = itr->h->table;
+  while (NULL == (next = table[j])) {
+    if (++j >= tablelength) {
+      itr->index = tablelength;
+      itr->e = NULL;
+      return 0;
+    }
+  }
+
+  itr->index = j;
+  itr->e = next;
+  return -1;
 }
 
-int arg_hashtable_change(arg_hashtable_t* h, void* k, void* v) {
-    struct arg_hashtable_entry* e;
-    unsigned int hashvalue;
-    unsigned int index;
+int arg_hashtable_itr_remove(arg_hashtable_itr_t *itr) {
+  struct arg_hashtable_entry *remember_e;
+  struct arg_hashtable_entry *remember_parent;
+  int ret;
 
-    hashvalue = enhanced_hash(h, k);
-    index = index_for(h->tablelength, hashvalue);
-    e = h->table[index];
-    while (e != NULL) {
-        /* Check hash value to short circuit heavier comparison */
-        if ((hashvalue == e->h) && (h->eqfn(k, e->k))) {
-            xfree(e->v);
-            e->v = v;
-            return -1;
-        }
-        e = e->next;
+  /* Do the removal */
+  if ((itr->parent) == NULL) {
+    /* element is head of a chain */
+    itr->h->table[itr->index] = itr->e->next;
+  } else {
+    /* element is mid-chain */
+    itr->parent->next = itr->e->next;
+  }
+  /* itr->e is now outside the hashtable */
+  remember_e = itr->e;
+  itr->h->entrycount--;
+  xfree(remember_e->k);
+  xfree(remember_e->v);
+
+  /* Advance the iterator, correcting the parent */
+  remember_parent = itr->parent;
+  ret = arg_hashtable_itr_advance(itr);
+  if (itr->parent == remember_e) {
+    itr->parent = remember_parent;
+  }
+  xfree(remember_e);
+  return ret;
+}
+
+int arg_hashtable_itr_search(arg_hashtable_itr_t *itr, arg_hashtable_t *h,
+                             void *k) {
+  struct arg_hashtable_entry *e;
+  struct arg_hashtable_entry *parent;
+  unsigned int hashvalue;
+  unsigned int index;
+
+  hashvalue = enhanced_hash(h, k);
+  index = index_for(h->tablelength, hashvalue);
+
+  e = h->table[index];
+  parent = NULL;
+  while (e != NULL) {
+    /* Check hash value to short circuit heavier comparison */
+    if ((hashvalue == e->h) && (h->eqfn(k, e->k))) {
+      itr->index = index;
+      itr->e = e;
+      itr->parent = parent;
+      itr->h = h;
+      return -1;
     }
-    return 0;
+    parent = e;
+    e = e->next;
+  }
+  return 0;
+}
+
+int arg_hashtable_change(arg_hashtable_t *h, void *k, void *v) {
+  struct arg_hashtable_entry *e;
+  unsigned int hashvalue;
+  unsigned int index;
+
+  hashvalue = enhanced_hash(h, k);
+  index = index_for(h->tablelength, hashvalue);
+  e = h->table[index];
+  while (e != NULL) {
+    /* Check hash value to short circuit heavier comparison */
+    if ((hashvalue == e->h) && (h->eqfn(k, e->k))) {
+      xfree(e->v);
+      e->v = v;
+      return -1;
+    }
+    e = e->next;
+  }
+  return 0;
 }
 /*******************************************************************************
  * arg_dstr: Implements the dynamic string utilities
@@ -908,7 +938,7 @@ int arg_hashtable_change(arg_hashtable_t* h, void* k, void* v) {
 #include "argtable3.h"
 
 #ifndef ARG_AMALGAMATION
-#include "argtable3_private.h"
+  #include "argtable3_private.h"
 #endif
 
 #include <stdarg.h>
@@ -916,8 +946,8 @@ int arg_hashtable_change(arg_hashtable_t* h, void* k, void* v) {
 #include <string.h>
 
 #if defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 4996)
+  #pragma warning(push)
+  #pragma warning(disable : 4996)
 #endif
 
 #define START_VSNBUFF 16
@@ -969,92 +999,93 @@ int arg_hashtable_change(arg_hashtable_t* h, void* k, void* v) {
  */
 
 typedef struct _internal_arg_dstr {
-    char* data;
-    arg_dstr_freefn* free_proc;
-    char sbuf[ARG_DSTR_SIZE + 1];
-    char* append_data;
-    int append_data_size;
-    int append_used;
+  char *data;
+  arg_dstr_freefn *free_proc;
+  char sbuf[ARG_DSTR_SIZE + 1];
+  char *append_data;
+  int append_data_size;
+  int append_used;
 } _internal_arg_dstr_t;
 
 static void setup_append_buf(arg_dstr_t res, int newSpace);
 
 arg_dstr_t arg_dstr_create(void) {
-    _internal_arg_dstr_t* h = (_internal_arg_dstr_t*)xmalloc(sizeof(_internal_arg_dstr_t));
-    memset(h, 0, sizeof(_internal_arg_dstr_t));
-    h->sbuf[0] = 0;
-    h->data = h->sbuf;
-    h->free_proc = ARG_DSTR_STATIC;
-    return h;
+  _internal_arg_dstr_t *h =
+      (_internal_arg_dstr_t *)xmalloc(sizeof(_internal_arg_dstr_t));
+  memset(h, 0, sizeof(_internal_arg_dstr_t));
+  h->sbuf[0] = 0;
+  h->data = h->sbuf;
+  h->free_proc = ARG_DSTR_STATIC;
+  return h;
 }
 
 void arg_dstr_destroy(arg_dstr_t ds) {
-    if (ds == NULL)
-        return;
-
-    arg_dstr_reset(ds);
-    xfree(ds);
+  if (ds == NULL)
     return;
+
+  arg_dstr_reset(ds);
+  xfree(ds);
+  return;
 }
 
-void arg_dstr_set(arg_dstr_t ds, char* str, arg_dstr_freefn* free_proc) {
-    int length;
-    register arg_dstr_freefn* old_free_proc = ds->free_proc;
-    char* old_result = ds->data;
+void arg_dstr_set(arg_dstr_t ds, char *str, arg_dstr_freefn *free_proc) {
+  int length;
+  register arg_dstr_freefn *old_free_proc = ds->free_proc;
+  char *old_result = ds->data;
 
-    if (str == NULL) {
-        ds->sbuf[0] = 0;
-        ds->data = ds->sbuf;
-        ds->free_proc = ARG_DSTR_STATIC;
-    } else if (free_proc == ARG_DSTR_VOLATILE) {
-        length = (int)strlen(str);
-        if (length > ARG_DSTR_SIZE) {
-            ds->data = (char*)xmalloc((unsigned)length + 1);
-            ds->free_proc = ARG_DSTR_DYNAMIC;
-        } else {
-            ds->data = ds->sbuf;
-            ds->free_proc = ARG_DSTR_STATIC;
-        }
-        strcpy(ds->data, str);
+  if (str == NULL) {
+    ds->sbuf[0] = 0;
+    ds->data = ds->sbuf;
+    ds->free_proc = ARG_DSTR_STATIC;
+  } else if (free_proc == ARG_DSTR_VOLATILE) {
+    length = (int)strlen(str);
+    if (length > ARG_DSTR_SIZE) {
+      ds->data = (char *)xmalloc((unsigned)length + 1);
+      ds->free_proc = ARG_DSTR_DYNAMIC;
     } else {
-        ds->data = str;
-        ds->free_proc = free_proc;
+      ds->data = ds->sbuf;
+      ds->free_proc = ARG_DSTR_STATIC;
     }
+    strcpy(ds->data, str);
+  } else {
+    ds->data = str;
+    ds->free_proc = free_proc;
+  }
 
-    /*
-     * If the old result was dynamically-allocated, free it up. Do it here,
-     * rather than at the beginning, in case the new result value was part of
-     * the old result value.
-     */
+  /*
+   * If the old result was dynamically-allocated, free it up. Do it here,
+   * rather than at the beginning, in case the new result value was part of
+   * the old result value.
+   */
 
-    if ((old_free_proc != 0) && (old_result != ds->data)) {
-        if (old_free_proc == ARG_DSTR_DYNAMIC) {
-            xfree(old_result);
-        } else {
-            (*old_free_proc)(old_result);
-        }
+  if ((old_free_proc != 0) && (old_result != ds->data)) {
+    if (old_free_proc == ARG_DSTR_DYNAMIC) {
+      xfree(old_result);
+    } else {
+      (*old_free_proc)(old_result);
     }
+  }
 
-    if ((ds->append_data != NULL) && (ds->append_data_size > 0)) {
-        xfree(ds->append_data);
-        ds->append_data = NULL;
-        ds->append_data_size = 0;
-    }
+  if ((ds->append_data != NULL) && (ds->append_data_size > 0)) {
+    xfree(ds->append_data);
+    ds->append_data = NULL;
+    ds->append_data_size = 0;
+  }
 }
 
-char* arg_dstr_cstr(arg_dstr_t ds) /* Interpreter whose result to return. */
+char *arg_dstr_cstr(arg_dstr_t ds) /* Interpreter whose result to return. */
 {
-    return ds->data;
+  return ds->data;
 }
 
-void arg_dstr_cat(arg_dstr_t ds, const char* str) {
-    setup_append_buf(ds, (int)strlen(str) + 1);
-    memcpy(ds->data + strlen(ds->data), str, strlen(str));
+void arg_dstr_cat(arg_dstr_t ds, const char *str) {
+  setup_append_buf(ds, (int)strlen(str) + 1);
+  memcpy(ds->data + strlen(ds->data), str, strlen(str));
 }
 
 void arg_dstr_catc(arg_dstr_t ds, char c) {
-    setup_append_buf(ds, 2);
-    memcpy(ds->data + strlen(ds->data), &c, 1);
+  setup_append_buf(ds, 2);
+  memcpy(ds->data + strlen(ds->data), &c, 1);
 }
 
 /*
@@ -1081,136 +1112,137 @@ void arg_dstr_catc(arg_dstr_t ds, char c) {
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
-void arg_dstr_catf(arg_dstr_t ds, const char* fmt, ...) {
-    va_list arglist;
-    char* buff;
-    int n, r;
-    size_t slen;
+void arg_dstr_catf(arg_dstr_t ds, const char *fmt, ...) {
+  va_list arglist;
+  char *buff;
+  int n, r;
+  size_t slen;
 
-    if (fmt == NULL)
-        return;
+  if (fmt == NULL)
+    return;
 
-    /* Since the length is not determinable beforehand, a search is
-       performed using the truncating "vsnprintf" call (to avoid buffer
-       overflows) on increasing potential sizes for the output result. */
+  /* Since the length is not determinable beforehand, a search is
+     performed using the truncating "vsnprintf" call (to avoid buffer
+     overflows) on increasing potential sizes for the output result. */
 
-    if ((n = (int)(2 * strlen(fmt))) < START_VSNBUFF)
-        n = START_VSNBUFF;
+  if ((n = (int)(2 * strlen(fmt))) < START_VSNBUFF)
+    n = START_VSNBUFF;
 
-    buff = (char*)xmalloc((size_t)(n + 2));
-    memset(buff, 0, (size_t)(n + 2));
+  buff = (char *)xmalloc((size_t)(n + 2));
+  memset(buff, 0, (size_t)(n + 2));
 
-    for (;;) {
-        va_start(arglist, fmt);
-        r = vsnprintf(buff, (size_t)(n + 1), fmt, arglist);
-        va_end(arglist);
+  for (;;) {
+    va_start(arglist, fmt);
+    r = vsnprintf(buff, (size_t)(n + 1), fmt, arglist);
+    va_end(arglist);
 
-        slen = strlen(buff);
-        if (slen < (size_t)n)
-            break;
+    slen = strlen(buff);
+    if (slen < (size_t)n)
+      break;
 
-        if (r > n)
-            n = r;
-        else
-            n += n;
+    if (r > n)
+      n = r;
+    else
+      n += n;
 
-        xfree(buff);
-        buff = (char*)xmalloc((size_t)(n + 2));
-        memset(buff, 0, (size_t)(n + 2));
-    }
-
-    arg_dstr_cat(ds, buff);
     xfree(buff);
+    buff = (char *)xmalloc((size_t)(n + 2));
+    memset(buff, 0, (size_t)(n + 2));
+  }
+
+  arg_dstr_cat(ds, buff);
+  xfree(buff);
 }
 
 static void setup_append_buf(arg_dstr_t ds, int new_space) {
-    int total_space;
+  int total_space;
 
+  /*
+   * Make the append buffer larger, if that's necessary, then copy the
+   * data into the append buffer and make the append buffer the official
+   * data.
+   */
+  if (ds->data != ds->append_data) {
     /*
-     * Make the append buffer larger, if that's necessary, then copy the
-     * data into the append buffer and make the append buffer the official
-     * data.
+     * If the buffer is too big, then free it up so we go back to a
+     * smaller buffer. This avoids tying up memory forever after a large
+     * operation.
      */
-    if (ds->data != ds->append_data) {
-        /*
-         * If the buffer is too big, then free it up so we go back to a
-         * smaller buffer. This avoids tying up memory forever after a large
-         * operation.
-         */
-        if (ds->append_data_size > 500) {
-            xfree(ds->append_data);
-            ds->append_data = NULL;
-            ds->append_data_size = 0;
-        }
-        ds->append_used = (int)strlen(ds->data);
-    } else if (ds->data[ds->append_used] != 0) {
-        /*
-         * Most likely someone has modified a result created by
-         * arg_dstr_cat et al. so that it has a different size. Just
-         * recompute the size.
-         */
-        ds->append_used = (int)strlen(ds->data);
+    if (ds->append_data_size > 500) {
+      xfree(ds->append_data);
+      ds->append_data = NULL;
+      ds->append_data_size = 0;
     }
+    ds->append_used = (int)strlen(ds->data);
+  } else if (ds->data[ds->append_used] != 0) {
+    /*
+     * Most likely someone has modified a result created by
+     * arg_dstr_cat et al. so that it has a different size. Just
+     * recompute the size.
+     */
+    ds->append_used = (int)strlen(ds->data);
+  }
 
-    total_space = new_space + ds->append_used;
-    if (total_space >= ds->append_data_size) {
-        char* newbuf;
+  total_space = new_space + ds->append_used;
+  if (total_space >= ds->append_data_size) {
+    char *newbuf;
 
-        if (total_space < 100) {
-            total_space = 200;
-        } else {
-            total_space *= 2;
-        }
-        newbuf = (char*)xmalloc((unsigned)total_space);
-        memset(newbuf, 0, (size_t)total_space);
-        strcpy(newbuf, ds->data);
-        if (ds->append_data != NULL) {
-            xfree(ds->append_data);
-        }
-        ds->append_data = newbuf;
-        ds->append_data_size = total_space;
-    } else if (ds->data != ds->append_data) {
-        strcpy(ds->append_data, ds->data);
+    if (total_space < 100) {
+      total_space = 200;
+    } else {
+      total_space *= 2;
     }
+    newbuf = (char *)xmalloc((unsigned)total_space);
+    memset(newbuf, 0, (size_t)total_space);
+    strcpy(newbuf, ds->data);
+    if (ds->append_data != NULL) {
+      xfree(ds->append_data);
+    }
+    ds->append_data = newbuf;
+    ds->append_data_size = total_space;
+  } else if (ds->data != ds->append_data) {
+    strcpy(ds->append_data, ds->data);
+  }
 
-    arg_dstr_free(ds);
-    ds->data = ds->append_data;
+  arg_dstr_free(ds);
+  ds->data = ds->append_data;
 }
 
 void arg_dstr_free(arg_dstr_t ds) {
-    if (ds->free_proc != NULL) {
-        if (ds->free_proc == ARG_DSTR_DYNAMIC) {
-            xfree(ds->data);
-        } else {
-            (*ds->free_proc)(ds->data);
-        }
-        ds->free_proc = NULL;
+  if (ds->free_proc != NULL) {
+    if (ds->free_proc == ARG_DSTR_DYNAMIC) {
+      xfree(ds->data);
+    } else {
+      (*ds->free_proc)(ds->data);
     }
+    ds->free_proc = NULL;
+  }
 }
 
 void arg_dstr_reset(arg_dstr_t ds) {
-    arg_dstr_free(ds);
-    if ((ds->append_data != NULL) && (ds->append_data_size > 0)) {
-        xfree(ds->append_data);
-        ds->append_data = NULL;
-        ds->append_data_size = 0;
-    }
+  arg_dstr_free(ds);
+  if ((ds->append_data != NULL) && (ds->append_data_size > 0)) {
+    xfree(ds->append_data);
+    ds->append_data = NULL;
+    ds->append_data_size = 0;
+  }
 
-    ds->data = ds->sbuf;
-    ds->sbuf[0] = 0;
+  ds->data = ds->sbuf;
+  ds->sbuf[0] = 0;
 }
 
 #if defined(_MSC_VER)
-#pragma warning(pop)
+  #pragma warning(pop)
 #endif
 /*	$NetBSD: getopt.h,v 1.4 2000/07/07 10:43:54 ad Exp $	*/
 /*	$FreeBSD$ */
@@ -1248,56 +1280,55 @@ void arg_dstr_reset(arg_dstr_t ds) {
 
 #if ARG_REPLACE_GETOPT == 1
 
-#ifndef _GETOPT_H_
-#define _GETOPT_H_
+  #ifndef _GETOPT_H_
+    #define _GETOPT_H_
 
-/*
- * GNU-like getopt_long()/getopt_long_only() with 4.4BSD optreset extension.
- * getopt() is declared here too for GNU programs.
- */
-#define no_argument        0
-#define required_argument  1
-#define optional_argument  2
+    /*
+     * GNU-like getopt_long()/getopt_long_only() with 4.4BSD optreset extension.
+     * getopt() is declared here too for GNU programs.
+     */
+    #define no_argument 0
+    #define required_argument 1
+    #define optional_argument 2
 
 struct option {
-	/* name of long option */
-	const char *name;
-	/*
-	 * one of no_argument, required_argument, and optional_argument:
-	 * whether option takes an argument
-	 */
-	int has_arg;
-	/* if not NULL, set *flag to val when option found */
-	int *flag;
-	/* if flag not NULL, value to set *flag to; else return value */
-	int val;
+  /* name of long option */
+  const char *name;
+  /*
+   * one of no_argument, required_argument, and optional_argument:
+   * whether option takes an argument
+   */
+  int has_arg;
+  /* if not NULL, set *flag to val when option found */
+  int *flag;
+  /* if flag not NULL, value to set *flag to; else return value */
+  int val;
 };
 
-#ifdef __cplusplus
+    #ifdef __cplusplus
 extern "C" {
-#endif
+    #endif
 
-int	getopt_long(int, char * const *, const char *,
-	const struct option *, int *);
-int	getopt_long_only(int, char * const *, const char *,
-	const struct option *, int *);
-#ifndef _GETOPT_DECLARED
-#define	_GETOPT_DECLARED
-int getopt(int, char * const [], const char *);
+int getopt_long(int, char *const *, const char *, const struct option *, int *);
+int getopt_long_only(int, char *const *, const char *, const struct option *,
+                     int *);
+    #ifndef _GETOPT_DECLARED
+      #define _GETOPT_DECLARED
+int getopt(int, char *const[], const char *);
 
-extern char *optarg;			/* getopt(3) external variables */
+extern char *optarg; /* getopt(3) external variables */
 extern int optind, opterr, optopt;
-#endif
-#ifndef _OPTRESET_DECLARED
-#define	_OPTRESET_DECLARED
-extern int optreset;			/* getopt(3) external variable */
-#endif
+    #endif
+    #ifndef _OPTRESET_DECLARED
+      #define _OPTRESET_DECLARED
+extern int optreset; /* getopt(3) external variable */
+    #endif
 
-#ifdef __cplusplus
+    #ifdef __cplusplus
 }
-#endif
- 
-#endif /* !_GETOPT_H_ */
+    #endif
+
+  #endif /* !_GETOPT_H_ */
 
 #endif /* ARG_REPLACE_GETOPT == 1 */
 /*	$OpenBSD: getopt_long.c,v 1.26 2013/06/08 22:47:56 millert Exp $	*/
@@ -1355,48 +1386,48 @@ extern int optreset;			/* getopt(3) external variable */
 
 #if ARG_REPLACE_GETOPT == 1
 
-#ifndef ARG_AMALGAMATION
-#include "arg_getopt.h"
-#endif
+  #ifndef ARG_AMALGAMATION
+    #include "arg_getopt.h"
+  #endif
 
-#include <errno.h>
-#include <stdlib.h>
-#include <string.h>
+  #include <errno.h>
+  #include <stdlib.h>
+  #include <string.h>
 
-#define GNU_COMPATIBLE		/* Be more compatible, configure's use us! */
+  #define GNU_COMPATIBLE /* Be more compatible, configure's use us! */
 
-int	opterr = 1;		/* if error message should be printed */
-int	optind = 1;		/* index into parent argv vector */
-int	optopt = '?';	/* character checked for validity */
-int	optreset;		/* reset getopt */
-char *optarg;		/* argument associated with option */
+int opterr = 1;   /* if error message should be printed */
+int optind = 1;   /* index into parent argv vector */
+int optopt = '?'; /* character checked for validity */
+int optreset;     /* reset getopt */
+char *optarg;     /* argument associated with option */
 
-#define PRINT_ERROR	((opterr) && (*options != ':'))
+  #define PRINT_ERROR ((opterr) && (*options != ':'))
 
-#define FLAG_PERMUTE	0x01	/* permute non-options to the end of argv */
-#define FLAG_ALLARGS	0x02	/* treat non-options as args to option "-1" */
-#define FLAG_LONGONLY	0x04	/* operate as getopt_long_only */
+  #define FLAG_PERMUTE 0x01  /* permute non-options to the end of argv */
+  #define FLAG_ALLARGS 0x02  /* treat non-options as args to option "-1" */
+  #define FLAG_LONGONLY 0x04 /* operate as getopt_long_only */
 
-/* return values */
-#define	BADCH		(int)'?'
-#define	BADARG		((*options == ':') ? (int)':' : (int)'?')
-#define	INORDER 	(int)1
+  /* return values */
+  #define BADCH (int)'?'
+  #define BADARG ((*options == ':') ? (int)':' : (int)'?')
+  #define INORDER (int)1
 
-#define	EMSG		""
+  #define EMSG ""
 
-#ifdef GNU_COMPATIBLE
-#define NO_PREFIX	(-1)
-#define D_PREFIX	0
-#define DD_PREFIX	1
-#define W_PREFIX	2
-#endif
+  #ifdef GNU_COMPATIBLE
+    #define NO_PREFIX (-1)
+    #define D_PREFIX 0
+    #define DD_PREFIX 1
+    #define W_PREFIX 2
+  #endif
 
-static int getopt_internal(int, char * const *, const char *,
-			   const struct option *, int *, int);
-static int parse_long_options(char * const *, const char *,
-			      const struct option *, int *, int, int);
+static int getopt_internal(int, char *const *, const char *,
+                           const struct option *, int *, int);
+static int parse_long_options(char *const *, const char *,
+                              const struct option *, int *, int, int);
 static int gcd(int, int);
-static void permute_args(int, int, int, char * const *);
+static void permute_args(int, int, int, char *const *);
 
 static char *place = EMSG; /* option letter processing */
 
@@ -1407,7 +1438,7 @@ static int nonopt_end = -1;   /* first option after non options (for permute) */
 /* Error messages */
 static const char recargchar[] = "option requires an argument -- %c";
 static const char illoptchar[] = "illegal option -- %c"; /* From P1003.2 */
-#ifdef GNU_COMPATIBLE
+  #ifdef GNU_COMPATIBLE
 static int dash_prefix = NO_PREFIX;
 static const char gnuoptchar[] = "invalid option -- %c";
 
@@ -1415,74 +1446,73 @@ static const char recargstring[] = "option `%s%s' requires an argument";
 static const char ambig[] = "option `%s%.*s' is ambiguous";
 static const char noarg[] = "option `%s%.*s' doesn't allow an argument";
 static const char illoptstring[] = "unrecognized option `%s%s'";
-#else
+  #else
 static const char recargstring[] = "option requires an argument -- %s";
 static const char ambig[] = "ambiguous option -- %.*s";
 static const char noarg[] = "option doesn't take an argument -- %.*s";
 static const char illoptstring[] = "unknown option -- %s";
-#endif
+  #endif
 
-#ifdef _WIN32
+  #ifdef _WIN32
 
-/*
- * Windows needs warnx().  We change the definition though:
- *  1. (another) global is defined, opterrmsg, which holds the error message
- *  2. errors are always printed out on stderr w/o the program name
- * Note that opterrmsg always gets set no matter what opterr is set to.  The
- * error message will not be printed if opterr is 0 as usual.
- */
+  /*
+   * Windows needs warnx().  We change the definition though:
+   *  1. (another) global is defined, opterrmsg, which holds the error message
+   *  2. errors are always printed out on stderr w/o the program name
+   * Note that opterrmsg always gets set no matter what opterr is set to.  The
+   * error message will not be printed if opterr is 0 as usual.
+   */
 
-#include <stdarg.h>
-#include <stdio.h>
+    #include <stdarg.h>
+    #include <stdio.h>
 
-#define MAX_OPTERRMSG_SIZE 128
+    #define MAX_OPTERRMSG_SIZE 128
 
 extern char opterrmsg[MAX_OPTERRMSG_SIZE];
 char opterrmsg[MAX_OPTERRMSG_SIZE]; /* buffer for the last error message */
 
-static void warnx(const char* fmt, ...) {
-    va_list ap;
-    va_start(ap, fmt);
+static void warnx(const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
 
-    /*
-     * Make sure opterrmsg is always zero-terminated despite the _vsnprintf()
-     * implementation specifics and manually suppress the warning.
-     */
-    memset(opterrmsg, 0, sizeof(opterrmsg));
-    if (fmt != NULL)
-#if (defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) || (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__))
-        _vsnprintf_s(opterrmsg, sizeof(opterrmsg), sizeof(opterrmsg) - 1, fmt, ap);
-#else
-        _vsnprintf(opterrmsg, sizeof(opterrmsg) - 1, fmt, ap);
-#endif
+  /*
+   * Make sure opterrmsg is always zero-terminated despite the _vsnprintf()
+   * implementation specifics and manually suppress the warning.
+   */
+  memset(opterrmsg, 0, sizeof(opterrmsg));
+  if (fmt != NULL)
+    #if (defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) ||     \
+        (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__))
+    _vsnprintf_s(opterrmsg, sizeof(opterrmsg), sizeof(opterrmsg) - 1, fmt, ap);
+    #else
+    _vsnprintf(opterrmsg, sizeof(opterrmsg) - 1, fmt, ap);
+    #endif
 
-    va_end(ap);
+  va_end(ap);
 
-#ifdef _MSC_VER
-#pragma warning(suppress : 6053)
-#endif
-    fprintf(stderr, "%s\n", opterrmsg);
+    #ifdef _MSC_VER
+      #pragma warning(suppress : 6053)
+    #endif
+  fprintf(stderr, "%s\n", opterrmsg);
 }
 
-#else
-#include <err.h>
-#endif /*_WIN32*/
+  #else
+    #include <err.h>
+  #endif /*_WIN32*/
 /*
  * Compute the greatest common divisor of a and b.
  */
-static int
-gcd(int a, int b)
-{
-	int c;
+static int gcd(int a, int b) {
+  int c;
 
-	c = a % b;
-	while (c != 0) {
-		a = b;
-		b = c;
-		c = a % b;
-	}
+  c = a % b;
+  while (c != 0) {
+    a = b;
+    b = c;
+    c = a % b;
+  }
 
-	return (b);
+  return (b);
 }
 
 /*
@@ -1490,36 +1520,34 @@ gcd(int a, int b)
  * from nonopt_end to opt_end (keeping the same order of arguments
  * in each block).
  */
-static void
-permute_args(int panonopt_start, int panonopt_end, int opt_end,
-	char * const *nargv)
-{
-	int cstart, cyclelen, i, j, ncycle, nnonopts, nopts, pos;
-	char *swap;
+static void permute_args(int panonopt_start, int panonopt_end, int opt_end,
+                         char *const *nargv) {
+  int cstart, cyclelen, i, j, ncycle, nnonopts, nopts, pos;
+  char *swap;
 
-	/*
-	 * compute lengths of blocks and number and size of cycles
-	 */
-	nnonopts = panonopt_end - panonopt_start;
-	nopts = opt_end - panonopt_end;
-	ncycle = gcd(nnonopts, nopts);
-	cyclelen = (opt_end - panonopt_start) / ncycle;
+  /*
+   * compute lengths of blocks and number and size of cycles
+   */
+  nnonopts = panonopt_end - panonopt_start;
+  nopts = opt_end - panonopt_end;
+  ncycle = gcd(nnonopts, nopts);
+  cyclelen = (opt_end - panonopt_start) / ncycle;
 
-	for (i = 0; i < ncycle; i++) {
-		cstart = panonopt_end+i;
-		pos = cstart;
-		for (j = 0; j < cyclelen; j++) {
-			if (pos >= panonopt_end)
-				pos -= nnonopts;
-			else
-				pos += nopts;
-			swap = nargv[pos];
-			/* LINTED const cast */
-			((char **) nargv)[pos] = nargv[cstart];
-			/* LINTED const cast */
-			((char **)nargv)[cstart] = swap;
-		}
-	}
+  for (i = 0; i < ncycle; i++) {
+    cstart = panonopt_end + i;
+    pos = cstart;
+    for (j = 0; j < cyclelen; j++) {
+      if (pos >= panonopt_end)
+        pos -= nnonopts;
+      else
+        pos += nopts;
+      swap = nargv[pos];
+      /* LINTED const cast */
+      ((char **)nargv)[pos] = nargv[cstart];
+      /* LINTED const cast */
+      ((char **)nargv)[cstart] = swap;
+    }
+  }
 }
 
 /*
@@ -1527,388 +1555,375 @@ permute_args(int panonopt_start, int panonopt_end, int opt_end,
  *	Parse long options in argc/argv argument vector.
  * Returns -1 if short_too is set and the option does not match long_options.
  */
-static int
-parse_long_options(char * const *nargv, const char *options,
-	const struct option *long_options, int *idx, int short_too, int flags)
-{
-	char *current_argv, *has_equal;
-#ifdef GNU_COMPATIBLE
-	char *current_dash;
-#endif
-	size_t current_argv_len;
-	int i, match, exact_match, second_partial_match;
+static int parse_long_options(char *const *nargv, const char *options,
+                              const struct option *long_options, int *idx,
+                              int short_too, int flags) {
+  char *current_argv, *has_equal;
+  #ifdef GNU_COMPATIBLE
+  char *current_dash;
+  #endif
+  size_t current_argv_len;
+  int i, match, exact_match, second_partial_match;
 
-	current_argv = place;
-#ifdef GNU_COMPATIBLE
-	switch (dash_prefix) {
-		case D_PREFIX:
-			current_dash = "-";
-			break;
-		case DD_PREFIX:
-			current_dash = "--";
-			break;
-		case W_PREFIX:
-			current_dash = "-W ";
-			break;
-		default:
-			current_dash = "";
-			break;
-	}
-#endif
-	match = -1;
-	exact_match = 0;
-	second_partial_match = 0;
+  current_argv = place;
+  #ifdef GNU_COMPATIBLE
+  switch (dash_prefix) {
+  case D_PREFIX:
+    current_dash = "-";
+    break;
+  case DD_PREFIX:
+    current_dash = "--";
+    break;
+  case W_PREFIX:
+    current_dash = "-W ";
+    break;
+  default:
+    current_dash = "";
+    break;
+  }
+  #endif
+  match = -1;
+  exact_match = 0;
+  second_partial_match = 0;
 
-	optind++;
+  optind++;
 
-	if ((has_equal = strchr(current_argv, '=')) != NULL) {
-		/* argument found (--option=arg) */
-		current_argv_len = (size_t)(has_equal - current_argv);
-		has_equal++;
-	} else
-		current_argv_len = strlen(current_argv);
+  if ((has_equal = strchr(current_argv, '=')) != NULL) {
+    /* argument found (--option=arg) */
+    current_argv_len = (size_t)(has_equal - current_argv);
+    has_equal++;
+  } else
+    current_argv_len = strlen(current_argv);
 
-	for (i = 0; long_options[i].name; i++) {
-		/* find matching long option */
-		if (strncmp(current_argv, long_options[i].name,
-		    current_argv_len))
-			continue;
+  for (i = 0; long_options[i].name; i++) {
+    /* find matching long option */
+    if (strncmp(current_argv, long_options[i].name, current_argv_len))
+      continue;
 
-		if (strlen(long_options[i].name) == current_argv_len) {
-			/* exact match */
-			match = i;
-			exact_match = 1;
-			break;
-		}
-		/*
-		 * If this is a known short option, don't allow
-		 * a partial match of a single character.
-		 */
-		if (short_too && current_argv_len == 1)
-			continue;
+    if (strlen(long_options[i].name) == current_argv_len) {
+      /* exact match */
+      match = i;
+      exact_match = 1;
+      break;
+    }
+    /*
+     * If this is a known short option, don't allow
+     * a partial match of a single character.
+     */
+    if (short_too && current_argv_len == 1)
+      continue;
 
-		if (match == -1)	/* first partial match */
-			match = i;
-		else if ((flags & FLAG_LONGONLY) ||
-			 long_options[i].has_arg !=
-			     long_options[match].has_arg ||
-			 long_options[i].flag != long_options[match].flag ||
-			 long_options[i].val != long_options[match].val)
-			second_partial_match = 1;
-	}
-	if (!exact_match && second_partial_match) {
-		/* ambiguous abbreviation */
-		if (PRINT_ERROR)
-			warnx(ambig,
-#ifdef GNU_COMPATIBLE
-			     current_dash,
-#endif
-			     (int)current_argv_len,
-			     current_argv);
-		optopt = 0;
-		return (BADCH);
-	}
-	if (match != -1) {		/* option found */
-		if (long_options[match].has_arg == no_argument
-		    && has_equal) {
-			if (PRINT_ERROR)
-				warnx(noarg,
-#ifdef GNU_COMPATIBLE
-				     current_dash,
-#endif
-				     (int)current_argv_len,
-				     current_argv);
-			/*
-			 * XXX: GNU sets optopt to val regardless of flag
-			 */
-			if (long_options[match].flag == NULL)
-				optopt = long_options[match].val;
-			else
-				optopt = 0;
-#ifdef GNU_COMPATIBLE
-			return (BADCH);
-#else
-			return (BADARG);
-#endif
-		}
-		if (long_options[match].has_arg == required_argument ||
-		    long_options[match].has_arg == optional_argument) {
-			if (has_equal)
-				optarg = has_equal;
-			else if (long_options[match].has_arg ==
-			    required_argument) {
-				/*
-				 * optional argument doesn't use next nargv
-				 */
-				optarg = nargv[optind++];
-			}
-		}
-		if ((long_options[match].has_arg == required_argument)
-		    && (optarg == NULL)) {
-			/*
-			 * Missing argument; leading ':' indicates no error
-			 * should be generated.
-			 */
-			if (PRINT_ERROR)
-				warnx(recargstring,
-#ifdef GNU_COMPATIBLE
-				    current_dash,
-#endif
-				    current_argv);
-			/*
-			 * XXX: GNU sets optopt to val regardless of flag
-			 */
-			if (long_options[match].flag == NULL)
-				optopt = long_options[match].val;
-			else
-				optopt = 0;
-			--optind;
-			return (BADARG);
-		}
-	} else {			/* unknown option */
-		if (short_too) {
-			--optind;
-			return (-1);
-		}
-		if (PRINT_ERROR)
-			warnx(illoptstring,
-#ifdef GNU_COMPATIBLE
-			      current_dash,
-#endif
-			      current_argv);
-		optopt = 0;
-		return (BADCH);
-	}
-	if (idx)
-		*idx = match;
-	if (long_options[match].flag) {
-		*long_options[match].flag = long_options[match].val;
-		return (0);
-	} else
-		return (long_options[match].val);
+    if (match == -1) /* first partial match */
+      match = i;
+    else if ((flags & FLAG_LONGONLY) ||
+             long_options[i].has_arg != long_options[match].has_arg ||
+             long_options[i].flag != long_options[match].flag ||
+             long_options[i].val != long_options[match].val)
+      second_partial_match = 1;
+  }
+  if (!exact_match && second_partial_match) {
+    /* ambiguous abbreviation */
+    if (PRINT_ERROR)
+      warnx(ambig,
+  #ifdef GNU_COMPATIBLE
+            current_dash,
+  #endif
+            (int)current_argv_len, current_argv);
+    optopt = 0;
+    return (BADCH);
+  }
+  if (match != -1) { /* option found */
+    if (long_options[match].has_arg == no_argument && has_equal) {
+      if (PRINT_ERROR)
+        warnx(noarg,
+  #ifdef GNU_COMPATIBLE
+              current_dash,
+  #endif
+              (int)current_argv_len, current_argv);
+      /*
+       * XXX: GNU sets optopt to val regardless of flag
+       */
+      if (long_options[match].flag == NULL)
+        optopt = long_options[match].val;
+      else
+        optopt = 0;
+  #ifdef GNU_COMPATIBLE
+      return (BADCH);
+  #else
+      return (BADARG);
+  #endif
+    }
+    if (long_options[match].has_arg == required_argument ||
+        long_options[match].has_arg == optional_argument) {
+      if (has_equal)
+        optarg = has_equal;
+      else if (long_options[match].has_arg == required_argument) {
+        /*
+         * optional argument doesn't use next nargv
+         */
+        optarg = nargv[optind++];
+      }
+    }
+    if ((long_options[match].has_arg == required_argument) &&
+        (optarg == NULL)) {
+      /*
+       * Missing argument; leading ':' indicates no error
+       * should be generated.
+       */
+      if (PRINT_ERROR)
+        warnx(recargstring,
+  #ifdef GNU_COMPATIBLE
+              current_dash,
+  #endif
+              current_argv);
+      /*
+       * XXX: GNU sets optopt to val regardless of flag
+       */
+      if (long_options[match].flag == NULL)
+        optopt = long_options[match].val;
+      else
+        optopt = 0;
+      --optind;
+      return (BADARG);
+    }
+  } else { /* unknown option */
+    if (short_too) {
+      --optind;
+      return (-1);
+    }
+    if (PRINT_ERROR)
+      warnx(illoptstring,
+  #ifdef GNU_COMPATIBLE
+            current_dash,
+  #endif
+            current_argv);
+    optopt = 0;
+    return (BADCH);
+  }
+  if (idx)
+    *idx = match;
+  if (long_options[match].flag) {
+    *long_options[match].flag = long_options[match].val;
+    return (0);
+  } else
+    return (long_options[match].val);
 }
 
 /*
  * getopt_internal --
  *	Parse argc/argv argument vector.  Called by user level routines.
  */
-static int
-getopt_internal(int nargc, char * const *nargv, const char *options,
-	const struct option *long_options, int *idx, int flags)
-{
-	char *oli;				/* option letter list index */
-	int optchar, short_too;
-	static int posixly_correct = -1;
+static int getopt_internal(int nargc, char *const *nargv, const char *options,
+                           const struct option *long_options, int *idx,
+                           int flags) {
+  char *oli; /* option letter list index */
+  int optchar, short_too;
+  static int posixly_correct = -1;
 
-	if (options == NULL)
-		return (-1);
+  if (options == NULL)
+    return (-1);
 
-	/*
-	 * XXX Some GNU programs (like cvs) set optind to 0 instead of
-	 * XXX using optreset.  Work around this braindamage.
-	 */
-	if (optind == 0)
-		optind = optreset = 1;
+  /*
+   * XXX Some GNU programs (like cvs) set optind to 0 instead of
+   * XXX using optreset.  Work around this braindamage.
+   */
+  if (optind == 0)
+    optind = optreset = 1;
 
-	/*
-	 * Disable GNU extensions if POSIXLY_CORRECT is set or options
-	 * string begins with a '+'.
-	 */
-	if (posixly_correct == -1 || optreset) {
-#if defined(_WIN32) && ((defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) || (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__)))
-		size_t requiredSize;
-		getenv_s(&requiredSize, NULL, 0, "POSIXLY_CORRECT");
-		posixly_correct = requiredSize != 0;
-#else
-		posixly_correct = (getenv("POSIXLY_CORRECT") != NULL);
-#endif
-	}
+  /*
+   * Disable GNU extensions if POSIXLY_CORRECT is set or options
+   * string begins with a '+'.
+   */
+  if (posixly_correct == -1 || optreset) {
+  #if defined(_WIN32) &&                                                       \
+      ((defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) ||      \
+       (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__)))
+    size_t requiredSize;
+    getenv_s(&requiredSize, NULL, 0, "POSIXLY_CORRECT");
+    posixly_correct = requiredSize != 0;
+  #else
+    posixly_correct = (getenv("POSIXLY_CORRECT") != NULL);
+  #endif
+  }
 
-	if (*options == '-')
-		flags |= FLAG_ALLARGS;
-	else if (posixly_correct || *options == '+')
-		flags &= ~FLAG_PERMUTE;
-	if (*options == '+' || *options == '-')
-		options++;
+  if (*options == '-')
+    flags |= FLAG_ALLARGS;
+  else if (posixly_correct || *options == '+')
+    flags &= ~FLAG_PERMUTE;
+  if (*options == '+' || *options == '-')
+    options++;
 
-	optarg = NULL;
-	if (optreset)
-		nonopt_start = nonopt_end = -1;
+  optarg = NULL;
+  if (optreset)
+    nonopt_start = nonopt_end = -1;
 start:
-	if (optreset || !*place) {		/* update scanning pointer */
-		optreset = 0;
-		if (optind >= nargc) {          /* end of argument vector */
-			place = EMSG;
-			if (nonopt_end != -1) {
-				/* do permutation, if we have to */
-				permute_args(nonopt_start, nonopt_end,
-				    optind, nargv);
-				optind -= nonopt_end - nonopt_start;
-			}
-			else if (nonopt_start != -1) {
-				/*
-				 * If we skipped non-options, set optind
-				 * to the first of them.
-				 */
-				optind = nonopt_start;
-			}
-			nonopt_start = nonopt_end = -1;
-			return (-1);
-		}
-		if (*(place = nargv[optind]) != '-' ||
-#ifdef GNU_COMPATIBLE
-		    place[1] == '\0') {
-#else
-		    (place[1] == '\0' && strchr(options, '-') == NULL)) {
-#endif
-			place = EMSG;		/* found non-option */
-			if (flags & FLAG_ALLARGS) {
-				/*
-				 * GNU extension:
-				 * return non-option as argument to option 1
-				 */
-				optarg = nargv[optind++];
-				return (INORDER);
-			}
-			if (!(flags & FLAG_PERMUTE)) {
-				/*
-				 * If no permutation wanted, stop parsing
-				 * at first non-option.
-				 */
-				return (-1);
-			}
-			/* do permutation */
-			if (nonopt_start == -1)
-				nonopt_start = optind;
-			else if (nonopt_end != -1) {
-				permute_args(nonopt_start, nonopt_end,
-				    optind, nargv);
-				nonopt_start = optind -
-				    (nonopt_end - nonopt_start);
-				nonopt_end = -1;
-			}
-			optind++;
-			/* process next argument */
-			goto start;
-		}
-		if (nonopt_start != -1 && nonopt_end == -1)
-			nonopt_end = optind;
+  if (optreset || !*place) { /* update scanning pointer */
+    optreset = 0;
+    if (optind >= nargc) { /* end of argument vector */
+      place = EMSG;
+      if (nonopt_end != -1) {
+        /* do permutation, if we have to */
+        permute_args(nonopt_start, nonopt_end, optind, nargv);
+        optind -= nonopt_end - nonopt_start;
+      } else if (nonopt_start != -1) {
+        /*
+         * If we skipped non-options, set optind
+         * to the first of them.
+         */
+        optind = nonopt_start;
+      }
+      nonopt_start = nonopt_end = -1;
+      return (-1);
+    }
+    if (*(place = nargv[optind]) != '-' ||
+  #ifdef GNU_COMPATIBLE
+        place[1] == '\0') {
+  #else
+        (place[1] == '\0' && strchr(options, '-') == NULL)) {
+  #endif
+      place = EMSG; /* found non-option */
+      if (flags & FLAG_ALLARGS) {
+        /*
+         * GNU extension:
+         * return non-option as argument to option 1
+         */
+        optarg = nargv[optind++];
+        return (INORDER);
+      }
+      if (!(flags & FLAG_PERMUTE)) {
+        /*
+         * If no permutation wanted, stop parsing
+         * at first non-option.
+         */
+        return (-1);
+      }
+      /* do permutation */
+      if (nonopt_start == -1)
+        nonopt_start = optind;
+      else if (nonopt_end != -1) {
+        permute_args(nonopt_start, nonopt_end, optind, nargv);
+        nonopt_start = optind - (nonopt_end - nonopt_start);
+        nonopt_end = -1;
+      }
+      optind++;
+      /* process next argument */
+      goto start;
+    }
+    if (nonopt_start != -1 && nonopt_end == -1)
+      nonopt_end = optind;
 
-		/*
-		 * If we have "-" do nothing, if "--" we are done.
-		 */
-		if (place[1] != '\0' && *++place == '-' && place[1] == '\0') {
-			optind++;
-			place = EMSG;
-			/*
-			 * We found an option (--), so if we skipped
-			 * non-options, we have to permute.
-			 */
-			if (nonopt_end != -1) {
-				permute_args(nonopt_start, nonopt_end,
-				    optind, nargv);
-				optind -= nonopt_end - nonopt_start;
-			}
-			nonopt_start = nonopt_end = -1;
-			return (-1);
-		}
-	}
+    /*
+     * If we have "-" do nothing, if "--" we are done.
+     */
+    if (place[1] != '\0' && *++place == '-' && place[1] == '\0') {
+      optind++;
+      place = EMSG;
+      /*
+       * We found an option (--), so if we skipped
+       * non-options, we have to permute.
+       */
+      if (nonopt_end != -1) {
+        permute_args(nonopt_start, nonopt_end, optind, nargv);
+        optind -= nonopt_end - nonopt_start;
+      }
+      nonopt_start = nonopt_end = -1;
+      return (-1);
+    }
+  }
 
-	/*
-	 * Check long options if:
-	 *  1) we were passed some
-	 *  2) the arg is not just "-"
-	 *  3) either the arg starts with -- we are getopt_long_only()
-	 */
-	if (long_options != NULL && place != nargv[optind] &&
-	    (*place == '-' || (flags & FLAG_LONGONLY))) {
-		short_too = 0;
-#ifdef GNU_COMPATIBLE
-		dash_prefix = D_PREFIX;
-#endif
-		if (*place == '-') {
-			place++;		/* --foo long option */
-			if (*place == '\0')
-				return (BADARG);	/* malformed option */
-#ifdef GNU_COMPATIBLE
-			dash_prefix = DD_PREFIX;
-#endif
-		} else if (*place != ':' && strchr(options, *place) != NULL)
-			short_too = 1;		/* could be short option too */
+  /*
+   * Check long options if:
+   *  1) we were passed some
+   *  2) the arg is not just "-"
+   *  3) either the arg starts with -- we are getopt_long_only()
+   */
+  if (long_options != NULL && place != nargv[optind] &&
+      (*place == '-' || (flags & FLAG_LONGONLY))) {
+    short_too = 0;
+  #ifdef GNU_COMPATIBLE
+    dash_prefix = D_PREFIX;
+  #endif
+    if (*place == '-') {
+      place++; /* --foo long option */
+      if (*place == '\0')
+        return (BADARG); /* malformed option */
+  #ifdef GNU_COMPATIBLE
+      dash_prefix = DD_PREFIX;
+  #endif
+    } else if (*place != ':' && strchr(options, *place) != NULL)
+      short_too = 1; /* could be short option too */
 
-		optchar = parse_long_options(nargv, options, long_options,
-		    idx, short_too, flags);
-		if (optchar != -1) {
-			place = EMSG;
-			return (optchar);
-		}
-	}
+    optchar =
+        parse_long_options(nargv, options, long_options, idx, short_too, flags);
+    if (optchar != -1) {
+      place = EMSG;
+      return (optchar);
+    }
+  }
 
-	if ((optchar = (int)*place++) == (int)':' ||
-	    (optchar == (int)'-' && *place != '\0') ||
-	    (oli = strchr(options, optchar)) == NULL) {
-		/*
-		 * If the user specified "-" and  '-' isn't listed in
-		 * options, return -1 (non-option) as per POSIX.
-		 * Otherwise, it is an unknown option character (or ':').
-		 */
-		if (optchar == (int)'-' && *place == '\0')
-			return (-1);
-		if (!*place)
-			++optind;
-#ifdef GNU_COMPATIBLE
-		if (PRINT_ERROR)
-			warnx(posixly_correct ? illoptchar : gnuoptchar,
-			      optchar);
-#else
-		if (PRINT_ERROR)
-			warnx(illoptchar, optchar);
-#endif
-		optopt = optchar;
-		return (BADCH);
-	}
-	if (long_options != NULL && optchar == 'W' && oli[1] == ';') {
-		/* -W long-option */
-		if (*place)			/* no space */
-			/* NOTHING */;
-		else if (++optind >= nargc) {	/* no arg */
-			place = EMSG;
-			if (PRINT_ERROR)
-				warnx(recargchar, optchar);
-			optopt = optchar;
-			return (BADARG);
-		} else				/* white space */
-			place = nargv[optind];
-#ifdef GNU_COMPATIBLE
-		dash_prefix = W_PREFIX;
-#endif
-		optchar = parse_long_options(nargv, options, long_options,
-		    idx, 0, flags);
-		place = EMSG;
-		return (optchar);
-	}
-	if (*++oli != ':') {			/* doesn't take argument */
-		if (!*place)
-			++optind;
-	} else {				/* takes (optional) argument */
-		optarg = NULL;
-		if (*place)			/* no white space */
-			optarg = place;
-		else if (oli[1] != ':') {	/* arg not optional */
-			if (++optind >= nargc) {	/* no arg */
-				place = EMSG;
-				if (PRINT_ERROR)
-					warnx(recargchar, optchar);
-				optopt = optchar;
-				return (BADARG);
-			} else
-				optarg = nargv[optind];
-		}
-		place = EMSG;
-		++optind;
-	}
-	/* dump back option letter */
-	return (optchar);
+  if ((optchar = (int)*place++) == (int)':' ||
+      (optchar == (int)'-' && *place != '\0') ||
+      (oli = strchr(options, optchar)) == NULL) {
+    /*
+     * If the user specified "-" and  '-' isn't listed in
+     * options, return -1 (non-option) as per POSIX.
+     * Otherwise, it is an unknown option character (or ':').
+     */
+    if (optchar == (int)'-' && *place == '\0')
+      return (-1);
+    if (!*place)
+      ++optind;
+  #ifdef GNU_COMPATIBLE
+    if (PRINT_ERROR)
+      warnx(posixly_correct ? illoptchar : gnuoptchar, optchar);
+  #else
+    if (PRINT_ERROR)
+      warnx(illoptchar, optchar);
+  #endif
+    optopt = optchar;
+    return (BADCH);
+  }
+  if (long_options != NULL && optchar == 'W' && oli[1] == ';') {
+    /* -W long-option */
+    if (*place) /* no space */
+      /* NOTHING */;
+    else if (++optind >= nargc) { /* no arg */
+      place = EMSG;
+      if (PRINT_ERROR)
+        warnx(recargchar, optchar);
+      optopt = optchar;
+      return (BADARG);
+    } else /* white space */
+      place = nargv[optind];
+  #ifdef GNU_COMPATIBLE
+    dash_prefix = W_PREFIX;
+  #endif
+    optchar = parse_long_options(nargv, options, long_options, idx, 0, flags);
+    place = EMSG;
+    return (optchar);
+  }
+  if (*++oli != ':') { /* doesn't take argument */
+    if (!*place)
+      ++optind;
+  } else { /* takes (optional) argument */
+    optarg = NULL;
+    if (*place) /* no white space */
+      optarg = place;
+    else if (oli[1] != ':') {  /* arg not optional */
+      if (++optind >= nargc) { /* no arg */
+        place = EMSG;
+        if (PRINT_ERROR)
+          warnx(recargchar, optchar);
+        optopt = optchar;
+        return (BADARG);
+      } else
+        optarg = nargv[optind];
+    }
+    place = EMSG;
+    ++optind;
+  }
+  /* dump back option letter */
+  return (optchar);
 }
 
 /*
@@ -1917,45 +1932,39 @@ start:
  *
  * [eventually this will replace the BSD getopt]
  */
-int
-getopt(int nargc, char * const *nargv, const char *options)
-{
+int getopt(int nargc, char *const *nargv, const char *options) {
 
-	/*
-	 * We don't pass FLAG_PERMUTE to getopt_internal() since
-	 * the BSD getopt(3) (unlike GNU) has never done this.
-	 *
-	 * Furthermore, since many privileged programs call getopt()
-	 * before dropping privileges it makes sense to keep things
-	 * as simple (and bug-free) as possible.
-	 */
-	return (getopt_internal(nargc, nargv, options, NULL, NULL, 0));
+  /*
+   * We don't pass FLAG_PERMUTE to getopt_internal() since
+   * the BSD getopt(3) (unlike GNU) has never done this.
+   *
+   * Furthermore, since many privileged programs call getopt()
+   * before dropping privileges it makes sense to keep things
+   * as simple (and bug-free) as possible.
+   */
+  return (getopt_internal(nargc, nargv, options, NULL, NULL, 0));
 }
 
 /*
  * getopt_long --
  *	Parse argc/argv argument vector.
  */
-int
-getopt_long(int nargc, char * const *nargv, const char *options,
-	const struct option *long_options, int *idx)
-{
+int getopt_long(int nargc, char *const *nargv, const char *options,
+                const struct option *long_options, int *idx) {
 
-	return (getopt_internal(nargc, nargv, options, long_options, idx,
-	    FLAG_PERMUTE));
+  return (
+      getopt_internal(nargc, nargv, options, long_options, idx, FLAG_PERMUTE));
 }
 
 /*
  * getopt_long_only --
  *	Parse argc/argv argument vector.
  */
-int
-getopt_long_only(int nargc, char * const *nargv, const char *options,
-	const struct option *long_options, int *idx)
-{
+int getopt_long_only(int nargc, char *const *nargv, const char *options,
+                     const struct option *long_options, int *idx) {
 
-	return (getopt_internal(nargc, nargv, options, long_options, idx,
-	    FLAG_PERMUTE|FLAG_LONGONLY));
+  return (getopt_internal(nargc, nargv, options, long_options, idx,
+                          FLAG_PERMUTE | FLAG_LONGONLY));
 }
 
 #endif /* ARG_REPLACE_GETOPT == 1 */
@@ -1994,134 +2003,143 @@ getopt_long_only(int nargc, char * const *nargv, const char *options,
 #include "argtable3.h"
 
 #ifndef ARG_AMALGAMATION
-#include "argtable3_private.h"
+  #include "argtable3_private.h"
 #endif
 
 #include <stdlib.h>
 #include <string.h>
 
-char* arg_strptime(const char* buf, const char* fmt, struct tm* tm);
+char *arg_strptime(const char *buf, const char *fmt, struct tm *tm);
 
-static void arg_date_resetfn(struct arg_date* parent) {
-    ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
-    parent->count = 0;
+static void arg_date_resetfn(struct arg_date *parent) {
+  ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
+  parent->count = 0;
 }
 
-static int arg_date_scanfn(struct arg_date* parent, const char* argval) {
-    int errorcode = 0;
+static int arg_date_scanfn(struct arg_date *parent, const char *argval) {
+  int errorcode = 0;
 
-    if (parent->count == parent->hdr.maxcount) {
-        errorcode = ARG_ERR_MAXCOUNT;
-    } else if (!argval) {
-        /* no argument value was given, leave parent->tmval[] unaltered but still count it */
-        parent->count++;
-    } else {
-        const char* pend;
-        struct tm tm = parent->tmval[parent->count];
+  if (parent->count == parent->hdr.maxcount) {
+    errorcode = ARG_ERR_MAXCOUNT;
+  } else if (!argval) {
+    /* no argument value was given, leave parent->tmval[] unaltered but still
+     * count it */
+    parent->count++;
+  } else {
+    const char *pend;
+    struct tm tm = parent->tmval[parent->count];
 
-        /* parse the given argument value, store result in parent->tmval[] */
-        pend = arg_strptime(argval, parent->format, &tm);
-        if (pend && pend[0] == '\0')
-            parent->tmval[parent->count++] = tm;
-        else
-            errorcode = ARG_ERR_BADDATE;
-    }
+    /* parse the given argument value, store result in parent->tmval[] */
+    pend = arg_strptime(argval, parent->format, &tm);
+    if (pend && pend[0] == '\0')
+      parent->tmval[parent->count++] = tm;
+    else
+      errorcode = ARG_ERR_BADDATE;
+  }
 
-    ARG_TRACE(("%s:scanfn(%p) returns %d\n", __FILE__, parent, errorcode));
-    return errorcode;
+  ARG_TRACE(("%s:scanfn(%p) returns %d\n", __FILE__, parent, errorcode));
+  return errorcode;
 }
 
-static int arg_date_checkfn(struct arg_date* parent) {
-    int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
+static int arg_date_checkfn(struct arg_date *parent) {
+  int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
 
-    ARG_TRACE(("%s:checkfn(%p) returns %d\n", __FILE__, parent, errorcode));
-    return errorcode;
+  ARG_TRACE(("%s:checkfn(%p) returns %d\n", __FILE__, parent, errorcode));
+  return errorcode;
 }
 
-static void arg_date_errorfn(struct arg_date* parent, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
-    const char* shortopts = parent->hdr.shortopts;
-    const char* longopts = parent->hdr.longopts;
-    const char* datatype = parent->hdr.datatype;
+static void arg_date_errorfn(struct arg_date *parent, arg_dstr_t ds,
+                             int errorcode, const char *argval,
+                             const char *progname) {
+  const char *shortopts = parent->hdr.shortopts;
+  const char *longopts = parent->hdr.longopts;
+  const char *datatype = parent->hdr.datatype;
 
-    /* make argval NULL safe */
-    argval = argval ? argval : "";
+  /* make argval NULL safe */
+  argval = argval ? argval : "";
 
-    arg_dstr_catf(ds, "%s: ", progname);
-    switch (errorcode) {
-        case ARG_ERR_MINCOUNT:
-            arg_dstr_cat(ds, "missing option ");
-            arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
-            break;
+  arg_dstr_catf(ds, "%s: ", progname);
+  switch (errorcode) {
+  case ARG_ERR_MINCOUNT:
+    arg_dstr_cat(ds, "missing option ");
+    arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
+    break;
 
-        case ARG_ERR_MAXCOUNT:
-            arg_dstr_cat(ds, "excess option ");
-            arg_print_option_ds(ds, shortopts, longopts, argval, "\n");
-            break;
+  case ARG_ERR_MAXCOUNT:
+    arg_dstr_cat(ds, "excess option ");
+    arg_print_option_ds(ds, shortopts, longopts, argval, "\n");
+    break;
 
-        case ARG_ERR_BADDATE: {
-            struct tm tm;
-            char buff[200];
+  case ARG_ERR_BADDATE: {
+    struct tm tm;
+    char buff[200];
 
-            arg_dstr_catf(ds, "illegal timestamp format \"%s\"\n", argval);
-            memset(&tm, 0, sizeof(tm));
-            arg_strptime("1999-12-31 23:59:59", "%F %H:%M:%S", &tm);
-            strftime(buff, sizeof(buff), parent->format, &tm);
-            arg_dstr_catf(ds, "correct format is \"%s\"\n", buff);
-            break;
-        }
-    }
+    arg_dstr_catf(ds, "illegal timestamp format \"%s\"\n", argval);
+    memset(&tm, 0, sizeof(tm));
+    arg_strptime("1999-12-31 23:59:59", "%F %H:%M:%S", &tm);
+    strftime(buff, sizeof(buff), parent->format, &tm);
+    arg_dstr_catf(ds, "correct format is \"%s\"\n", buff);
+    break;
+  }
+  }
 }
 
-struct arg_date* arg_date0(const char* shortopts, const char* longopts, const char* format, const char* datatype, const char* glossary) {
-    return arg_daten(shortopts, longopts, format, datatype, 0, 1, glossary);
+struct arg_date *arg_date0(const char *shortopts, const char *longopts,
+                           const char *format, const char *datatype,
+                           const char *glossary) {
+  return arg_daten(shortopts, longopts, format, datatype, 0, 1, glossary);
 }
 
-struct arg_date* arg_date1(const char* shortopts, const char* longopts, const char* format, const char* datatype, const char* glossary) {
-    return arg_daten(shortopts, longopts, format, datatype, 1, 1, glossary);
+struct arg_date *arg_date1(const char *shortopts, const char *longopts,
+                           const char *format, const char *datatype,
+                           const char *glossary) {
+  return arg_daten(shortopts, longopts, format, datatype, 1, 1, glossary);
 }
 
-struct arg_date*
-arg_daten(const char* shortopts, const char* longopts, const char* format, const char* datatype, int mincount, int maxcount, const char* glossary) {
-    size_t nbytes;
-    struct arg_date* result;
+struct arg_date *arg_daten(const char *shortopts, const char *longopts,
+                           const char *format, const char *datatype,
+                           int mincount, int maxcount, const char *glossary) {
+  size_t nbytes;
+  struct arg_date *result;
 
-    /* foolproof things by ensuring maxcount is not less than mincount */
-    maxcount = (maxcount < mincount) ? mincount : maxcount;
+  /* foolproof things by ensuring maxcount is not less than mincount */
+  maxcount = (maxcount < mincount) ? mincount : maxcount;
 
-    /* default time format is the national date format for the locale */
-    if (!format)
-        format = "%x";
+  /* default time format is the national date format for the locale */
+  if (!format)
+    format = "%x";
 
-    nbytes = sizeof(struct arg_date)         /* storage for struct arg_date */
-             + (size_t)maxcount * sizeof(struct tm); /* storage for tmval[maxcount] array */
+  nbytes = sizeof(struct arg_date) /* storage for struct arg_date */
+           + (size_t)maxcount *
+                 sizeof(struct tm); /* storage for tmval[maxcount] array */
 
-    /* allocate storage for the arg_date struct + tmval[] array.    */
-    /* we use calloc because we want the tmval[] array zero filled. */
-    result = (struct arg_date*)xcalloc(1, nbytes);
+  /* allocate storage for the arg_date struct + tmval[] array.    */
+  /* we use calloc because we want the tmval[] array zero filled. */
+  result = (struct arg_date *)xcalloc(1, nbytes);
 
-    /* init the arg_hdr struct */
-    result->hdr.flag = ARG_HASVALUE;
-    result->hdr.shortopts = shortopts;
-    result->hdr.longopts = longopts;
-    result->hdr.datatype = datatype ? datatype : format;
-    result->hdr.glossary = glossary;
-    result->hdr.mincount = mincount;
-    result->hdr.maxcount = maxcount;
-    result->hdr.parent = result;
-    result->hdr.resetfn = (arg_resetfn*)arg_date_resetfn;
-    result->hdr.scanfn = (arg_scanfn*)arg_date_scanfn;
-    result->hdr.checkfn = (arg_checkfn*)arg_date_checkfn;
-    result->hdr.errorfn = (arg_errorfn*)arg_date_errorfn;
+  /* init the arg_hdr struct */
+  result->hdr.flag = ARG_HASVALUE;
+  result->hdr.shortopts = shortopts;
+  result->hdr.longopts = longopts;
+  result->hdr.datatype = datatype ? datatype : format;
+  result->hdr.glossary = glossary;
+  result->hdr.mincount = mincount;
+  result->hdr.maxcount = maxcount;
+  result->hdr.parent = result;
+  result->hdr.resetfn = (arg_resetfn *)arg_date_resetfn;
+  result->hdr.scanfn = (arg_scanfn *)arg_date_scanfn;
+  result->hdr.checkfn = (arg_checkfn *)arg_date_checkfn;
+  result->hdr.errorfn = (arg_errorfn *)arg_date_errorfn;
 
-    /* store the tmval[maxcount] array immediately after the arg_date struct */
-    result->tmval = (struct tm*)(result + 1);
+  /* store the tmval[maxcount] array immediately after the arg_date struct */
+  result->tmval = (struct tm *)(result + 1);
 
-    /* init the remaining arg_date member variables */
-    result->count = 0;
-    result->format = format;
+  /* init the remaining arg_date member variables */
+  result->count = 0;
+  result->format = format;
 
-    ARG_TRACE(("arg_daten() returns %p\n", result));
-    return result;
+  ARG_TRACE(("arg_daten() returns %p\n", result));
+  return result;
 }
 
 /*-
@@ -2163,371 +2181,374 @@ arg_daten(const char* shortopts, const char* longopts, const char* format, const
  */
 #define ALT_E 0x01
 #define ALT_O 0x02
-#define LEGAL_ALT(x)           \
-    {                          \
-        if (alt_format & ~(x)) \
-            return (0);        \
-    }
+#define LEGAL_ALT(x)                                                           \
+  {                                                                            \
+    if (alt_format & ~(x))                                                     \
+      return (0);                                                              \
+  }
 #define TM_YEAR_BASE (1900)
 
-static int conv_num(const char**, int*, int, int);
+static int conv_num(const char **, int *, int, int);
 
-static const char* day[7] = {"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"};
+static const char *day[7] = {"Sunday",   "Monday", "Tuesday", "Wednesday",
+                             "Thursday", "Friday", "Saturday"};
 
-static const char* abday[7] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
+static const char *abday[7] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
 
-static const char* mon[12] = {"January", "February", "March",     "April",   "May",      "June",
-                              "July",    "August",   "September", "October", "November", "December"};
+static const char *mon[12] = {"January",   "February", "March",    "April",
+                              "May",       "June",     "July",     "August",
+                              "September", "October",  "November", "December"};
 
-static const char* abmon[12] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+static const char *abmon[12] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                                "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
 
-static const char* am_pm[2] = {"AM", "PM"};
+static const char *am_pm[2] = {"AM", "PM"};
 
-static int arg_strcasecmp(const char* s1, const char* s2) {
-    const unsigned char* us1 = (const unsigned char*)s1;
-    const unsigned char* us2 = (const unsigned char*)s2;
-    while (tolower(*us1) == tolower(*us2++))
-        if (*us1++ == '\0')
-            return 0;
+static int arg_strcasecmp(const char *s1, const char *s2) {
+  const unsigned char *us1 = (const unsigned char *)s1;
+  const unsigned char *us2 = (const unsigned char *)s2;
+  while (tolower(*us1) == tolower(*us2++))
+    if (*us1++ == '\0')
+      return 0;
 
-    return tolower(*us1) - tolower(*--us2);
+  return tolower(*us1) - tolower(*--us2);
 }
 
-static int arg_strncasecmp(const char* s1, const char* s2, size_t n) {
-    if (n != 0) {
-        const unsigned char* us1 = (const unsigned char*)s1;
-        const unsigned char* us2 = (const unsigned char*)s2;
-        do {
-            if (tolower(*us1) != tolower(*us2++))
-                return tolower(*us1) - tolower(*--us2);
-
-            if (*us1++ == '\0')
-                break;
-        } while (--n != 0);
-    }
-
-    return 0;
-}
-
-char* arg_strptime(const char* buf, const char* fmt, struct tm* tm) {
-    char c;
-    const char* bp;
-    size_t len = 0;
-    int alt_format, i, split_year = 0;
-
-    bp = buf;
-
-    while ((c = *fmt) != '\0') {
-        /* Clear `alternate' modifier prior to new conversion. */
-        alt_format = 0;
-
-        /* Eat up white-space. */
-        if (isspace(c)) {
-            while (isspace((int)(*bp)))
-                bp++;
-
-            fmt++;
-            continue;
-        }
-
-        if ((c = *fmt++) != '%')
-            goto literal;
-
-    again:
-        switch (c = *fmt++) {
-            case '%': /* "%%" is converted to "%". */
-            literal:
-                if (c != *bp++)
-                    return (0);
-                break;
-
-            /*
-             * "Alternative" modifiers. Just set the appropriate flag
-             * and start over again.
-             */
-            case 'E': /* "%E?" alternative conversion modifier. */
-                LEGAL_ALT(0);
-                alt_format |= ALT_E;
-                goto again;
-
-            case 'O': /* "%O?" alternative conversion modifier. */
-                LEGAL_ALT(0);
-                alt_format |= ALT_O;
-                goto again;
-
-            /*
-             * "Complex" conversion rules, implemented through recursion.
-             */
-            case 'c': /* Date and time, using the locale's format. */
-                LEGAL_ALT(ALT_E);
-                bp = arg_strptime(bp, "%x %X", tm);
-                if (!bp)
-                    return (0);
-                break;
-
-            case 'D': /* The date as "%m/%d/%y". */
-                LEGAL_ALT(0);
-                bp = arg_strptime(bp, "%m/%d/%y", tm);
-                if (!bp)
-                    return (0);
-                break;
-
-            case 'R': /* The time as "%H:%M". */
-                LEGAL_ALT(0);
-                bp = arg_strptime(bp, "%H:%M", tm);
-                if (!bp)
-                    return (0);
-                break;
-
-            case 'r': /* The time in 12-hour clock representation. */
-                LEGAL_ALT(0);
-                bp = arg_strptime(bp, "%I:%M:%S %p", tm);
-                if (!bp)
-                    return (0);
-                break;
-
-            case 'T': /* The time as "%H:%M:%S". */
-                LEGAL_ALT(0);
-                bp = arg_strptime(bp, "%H:%M:%S", tm);
-                if (!bp)
-                    return (0);
-                break;
-
-            case 'X': /* The time, using the locale's format. */
-                LEGAL_ALT(ALT_E);
-                bp = arg_strptime(bp, "%H:%M:%S", tm);
-                if (!bp)
-                    return (0);
-                break;
-
-            case 'x': /* The date, using the locale's format. */
-                LEGAL_ALT(ALT_E);
-                bp = arg_strptime(bp, "%m/%d/%y", tm);
-                if (!bp)
-                    return (0);
-                break;
-
-            /*
-             * "Elementary" conversion rules.
-             */
-            case 'A': /* The day of week, using the locale's form. */
-            case 'a':
-                LEGAL_ALT(0);
-                for (i = 0; i < 7; i++) {
-                    /* Full name. */
-                    len = strlen(day[i]);
-                    if (arg_strncasecmp(day[i], bp, len) == 0)
-                        break;
-
-                    /* Abbreviated name. */
-                    len = strlen(abday[i]);
-                    if (arg_strncasecmp(abday[i], bp, len) == 0)
-                        break;
-                }
-
-                /* Nothing matched. */
-                if (i == 7)
-                    return (0);
-
-                tm->tm_wday = i;
-                bp += len;
-                break;
-
-            case 'B': /* The month, using the locale's form. */
-            case 'b':
-            case 'h':
-                LEGAL_ALT(0);
-                for (i = 0; i < 12; i++) {
-                    /* Full name. */
-                    len = strlen(mon[i]);
-                    if (arg_strncasecmp(mon[i], bp, len) == 0)
-                        break;
-
-                    /* Abbreviated name. */
-                    len = strlen(abmon[i]);
-                    if (arg_strncasecmp(abmon[i], bp, len) == 0)
-                        break;
-                }
-
-                /* Nothing matched. */
-                if (i == 12)
-                    return (0);
-
-                tm->tm_mon = i;
-                bp += len;
-                break;
-
-            case 'C': /* The century number. */
-                LEGAL_ALT(ALT_E);
-                if (!(conv_num(&bp, &i, 0, 99)))
-                    return (0);
-
-                if (split_year) {
-                    tm->tm_year = (tm->tm_year % 100) + (i * 100);
-                } else {
-                    tm->tm_year = i * 100;
-                    split_year = 1;
-                }
-                break;
-
-            case 'd': /* The day of month. */
-            case 'e':
-                LEGAL_ALT(ALT_O);
-                if (!(conv_num(&bp, &tm->tm_mday, 1, 31)))
-                    return (0);
-                break;
-
-            case 'k': /* The hour (24-hour clock representation). */
-                LEGAL_ALT(0);
-            /* FALLTHROUGH */
-            case 'H':
-                LEGAL_ALT(ALT_O);
-                if (!(conv_num(&bp, &tm->tm_hour, 0, 23)))
-                    return (0);
-                break;
-
-            case 'l': /* The hour (12-hour clock representation). */
-                LEGAL_ALT(0);
-            /* FALLTHROUGH */
-            case 'I':
-                LEGAL_ALT(ALT_O);
-                if (!(conv_num(&bp, &tm->tm_hour, 1, 12)))
-                    return (0);
-                if (tm->tm_hour == 12)
-                    tm->tm_hour = 0;
-                break;
-
-            case 'j': /* The day of year. */
-                LEGAL_ALT(0);
-                if (!(conv_num(&bp, &i, 1, 366)))
-                    return (0);
-                tm->tm_yday = i - 1;
-                break;
-
-            case 'M': /* The minute. */
-                LEGAL_ALT(ALT_O);
-                if (!(conv_num(&bp, &tm->tm_min, 0, 59)))
-                    return (0);
-                break;
-
-            case 'm': /* The month. */
-                LEGAL_ALT(ALT_O);
-                if (!(conv_num(&bp, &i, 1, 12)))
-                    return (0);
-                tm->tm_mon = i - 1;
-                break;
-
-            case 'p': /* The locale's equivalent of AM/PM. */
-                LEGAL_ALT(0);
-                /* AM? */
-                if (arg_strcasecmp(am_pm[0], bp) == 0) {
-                    if (tm->tm_hour > 11)
-                        return (0);
-
-                    bp += strlen(am_pm[0]);
-                    break;
-                }
-                /* PM? */
-                else if (arg_strcasecmp(am_pm[1], bp) == 0) {
-                    if (tm->tm_hour > 11)
-                        return (0);
-
-                    tm->tm_hour += 12;
-                    bp += strlen(am_pm[1]);
-                    break;
-                }
-
-                /* Nothing matched. */
-                return (0);
-
-            case 'S': /* The seconds. */
-                LEGAL_ALT(ALT_O);
-                if (!(conv_num(&bp, &tm->tm_sec, 0, 61)))
-                    return (0);
-                break;
-
-            case 'U': /* The week of year, beginning on sunday. */
-            case 'W': /* The week of year, beginning on monday. */
-                LEGAL_ALT(ALT_O);
-                /*
-                 * XXX This is bogus, as we can not assume any valid
-                 * information present in the tm structure at this
-                 * point to calculate a real value, so just check the
-                 * range for now.
-                 */
-                if (!(conv_num(&bp, &i, 0, 53)))
-                    return (0);
-                break;
-
-            case 'w': /* The day of week, beginning on sunday. */
-                LEGAL_ALT(ALT_O);
-                if (!(conv_num(&bp, &tm->tm_wday, 0, 6)))
-                    return (0);
-                break;
-
-            case 'Y': /* The year. */
-                LEGAL_ALT(ALT_E);
-                if (!(conv_num(&bp, &i, 0, 9999)))
-                    return (0);
-
-                tm->tm_year = i - TM_YEAR_BASE;
-                break;
-
-            case 'y': /* The year within 100 years of the epoch. */
-                LEGAL_ALT(ALT_E | ALT_O);
-                if (!(conv_num(&bp, &i, 0, 99)))
-                    return (0);
-
-                if (split_year) {
-                    tm->tm_year = ((tm->tm_year / 100) * 100) + i;
-                    break;
-                }
-                split_year = 1;
-                if (i <= 68)
-                    tm->tm_year = i + 2000 - TM_YEAR_BASE;
-                else
-                    tm->tm_year = i + 1900 - TM_YEAR_BASE;
-                break;
-
-            /*
-             * Miscellaneous conversions.
-             */
-            case 'n': /* Any kind of white-space. */
-            case 't':
-                LEGAL_ALT(0);
-                while (isspace((int)(*bp)))
-                    bp++;
-                break;
-
-            default: /* Unknown/unsupported conversion. */
-                return (0);
-        }
-    }
-
-    /* LINTED functional specification */
-    return ((char*)bp);
-}
-
-static int conv_num(const char** buf, int* dest, int llim, int ulim) {
-    int result = 0;
-
-    /* The limit also determines the number of valid digits. */
-    int rulim = ulim;
-
-    if (**buf < '0' || **buf > '9')
-        return (0);
-
+static int arg_strncasecmp(const char *s1, const char *s2, size_t n) {
+  if (n != 0) {
+    const unsigned char *us1 = (const unsigned char *)s1;
+    const unsigned char *us2 = (const unsigned char *)s2;
     do {
-        result *= 10;
-        result += *(*buf)++ - '0';
-        rulim /= 10;
-    } while ((result * 10 <= ulim) && rulim && **buf >= '0' && **buf <= '9');
+      if (tolower(*us1) != tolower(*us2++))
+        return tolower(*us1) - tolower(*--us2);
 
-    if (result < llim || result > ulim)
+      if (*us1++ == '\0')
+        break;
+    } while (--n != 0);
+  }
+
+  return 0;
+}
+
+char *arg_strptime(const char *buf, const char *fmt, struct tm *tm) {
+  char c;
+  const char *bp;
+  size_t len = 0;
+  int alt_format, i, split_year = 0;
+
+  bp = buf;
+
+  while ((c = *fmt) != '\0') {
+    /* Clear `alternate' modifier prior to new conversion. */
+    alt_format = 0;
+
+    /* Eat up white-space. */
+    if (isspace(c)) {
+      while (isspace((int)(*bp)))
+        bp++;
+
+      fmt++;
+      continue;
+    }
+
+    if ((c = *fmt++) != '%')
+      goto literal;
+
+  again:
+    switch (c = *fmt++) {
+    case '%': /* "%%" is converted to "%". */
+    literal:
+      if (c != *bp++)
+        return (0);
+      break;
+
+    /*
+     * "Alternative" modifiers. Just set the appropriate flag
+     * and start over again.
+     */
+    case 'E': /* "%E?" alternative conversion modifier. */
+      LEGAL_ALT(0);
+      alt_format |= ALT_E;
+      goto again;
+
+    case 'O': /* "%O?" alternative conversion modifier. */
+      LEGAL_ALT(0);
+      alt_format |= ALT_O;
+      goto again;
+
+    /*
+     * "Complex" conversion rules, implemented through recursion.
+     */
+    case 'c': /* Date and time, using the locale's format. */
+      LEGAL_ALT(ALT_E);
+      bp = arg_strptime(bp, "%x %X", tm);
+      if (!bp)
+        return (0);
+      break;
+
+    case 'D': /* The date as "%m/%d/%y". */
+      LEGAL_ALT(0);
+      bp = arg_strptime(bp, "%m/%d/%y", tm);
+      if (!bp)
+        return (0);
+      break;
+
+    case 'R': /* The time as "%H:%M". */
+      LEGAL_ALT(0);
+      bp = arg_strptime(bp, "%H:%M", tm);
+      if (!bp)
+        return (0);
+      break;
+
+    case 'r': /* The time in 12-hour clock representation. */
+      LEGAL_ALT(0);
+      bp = arg_strptime(bp, "%I:%M:%S %p", tm);
+      if (!bp)
+        return (0);
+      break;
+
+    case 'T': /* The time as "%H:%M:%S". */
+      LEGAL_ALT(0);
+      bp = arg_strptime(bp, "%H:%M:%S", tm);
+      if (!bp)
+        return (0);
+      break;
+
+    case 'X': /* The time, using the locale's format. */
+      LEGAL_ALT(ALT_E);
+      bp = arg_strptime(bp, "%H:%M:%S", tm);
+      if (!bp)
+        return (0);
+      break;
+
+    case 'x': /* The date, using the locale's format. */
+      LEGAL_ALT(ALT_E);
+      bp = arg_strptime(bp, "%m/%d/%y", tm);
+      if (!bp)
+        return (0);
+      break;
+
+    /*
+     * "Elementary" conversion rules.
+     */
+    case 'A': /* The day of week, using the locale's form. */
+    case 'a':
+      LEGAL_ALT(0);
+      for (i = 0; i < 7; i++) {
+        /* Full name. */
+        len = strlen(day[i]);
+        if (arg_strncasecmp(day[i], bp, len) == 0)
+          break;
+
+        /* Abbreviated name. */
+        len = strlen(abday[i]);
+        if (arg_strncasecmp(abday[i], bp, len) == 0)
+          break;
+      }
+
+      /* Nothing matched. */
+      if (i == 7)
         return (0);
 
-    *dest = result;
-    return (1);
+      tm->tm_wday = i;
+      bp += len;
+      break;
+
+    case 'B': /* The month, using the locale's form. */
+    case 'b':
+    case 'h':
+      LEGAL_ALT(0);
+      for (i = 0; i < 12; i++) {
+        /* Full name. */
+        len = strlen(mon[i]);
+        if (arg_strncasecmp(mon[i], bp, len) == 0)
+          break;
+
+        /* Abbreviated name. */
+        len = strlen(abmon[i]);
+        if (arg_strncasecmp(abmon[i], bp, len) == 0)
+          break;
+      }
+
+      /* Nothing matched. */
+      if (i == 12)
+        return (0);
+
+      tm->tm_mon = i;
+      bp += len;
+      break;
+
+    case 'C': /* The century number. */
+      LEGAL_ALT(ALT_E);
+      if (!(conv_num(&bp, &i, 0, 99)))
+        return (0);
+
+      if (split_year) {
+        tm->tm_year = (tm->tm_year % 100) + (i * 100);
+      } else {
+        tm->tm_year = i * 100;
+        split_year = 1;
+      }
+      break;
+
+    case 'd': /* The day of month. */
+    case 'e':
+      LEGAL_ALT(ALT_O);
+      if (!(conv_num(&bp, &tm->tm_mday, 1, 31)))
+        return (0);
+      break;
+
+    case 'k': /* The hour (24-hour clock representation). */
+      LEGAL_ALT(0);
+    /* FALLTHROUGH */
+    case 'H':
+      LEGAL_ALT(ALT_O);
+      if (!(conv_num(&bp, &tm->tm_hour, 0, 23)))
+        return (0);
+      break;
+
+    case 'l': /* The hour (12-hour clock representation). */
+      LEGAL_ALT(0);
+    /* FALLTHROUGH */
+    case 'I':
+      LEGAL_ALT(ALT_O);
+      if (!(conv_num(&bp, &tm->tm_hour, 1, 12)))
+        return (0);
+      if (tm->tm_hour == 12)
+        tm->tm_hour = 0;
+      break;
+
+    case 'j': /* The day of year. */
+      LEGAL_ALT(0);
+      if (!(conv_num(&bp, &i, 1, 366)))
+        return (0);
+      tm->tm_yday = i - 1;
+      break;
+
+    case 'M': /* The minute. */
+      LEGAL_ALT(ALT_O);
+      if (!(conv_num(&bp, &tm->tm_min, 0, 59)))
+        return (0);
+      break;
+
+    case 'm': /* The month. */
+      LEGAL_ALT(ALT_O);
+      if (!(conv_num(&bp, &i, 1, 12)))
+        return (0);
+      tm->tm_mon = i - 1;
+      break;
+
+    case 'p': /* The locale's equivalent of AM/PM. */
+      LEGAL_ALT(0);
+      /* AM? */
+      if (arg_strcasecmp(am_pm[0], bp) == 0) {
+        if (tm->tm_hour > 11)
+          return (0);
+
+        bp += strlen(am_pm[0]);
+        break;
+      }
+      /* PM? */
+      else if (arg_strcasecmp(am_pm[1], bp) == 0) {
+        if (tm->tm_hour > 11)
+          return (0);
+
+        tm->tm_hour += 12;
+        bp += strlen(am_pm[1]);
+        break;
+      }
+
+      /* Nothing matched. */
+      return (0);
+
+    case 'S': /* The seconds. */
+      LEGAL_ALT(ALT_O);
+      if (!(conv_num(&bp, &tm->tm_sec, 0, 61)))
+        return (0);
+      break;
+
+    case 'U': /* The week of year, beginning on sunday. */
+    case 'W': /* The week of year, beginning on monday. */
+      LEGAL_ALT(ALT_O);
+      /*
+       * XXX This is bogus, as we can not assume any valid
+       * information present in the tm structure at this
+       * point to calculate a real value, so just check the
+       * range for now.
+       */
+      if (!(conv_num(&bp, &i, 0, 53)))
+        return (0);
+      break;
+
+    case 'w': /* The day of week, beginning on sunday. */
+      LEGAL_ALT(ALT_O);
+      if (!(conv_num(&bp, &tm->tm_wday, 0, 6)))
+        return (0);
+      break;
+
+    case 'Y': /* The year. */
+      LEGAL_ALT(ALT_E);
+      if (!(conv_num(&bp, &i, 0, 9999)))
+        return (0);
+
+      tm->tm_year = i - TM_YEAR_BASE;
+      break;
+
+    case 'y': /* The year within 100 years of the epoch. */
+      LEGAL_ALT(ALT_E | ALT_O);
+      if (!(conv_num(&bp, &i, 0, 99)))
+        return (0);
+
+      if (split_year) {
+        tm->tm_year = ((tm->tm_year / 100) * 100) + i;
+        break;
+      }
+      split_year = 1;
+      if (i <= 68)
+        tm->tm_year = i + 2000 - TM_YEAR_BASE;
+      else
+        tm->tm_year = i + 1900 - TM_YEAR_BASE;
+      break;
+
+    /*
+     * Miscellaneous conversions.
+     */
+    case 'n': /* Any kind of white-space. */
+    case 't':
+      LEGAL_ALT(0);
+      while (isspace((int)(*bp)))
+        bp++;
+      break;
+
+    default: /* Unknown/unsupported conversion. */
+      return (0);
+    }
+  }
+
+  /* LINTED functional specification */
+  return ((char *)bp);
+}
+
+static int conv_num(const char **buf, int *dest, int llim, int ulim) {
+  int result = 0;
+
+  /* The limit also determines the number of valid digits. */
+  int rulim = ulim;
+
+  if (**buf < '0' || **buf > '9')
+    return (0);
+
+  do {
+    result *= 10;
+    result += *(*buf)++ - '0';
+    rulim /= 10;
+  } while ((result * 10 <= ulim) && rulim && **buf >= '0' && **buf <= '9');
+
+  if (result < llim || result > ulim)
+    return (0);
+
+  *dest = result;
+  return (1);
 }
 /*******************************************************************************
  * arg_dbl: Implements the double command-line option
@@ -2564,129 +2585,139 @@ static int conv_num(const char** buf, int* dest, int llim, int ulim) {
 #include "argtable3.h"
 
 #ifndef ARG_AMALGAMATION
-#include "argtable3_private.h"
+  #include "argtable3_private.h"
 #endif
 
 #include <stdlib.h>
 
-static void arg_dbl_resetfn(struct arg_dbl* parent) {
-    ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
-    parent->count = 0;
+static void arg_dbl_resetfn(struct arg_dbl *parent) {
+  ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
+  parent->count = 0;
 }
 
-static int arg_dbl_scanfn(struct arg_dbl* parent, const char* argval) {
-    int errorcode = 0;
+static int arg_dbl_scanfn(struct arg_dbl *parent, const char *argval) {
+  int errorcode = 0;
 
-    if (parent->count == parent->hdr.maxcount) {
-        /* maximum number of arguments exceeded */
-        errorcode = ARG_ERR_MAXCOUNT;
-    } else if (!argval) {
-        /* a valid argument with no argument value was given. */
-        /* This happens when an optional argument value was invoked. */
-        /* leave parent argument value unaltered but still count the argument. */
-        parent->count++;
-    } else {
-        double val;
-        char* end;
+  if (parent->count == parent->hdr.maxcount) {
+    /* maximum number of arguments exceeded */
+    errorcode = ARG_ERR_MAXCOUNT;
+  } else if (!argval) {
+    /* a valid argument with no argument value was given. */
+    /* This happens when an optional argument value was invoked. */
+    /* leave parent argument value unaltered but still count the argument. */
+    parent->count++;
+  } else {
+    double val;
+    char *end;
 
-        /* extract double from argval into val */
-        val = strtod(argval, &end);
+    /* extract double from argval into val */
+    val = strtod(argval, &end);
 
-        /* if success then store result in parent->dval[] array otherwise return error*/
-        if (*end == 0)
-            parent->dval[parent->count++] = val;
-        else
-            errorcode = ARG_ERR_BADDOUBLE;
-    }
+    /* if success then store result in parent->dval[] array otherwise return
+     * error*/
+    if (*end == 0)
+      parent->dval[parent->count++] = val;
+    else
+      errorcode = ARG_ERR_BADDOUBLE;
+  }
 
-    ARG_TRACE(("%s:scanfn(%p) returns %d\n", __FILE__, parent, errorcode));
-    return errorcode;
+  ARG_TRACE(("%s:scanfn(%p) returns %d\n", __FILE__, parent, errorcode));
+  return errorcode;
 }
 
-static int arg_dbl_checkfn(struct arg_dbl* parent) {
-    int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
+static int arg_dbl_checkfn(struct arg_dbl *parent) {
+  int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
 
-    ARG_TRACE(("%s:checkfn(%p) returns %d\n", __FILE__, parent, errorcode));
-    return errorcode;
+  ARG_TRACE(("%s:checkfn(%p) returns %d\n", __FILE__, parent, errorcode));
+  return errorcode;
 }
 
-static void arg_dbl_errorfn(struct arg_dbl* parent, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
-    const char* shortopts = parent->hdr.shortopts;
-    const char* longopts = parent->hdr.longopts;
-    const char* datatype = parent->hdr.datatype;
+static void arg_dbl_errorfn(struct arg_dbl *parent, arg_dstr_t ds,
+                            int errorcode, const char *argval,
+                            const char *progname) {
+  const char *shortopts = parent->hdr.shortopts;
+  const char *longopts = parent->hdr.longopts;
+  const char *datatype = parent->hdr.datatype;
 
-    /* make argval NULL safe */
-    argval = argval ? argval : "";
+  /* make argval NULL safe */
+  argval = argval ? argval : "";
 
-    arg_dstr_catf(ds, "%s: ", progname);
-    switch (errorcode) {
-        case ARG_ERR_MINCOUNT:
-            arg_dstr_cat(ds, "missing option ");
-            arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
-            break;
+  arg_dstr_catf(ds, "%s: ", progname);
+  switch (errorcode) {
+  case ARG_ERR_MINCOUNT:
+    arg_dstr_cat(ds, "missing option ");
+    arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
+    break;
 
-        case ARG_ERR_MAXCOUNT:
-            arg_dstr_cat(ds, "excess option ");
-            arg_print_option_ds(ds, shortopts, longopts, argval, "\n");
-            break;
+  case ARG_ERR_MAXCOUNT:
+    arg_dstr_cat(ds, "excess option ");
+    arg_print_option_ds(ds, shortopts, longopts, argval, "\n");
+    break;
 
-        case ARG_ERR_BADDOUBLE:
-            arg_dstr_catf(ds, "invalid argument \"%s\" to option ", argval);
-            arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
-            break;
-    }
+  case ARG_ERR_BADDOUBLE:
+    arg_dstr_catf(ds, "invalid argument \"%s\" to option ", argval);
+    arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
+    break;
+  }
 }
 
-struct arg_dbl* arg_dbl0(const char* shortopts, const char* longopts, const char* datatype, const char* glossary) {
-    return arg_dbln(shortopts, longopts, datatype, 0, 1, glossary);
+struct arg_dbl *arg_dbl0(const char *shortopts, const char *longopts,
+                         const char *datatype, const char *glossary) {
+  return arg_dbln(shortopts, longopts, datatype, 0, 1, glossary);
 }
 
-struct arg_dbl* arg_dbl1(const char* shortopts, const char* longopts, const char* datatype, const char* glossary) {
-    return arg_dbln(shortopts, longopts, datatype, 1, 1, glossary);
+struct arg_dbl *arg_dbl1(const char *shortopts, const char *longopts,
+                         const char *datatype, const char *glossary) {
+  return arg_dbln(shortopts, longopts, datatype, 1, 1, glossary);
 }
 
-struct arg_dbl* arg_dbln(const char* shortopts, const char* longopts, const char* datatype, int mincount, int maxcount, const char* glossary) {
-    size_t nbytes;
-    struct arg_dbl* result;
-    size_t addr;
-    size_t rem;
+struct arg_dbl *arg_dbln(const char *shortopts, const char *longopts,
+                         const char *datatype, int mincount, int maxcount,
+                         const char *glossary) {
+  size_t nbytes;
+  struct arg_dbl *result;
+  size_t addr;
+  size_t rem;
 
-    /* foolproof things by ensuring maxcount is not less than mincount */
-    maxcount = (maxcount < mincount) ? mincount : maxcount;
+  /* foolproof things by ensuring maxcount is not less than mincount */
+  maxcount = (maxcount < mincount) ? mincount : maxcount;
 
-    nbytes = sizeof(struct arg_dbl)             /* storage for struct arg_dbl */
-             + (size_t)(maxcount + 1) * sizeof(double); /* storage for dval[maxcount] array plus one extra for padding to memory boundary */
+  nbytes = sizeof(struct arg_dbl) /* storage for struct arg_dbl */
+           + (size_t)(maxcount + 1) *
+                 sizeof(double); /* storage for dval[maxcount] array plus one
+                                    extra for padding to memory boundary */
 
-    result = (struct arg_dbl*)xmalloc(nbytes);
+  result = (struct arg_dbl *)xmalloc(nbytes);
 
-    /* init the arg_hdr struct */
-    result->hdr.flag = ARG_HASVALUE;
-    result->hdr.shortopts = shortopts;
-    result->hdr.longopts = longopts;
-    result->hdr.datatype = datatype ? datatype : "<double>";
-    result->hdr.glossary = glossary;
-    result->hdr.mincount = mincount;
-    result->hdr.maxcount = maxcount;
-    result->hdr.parent = result;
-    result->hdr.resetfn = (arg_resetfn*)arg_dbl_resetfn;
-    result->hdr.scanfn = (arg_scanfn*)arg_dbl_scanfn;
-    result->hdr.checkfn = (arg_checkfn*)arg_dbl_checkfn;
-    result->hdr.errorfn = (arg_errorfn*)arg_dbl_errorfn;
+  /* init the arg_hdr struct */
+  result->hdr.flag = ARG_HASVALUE;
+  result->hdr.shortopts = shortopts;
+  result->hdr.longopts = longopts;
+  result->hdr.datatype = datatype ? datatype : "<double>";
+  result->hdr.glossary = glossary;
+  result->hdr.mincount = mincount;
+  result->hdr.maxcount = maxcount;
+  result->hdr.parent = result;
+  result->hdr.resetfn = (arg_resetfn *)arg_dbl_resetfn;
+  result->hdr.scanfn = (arg_scanfn *)arg_dbl_scanfn;
+  result->hdr.checkfn = (arg_checkfn *)arg_dbl_checkfn;
+  result->hdr.errorfn = (arg_errorfn *)arg_dbl_errorfn;
 
-    /* Store the dval[maxcount] array on the first double boundary that
-     * immediately follows the arg_dbl struct. We do the memory alignment
-     * purely for SPARC and Motorola systems. They require floats and
-     * doubles to be aligned on natural boundaries.
-     */
-    addr = (size_t)(result + 1);
-    rem = addr % sizeof(double);
-    result->dval = (double*)(addr + sizeof(double) - rem);
-    ARG_TRACE(("addr=%p, dval=%p, sizeof(double)=%d rem=%d\n", addr, result->dval, (int)sizeof(double), (int)rem));
+  /* Store the dval[maxcount] array on the first double boundary that
+   * immediately follows the arg_dbl struct. We do the memory alignment
+   * purely for SPARC and Motorola systems. They require floats and
+   * doubles to be aligned on natural boundaries.
+   */
+  addr = (size_t)(result + 1);
+  rem = addr % sizeof(double);
+  result->dval = (double *)(addr + sizeof(double) - rem);
+  ARG_TRACE(("addr=%p, dval=%p, sizeof(double)=%d rem=%d\n", addr, result->dval,
+             (int)sizeof(double), (int)rem));
 
-    result->count = 0;
+  result->count = 0;
 
-    ARG_TRACE(("arg_dbln() returns %p\n", result));
-    return result;
+  ARG_TRACE(("arg_dbln() returns %p\n", result));
+  return result;
 }
 /*******************************************************************************
  * arg_end: Implements the error handling utilities
@@ -2723,100 +2754,107 @@ struct arg_dbl* arg_dbln(const char* shortopts, const char* longopts, const char
 #include "argtable3.h"
 
 #ifndef ARG_AMALGAMATION
-#include "argtable3_private.h"
+  #include "argtable3_private.h"
 #endif
 
 #include <stdlib.h>
 
-static void arg_end_resetfn(struct arg_end* parent) {
-    ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
-    parent->count = 0;
+static void arg_end_resetfn(struct arg_end *parent) {
+  ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
+  parent->count = 0;
 }
 
-static void arg_end_errorfn(void* parent, arg_dstr_t ds, int error, const char* argval, const char* progname) {
-    /* suppress unreferenced formal parameter warning */
-    (void)parent;
+static void arg_end_errorfn(void *parent, arg_dstr_t ds, int error,
+                            const char *argval, const char *progname) {
+  /* suppress unreferenced formal parameter warning */
+  (void)parent;
 
-    progname = progname ? progname : "";
-    argval = argval ? argval : "";
+  progname = progname ? progname : "";
+  argval = argval ? argval : "";
 
-    arg_dstr_catf(ds, "%s: ", progname);
-    switch (error) {
-        case ARG_ELIMIT:
-            arg_dstr_cat(ds, "too many errors to display");
-            break;
-        case ARG_EMALLOC:
-            arg_dstr_cat(ds, "insufficient memory");
-            break;
-        case ARG_ENOMATCH:
-            arg_dstr_catf(ds, "unexpected argument \"%s\"", argval);
-            break;
-        case ARG_EMISSARG:
-            arg_dstr_catf(ds, "option \"%s\" requires an argument", argval);
-            break;
-        case ARG_ELONGOPT:
-            arg_dstr_catf(ds, "invalid option \"%s\"", argval);
-            break;
-        default:
-            arg_dstr_catf(ds, "invalid option \"-%c\"", error);
-            break;
-    }
+  arg_dstr_catf(ds, "%s: ", progname);
+  switch (error) {
+  case ARG_ELIMIT:
+    arg_dstr_cat(ds, "too many errors to display");
+    break;
+  case ARG_EMALLOC:
+    arg_dstr_cat(ds, "insufficient memory");
+    break;
+  case ARG_ENOMATCH:
+    arg_dstr_catf(ds, "unexpected argument \"%s\"", argval);
+    break;
+  case ARG_EMISSARG:
+    arg_dstr_catf(ds, "option \"%s\" requires an argument", argval);
+    break;
+  case ARG_ELONGOPT:
+    arg_dstr_catf(ds, "invalid option \"%s\"", argval);
+    break;
+  default:
+    arg_dstr_catf(ds, "invalid option \"-%c\"", error);
+    break;
+  }
 
-    arg_dstr_cat(ds, "\n");
+  arg_dstr_cat(ds, "\n");
 }
 
-struct arg_end* arg_end(int maxcount) {
-    size_t nbytes;
-    struct arg_end* result;
+struct arg_end *arg_end(int maxcount) {
+  size_t nbytes;
+  struct arg_end *result;
 
-    nbytes = sizeof(struct arg_end) + (size_t)maxcount * sizeof(int) /* storage for int error[maxcount] array*/
-             + (size_t)maxcount * sizeof(void*)                      /* storage for void* parent[maxcount] array */
-             + (size_t)maxcount * sizeof(char*);                     /* storage for char* argval[maxcount] array */
+  nbytes =
+      sizeof(struct arg_end) +
+      (size_t)maxcount * sizeof(int) /* storage for int error[maxcount] array*/
+      + (size_t)maxcount *
+            sizeof(void *) /* storage for void* parent[maxcount] array */
+      + (size_t)maxcount *
+            sizeof(char *); /* storage for char* argval[maxcount] array */
 
-    result = (struct arg_end*)xmalloc(nbytes);
+  result = (struct arg_end *)xmalloc(nbytes);
 
-    /* init the arg_hdr struct */
-    result->hdr.flag = ARG_TERMINATOR;
-    result->hdr.shortopts = NULL;
-    result->hdr.longopts = NULL;
-    result->hdr.datatype = NULL;
-    result->hdr.glossary = NULL;
-    result->hdr.mincount = 1;
-    result->hdr.maxcount = maxcount;
-    result->hdr.parent = result;
-    result->hdr.resetfn = (arg_resetfn*)arg_end_resetfn;
-    result->hdr.scanfn = NULL;
-    result->hdr.checkfn = NULL;
-    result->hdr.errorfn = (arg_errorfn*)arg_end_errorfn;
+  /* init the arg_hdr struct */
+  result->hdr.flag = ARG_TERMINATOR;
+  result->hdr.shortopts = NULL;
+  result->hdr.longopts = NULL;
+  result->hdr.datatype = NULL;
+  result->hdr.glossary = NULL;
+  result->hdr.mincount = 1;
+  result->hdr.maxcount = maxcount;
+  result->hdr.parent = result;
+  result->hdr.resetfn = (arg_resetfn *)arg_end_resetfn;
+  result->hdr.scanfn = NULL;
+  result->hdr.checkfn = NULL;
+  result->hdr.errorfn = (arg_errorfn *)arg_end_errorfn;
 
-    /* store error[maxcount] array immediately after struct arg_end */
-    result->error = (int*)(result + 1);
+  /* store error[maxcount] array immediately after struct arg_end */
+  result->error = (int *)(result + 1);
 
-    /* store parent[maxcount] array immediately after error[] array */
-    result->parent = (void**)(result->error + maxcount);
+  /* store parent[maxcount] array immediately after error[] array */
+  result->parent = (void **)(result->error + maxcount);
 
-    /* store argval[maxcount] array immediately after parent[] array */
-    result->argval = (const char**)(result->parent + maxcount);
+  /* store argval[maxcount] array immediately after parent[] array */
+  result->argval = (const char **)(result->parent + maxcount);
 
-    ARG_TRACE(("arg_end(%d) returns %p\n", maxcount, result));
-    return result;
+  ARG_TRACE(("arg_end(%d) returns %p\n", maxcount, result));
+  return result;
 }
 
-void arg_print_errors_ds(arg_dstr_t ds, struct arg_end* end, const char* progname) {
-    int i;
-    ARG_TRACE(("arg_errors()\n"));
-    for (i = 0; i < end->count; i++) {
-        struct arg_hdr* errorparent = (struct arg_hdr*)(end->parent[i]);
-        if (errorparent->errorfn)
-            errorparent->errorfn(end->parent[i], ds, end->error[i], end->argval[i], progname);
-    }
+void arg_print_errors_ds(arg_dstr_t ds, struct arg_end *end,
+                         const char *progname) {
+  int i;
+  ARG_TRACE(("arg_errors()\n"));
+  for (i = 0; i < end->count; i++) {
+    struct arg_hdr *errorparent = (struct arg_hdr *)(end->parent[i]);
+    if (errorparent->errorfn)
+      errorparent->errorfn(end->parent[i], ds, end->error[i], end->argval[i],
+                           progname);
+  }
 }
 
-void arg_print_errors(FILE* fp, struct arg_end* end, const char* progname) {
-    arg_dstr_t ds = arg_dstr_create();
-    arg_print_errors_ds(ds, end, progname);
-    fputs(arg_dstr_cstr(ds), fp);
-    arg_dstr_destroy(ds);
+void arg_print_errors(FILE *fp, struct arg_end *end, const char *progname) {
+  arg_dstr_t ds = arg_dstr_create();
+  arg_print_errors_ds(ds, end, progname);
+  fputs(arg_dstr_cstr(ds), fp);
+  arg_dstr_destroy(ds);
 }
 /*******************************************************************************
  * arg_file: Implements the file command-line option
@@ -2853,178 +2891,194 @@ void arg_print_errors(FILE* fp, struct arg_end* end, const char* progname) {
 #include "argtable3.h"
 
 #ifndef ARG_AMALGAMATION
-#include "argtable3_private.h"
+  #include "argtable3_private.h"
 #endif
 
 #include <stdlib.h>
 #include <string.h>
 
 #ifdef WIN32
-#define FILESEPARATOR1 '\\'
-#define FILESEPARATOR2 '/'
+  #define FILESEPARATOR1 '\\'
+  #define FILESEPARATOR2 '/'
 #else
-#define FILESEPARATOR1 '/'
-#define FILESEPARATOR2 '/'
+  #define FILESEPARATOR1 '/'
+  #define FILESEPARATOR2 '/'
 #endif
 
-static void arg_file_resetfn(struct arg_file* parent) {
-    ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
-    parent->count = 0;
+static void arg_file_resetfn(struct arg_file *parent) {
+  ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
+  parent->count = 0;
 }
 
 /* Returns ptr to the base filename within *filename */
-static const char* arg_basename(const char* filename) {
-    const char *result = NULL, *result1, *result2;
+static const char *arg_basename(const char *filename) {
+  const char *result = NULL, *result1, *result2;
 
-    /* Find the last occurrence of eother file separator character. */
-    /* Two alternative file separator chars are supported as legal  */
-    /* file separators but not both together in the same filename.  */
-    result1 = (filename ? strrchr(filename, FILESEPARATOR1) : NULL);
-    result2 = (filename ? strrchr(filename, FILESEPARATOR2) : NULL);
+  /* Find the last occurrence of eother file separator character. */
+  /* Two alternative file separator chars are supported as legal  */
+  /* file separators but not both together in the same filename.  */
+  result1 = (filename ? strrchr(filename, FILESEPARATOR1) : NULL);
+  result2 = (filename ? strrchr(filename, FILESEPARATOR2) : NULL);
 
-    if (result2)
-        result = result2 + 1; /* using FILESEPARATOR2 (the alternative file separator) */
+  if (result2)
+    result =
+        result2 + 1; /* using FILESEPARATOR2 (the alternative file separator) */
 
-    if (result1)
-        result = result1 + 1; /* using FILESEPARATOR1 (the preferred file separator) */
+  if (result1)
+    result =
+        result1 + 1; /* using FILESEPARATOR1 (the preferred file separator) */
 
-    if (!result)
-        result = filename; /* neither file separator was found so basename is the whole filename */
+  if (!result)
+    result = filename; /* neither file separator was found so basename is the
+                          whole filename */
 
-    /* special cases of "." and ".." are not considered basenames */
-    if (result && (strcmp(".", result) == 0 || strcmp("..", result) == 0))
-        result = filename + strlen(filename);
+  /* special cases of "." and ".." are not considered basenames */
+  if (result && (strcmp(".", result) == 0 || strcmp("..", result) == 0))
+    result = filename + strlen(filename);
 
-    return result;
+  return result;
 }
 
 /* Returns ptr to the file extension within *basename */
-static const char* arg_extension(const char* basename) {
-    /* find the last occurrence of '.' in basename */
-    const char* result = (basename ? strrchr(basename, '.') : NULL);
+static const char *arg_extension(const char *basename) {
+  /* find the last occurrence of '.' in basename */
+  const char *result = (basename ? strrchr(basename, '.') : NULL);
 
-    /* if no '.' was found then return pointer to end of basename */
-    if (basename && !result)
-        result = basename + strlen(basename);
+  /* if no '.' was found then return pointer to end of basename */
+  if (basename && !result)
+    result = basename + strlen(basename);
 
-    /* special case: basenames with a single leading dot (eg ".foo") are not considered as true extensions */
-    if (basename && result == basename)
-        result = basename + strlen(basename);
+  /* special case: basenames with a single leading dot (eg ".foo") are not
+   * considered as true extensions */
+  if (basename && result == basename)
+    result = basename + strlen(basename);
 
-    /* special case: empty extensions (eg "foo.","foo..") are not considered as true extensions */
-    if (basename && result && strlen(result) == 1)
-        result = basename + strlen(basename);
+  /* special case: empty extensions (eg "foo.","foo..") are not considered as
+   * true extensions */
+  if (basename && result && strlen(result) == 1)
+    result = basename + strlen(basename);
 
-    return result;
+  return result;
 }
 
-static int arg_file_scanfn(struct arg_file* parent, const char* argval) {
-    int errorcode = 0;
+static int arg_file_scanfn(struct arg_file *parent, const char *argval) {
+  int errorcode = 0;
 
-    if (parent->count == parent->hdr.maxcount) {
-        /* maximum number of arguments exceeded */
-        errorcode = ARG_ERR_MAXCOUNT;
-    } else if (!argval) {
-        /* a valid argument with no argument value was given. */
-        /* This happens when an optional argument value was invoked. */
-        /* leave parent arguiment value unaltered but still count the argument. */
-        parent->count++;
-    } else {
-        parent->filename[parent->count] = argval;
-        parent->basename[parent->count] = arg_basename(argval);
-        parent->extension[parent->count] =
-                arg_extension(parent->basename[parent->count]); /* only seek extensions within the basename (not the file path)*/
-        parent->count++;
-    }
+  if (parent->count == parent->hdr.maxcount) {
+    /* maximum number of arguments exceeded */
+    errorcode = ARG_ERR_MAXCOUNT;
+  } else if (!argval) {
+    /* a valid argument with no argument value was given. */
+    /* This happens when an optional argument value was invoked. */
+    /* leave parent arguiment value unaltered but still count the argument. */
+    parent->count++;
+  } else {
+    parent->filename[parent->count] = argval;
+    parent->basename[parent->count] = arg_basename(argval);
+    parent->extension[parent->count] = arg_extension(
+        parent->basename[parent->count]); /* only seek extensions within the
+                                             basename (not the file path)*/
+    parent->count++;
+  }
 
-    ARG_TRACE(("%s4:scanfn(%p) returns %d\n", __FILE__, parent, errorcode));
-    return errorcode;
+  ARG_TRACE(("%s4:scanfn(%p) returns %d\n", __FILE__, parent, errorcode));
+  return errorcode;
 }
 
-static int arg_file_checkfn(struct arg_file* parent) {
-    int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
+static int arg_file_checkfn(struct arg_file *parent) {
+  int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
 
-    ARG_TRACE(("%s:checkfn(%p) returns %d\n", __FILE__, parent, errorcode));
-    return errorcode;
+  ARG_TRACE(("%s:checkfn(%p) returns %d\n", __FILE__, parent, errorcode));
+  return errorcode;
 }
 
-static void arg_file_errorfn(struct arg_file* parent, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
-    const char* shortopts = parent->hdr.shortopts;
-    const char* longopts = parent->hdr.longopts;
-    const char* datatype = parent->hdr.datatype;
+static void arg_file_errorfn(struct arg_file *parent, arg_dstr_t ds,
+                             int errorcode, const char *argval,
+                             const char *progname) {
+  const char *shortopts = parent->hdr.shortopts;
+  const char *longopts = parent->hdr.longopts;
+  const char *datatype = parent->hdr.datatype;
 
-    /* make argval NULL safe */
-    argval = argval ? argval : "";
+  /* make argval NULL safe */
+  argval = argval ? argval : "";
 
-    arg_dstr_catf(ds, "%s: ", progname);
-    switch (errorcode) {
-        case ARG_ERR_MINCOUNT:
-            arg_dstr_cat(ds, "missing option ");
-            arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
-            break;
+  arg_dstr_catf(ds, "%s: ", progname);
+  switch (errorcode) {
+  case ARG_ERR_MINCOUNT:
+    arg_dstr_cat(ds, "missing option ");
+    arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
+    break;
 
-        case ARG_ERR_MAXCOUNT:
-            arg_dstr_cat(ds, "excess option ");
-            arg_print_option_ds(ds, shortopts, longopts, argval, "\n");
-            break;
+  case ARG_ERR_MAXCOUNT:
+    arg_dstr_cat(ds, "excess option ");
+    arg_print_option_ds(ds, shortopts, longopts, argval, "\n");
+    break;
 
-        default:
-            arg_dstr_catf(ds, "unknown error at \"%s\"\n", argval);
-    }
+  default:
+    arg_dstr_catf(ds, "unknown error at \"%s\"\n", argval);
+  }
 }
 
-struct arg_file* arg_file0(const char* shortopts, const char* longopts, const char* datatype, const char* glossary) {
-    return arg_filen(shortopts, longopts, datatype, 0, 1, glossary);
+struct arg_file *arg_file0(const char *shortopts, const char *longopts,
+                           const char *datatype, const char *glossary) {
+  return arg_filen(shortopts, longopts, datatype, 0, 1, glossary);
 }
 
-struct arg_file* arg_file1(const char* shortopts, const char* longopts, const char* datatype, const char* glossary) {
-    return arg_filen(shortopts, longopts, datatype, 1, 1, glossary);
+struct arg_file *arg_file1(const char *shortopts, const char *longopts,
+                           const char *datatype, const char *glossary) {
+  return arg_filen(shortopts, longopts, datatype, 1, 1, glossary);
 }
 
-struct arg_file* arg_filen(const char* shortopts, const char* longopts, const char* datatype, int mincount, int maxcount, const char* glossary) {
-    size_t nbytes;
-    struct arg_file* result;
-    int i;
+struct arg_file *arg_filen(const char *shortopts, const char *longopts,
+                           const char *datatype, int mincount, int maxcount,
+                           const char *glossary) {
+  size_t nbytes;
+  struct arg_file *result;
+  int i;
 
-    /* foolproof things by ensuring maxcount is not less than mincount */
-    maxcount = (maxcount < mincount) ? mincount : maxcount;
+  /* foolproof things by ensuring maxcount is not less than mincount */
+  maxcount = (maxcount < mincount) ? mincount : maxcount;
 
-    nbytes = sizeof(struct arg_file)     /* storage for struct arg_file */
-             + sizeof(char*) * (size_t)maxcount  /* storage for filename[maxcount] array */
-             + sizeof(char*) * (size_t)maxcount  /* storage for basename[maxcount] array */
-             + sizeof(char*) * (size_t)maxcount; /* storage for extension[maxcount] array */
+  nbytes = sizeof(struct arg_file) /* storage for struct arg_file */
+           + sizeof(char *) *
+                 (size_t)maxcount /* storage for filename[maxcount] array */
+           + sizeof(char *) *
+                 (size_t)maxcount /* storage for basename[maxcount] array */
+           + sizeof(char *) *
+                 (size_t)maxcount; /* storage for extension[maxcount] array */
 
-    result = (struct arg_file*)xmalloc(nbytes);
+  result = (struct arg_file *)xmalloc(nbytes);
 
-    /* init the arg_hdr struct */
-    result->hdr.flag = ARG_HASVALUE;
-    result->hdr.shortopts = shortopts;
-    result->hdr.longopts = longopts;
-    result->hdr.glossary = glossary;
-    result->hdr.datatype = datatype ? datatype : "<file>";
-    result->hdr.mincount = mincount;
-    result->hdr.maxcount = maxcount;
-    result->hdr.parent = result;
-    result->hdr.resetfn = (arg_resetfn*)arg_file_resetfn;
-    result->hdr.scanfn = (arg_scanfn*)arg_file_scanfn;
-    result->hdr.checkfn = (arg_checkfn*)arg_file_checkfn;
-    result->hdr.errorfn = (arg_errorfn*)arg_file_errorfn;
+  /* init the arg_hdr struct */
+  result->hdr.flag = ARG_HASVALUE;
+  result->hdr.shortopts = shortopts;
+  result->hdr.longopts = longopts;
+  result->hdr.glossary = glossary;
+  result->hdr.datatype = datatype ? datatype : "<file>";
+  result->hdr.mincount = mincount;
+  result->hdr.maxcount = maxcount;
+  result->hdr.parent = result;
+  result->hdr.resetfn = (arg_resetfn *)arg_file_resetfn;
+  result->hdr.scanfn = (arg_scanfn *)arg_file_scanfn;
+  result->hdr.checkfn = (arg_checkfn *)arg_file_checkfn;
+  result->hdr.errorfn = (arg_errorfn *)arg_file_errorfn;
 
-    /* store the filename,basename,extension arrays immediately after the arg_file struct */
-    result->filename = (const char**)(result + 1);
-    result->basename = result->filename + maxcount;
-    result->extension = result->basename + maxcount;
-    result->count = 0;
+  /* store the filename,basename,extension arrays immediately after the arg_file
+   * struct */
+  result->filename = (const char **)(result + 1);
+  result->basename = result->filename + maxcount;
+  result->extension = result->basename + maxcount;
+  result->count = 0;
 
-    /* foolproof the string pointers by initialising them with empty strings */
-    for (i = 0; i < maxcount; i++) {
-        result->filename[i] = "";
-        result->basename[i] = "";
-        result->extension[i] = "";
-    }
+  /* foolproof the string pointers by initialising them with empty strings */
+  for (i = 0; i < maxcount; i++) {
+    result->filename[i] = "";
+    result->basename[i] = "";
+    result->extension[i] = "";
+  }
 
-    ARG_TRACE(("arg_filen() returns %p\n", result));
-    return result;
+  ARG_TRACE(("arg_filen() returns %p\n", result));
+  return result;
 }
 /*******************************************************************************
  * arg_int: Implements the int command-line option
@@ -3061,16 +3115,16 @@ struct arg_file* arg_filen(const char* shortopts, const char* longopts, const ch
 #include "argtable3.h"
 
 #ifndef ARG_AMALGAMATION
-#include "argtable3_private.h"
+  #include "argtable3_private.h"
 #endif
 
 #include <ctype.h>
 #include <limits.h>
 #include <stdlib.h>
 
-static void arg_int_resetfn(struct arg_int* parent) {
-    ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
-    parent->count = 0;
+static void arg_int_resetfn(struct arg_int *parent) {
+  ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
+  parent->count = 0;
 }
 
 /* strtol0x() is like strtol() except that the numeric string is    */
@@ -3083,237 +3137,250 @@ static void arg_int_resetfn(struct arg_int* parent) {
 /* eg: to parse oct str="+0o12324", specify X='O' and base=8.       */
 /* eg: to parse bin str="-0B01010", specify X='B' and base=2.       */
 /* Failure of conversion is indicated by result where *endptr==str. */
-static long int strtol0X(const char* str, const char** endptr, char X, int base) {
-    long int val;          /* stores result */
-    int s = 1;             /* sign is +1 or -1 */
-    const char* ptr = str; /* ptr to current position in str */
+static long int strtol0X(const char *str, const char **endptr, char X,
+                         int base) {
+  long int val;          /* stores result */
+  int s = 1;             /* sign is +1 or -1 */
+  const char *ptr = str; /* ptr to current position in str */
 
-    /* skip leading whitespace */
-    while (isspace((int)(*ptr)))
-        ptr++;
-    /* printf("1) %s\n",ptr); */
+  /* skip leading whitespace */
+  while (isspace((int)(*ptr)))
+    ptr++;
+  /* printf("1) %s\n",ptr); */
 
-    /* scan optional sign character */
-    switch (*ptr) {
-        case '+':
-            ptr++;
-            s = 1;
-            break;
-        case '-':
-            ptr++;
-            s = -1;
-            break;
-        default:
-            s = 1;
-            break;
-    }
-    /* printf("2) %s\n",ptr); */
+  /* scan optional sign character */
+  switch (*ptr) {
+  case '+':
+    ptr++;
+    s = 1;
+    break;
+  case '-':
+    ptr++;
+    s = -1;
+    break;
+  default:
+    s = 1;
+    break;
+  }
+  /* printf("2) %s\n",ptr); */
 
-    /* '0X' prefix */
-    if ((*ptr++) != '0') {
-        /* printf("failed to detect '0'\n"); */
-        *endptr = str;
-        return 0;
-    }
-    /* printf("3) %s\n",ptr); */
-    if (toupper(*ptr++) != toupper(X)) {
-        /* printf("failed to detect '%c'\n",X); */
-        *endptr = str;
-        return 0;
-    }
-    /* printf("4) %s\n",ptr); */
+  /* '0X' prefix */
+  if ((*ptr++) != '0') {
+    /* printf("failed to detect '0'\n"); */
+    *endptr = str;
+    return 0;
+  }
+  /* printf("3) %s\n",ptr); */
+  if (toupper(*ptr++) != toupper(X)) {
+    /* printf("failed to detect '%c'\n",X); */
+    *endptr = str;
+    return 0;
+  }
+  /* printf("4) %s\n",ptr); */
 
-    /* attempt conversion on remainder of string using strtol() */
-    val = strtol(ptr, (char**)endptr, base);
-    if (*endptr == ptr) {
-        /* conversion failed */
-        *endptr = str;
-        return 0;
-    }
+  /* attempt conversion on remainder of string using strtol() */
+  val = strtol(ptr, (char **)endptr, base);
+  if (*endptr == ptr) {
+    /* conversion failed */
+    *endptr = str;
+    return 0;
+  }
 
-    /* success */
-    return s * val;
+  /* success */
+  return s * val;
 }
 
 /* Returns 1 if str matches suffix (case insensitive).    */
 /* Str may contain trailing whitespace, but nothing else. */
-static int detectsuffix(const char* str, const char* suffix) {
-    /* scan pairwise through strings until mismatch detected */
-    while (toupper(*str) == toupper(*suffix)) {
-        /* printf("'%c' '%c'\n", *str, *suffix); */
+static int detectsuffix(const char *str, const char *suffix) {
+  /* scan pairwise through strings until mismatch detected */
+  while (toupper(*str) == toupper(*suffix)) {
+    /* printf("'%c' '%c'\n", *str, *suffix); */
 
-        /* return 1 (success) if match persists until the string terminator */
-        if (*str == '\0')
-            return 1;
+    /* return 1 (success) if match persists until the string terminator */
+    if (*str == '\0')
+      return 1;
 
-        /* next chars */
-        str++;
-        suffix++;
-    }
-    /* printf("'%c' '%c' mismatch\n", *str, *suffix); */
+    /* next chars */
+    str++;
+    suffix++;
+  }
+  /* printf("'%c' '%c' mismatch\n", *str, *suffix); */
 
-    /* return 0 (fail) if the matching did not consume the entire suffix */
-    if (*suffix != 0)
-        return 0; /* failed to consume entire suffix */
+  /* return 0 (fail) if the matching did not consume the entire suffix */
+  if (*suffix != 0)
+    return 0; /* failed to consume entire suffix */
 
-    /* skip any remaining whitespace in str */
-    while (isspace((int)(*str)))
-        str++;
+  /* skip any remaining whitespace in str */
+  while (isspace((int)(*str)))
+    str++;
 
-    /* return 1 (success) if we have reached end of str else return 0 (fail) */
-    return (*str == '\0') ? 1 : 0;
+  /* return 1 (success) if we have reached end of str else return 0 (fail) */
+  return (*str == '\0') ? 1 : 0;
 }
 
-static int arg_int_scanfn(struct arg_int* parent, const char* argval) {
-    int errorcode = 0;
+static int arg_int_scanfn(struct arg_int *parent, const char *argval) {
+  int errorcode = 0;
 
-    if (parent->count == parent->hdr.maxcount) {
-        /* maximum number of arguments exceeded */
-        errorcode = ARG_ERR_MAXCOUNT;
-    } else if (!argval) {
-        /* a valid argument with no argument value was given. */
-        /* This happens when an optional argument value was invoked. */
-        /* leave parent arguiment value unaltered but still count the argument. */
-        parent->count++;
-    } else {
-        long int val;
-        const char* end;
+  if (parent->count == parent->hdr.maxcount) {
+    /* maximum number of arguments exceeded */
+    errorcode = ARG_ERR_MAXCOUNT;
+  } else if (!argval) {
+    /* a valid argument with no argument value was given. */
+    /* This happens when an optional argument value was invoked. */
+    /* leave parent arguiment value unaltered but still count the argument. */
+    parent->count++;
+  } else {
+    long int val;
+    const char *end;
 
-        /* attempt to extract hex integer (eg: +0x123) from argval into val conversion */
-        val = strtol0X(argval, &end, 'X', 16);
+    /* attempt to extract hex integer (eg: +0x123) from argval into val
+     * conversion */
+    val = strtol0X(argval, &end, 'X', 16);
+    if (end == argval) {
+      /* hex failed, attempt octal conversion (eg +0o123) */
+      val = strtol0X(argval, &end, 'O', 8);
+      if (end == argval) {
+        /* octal failed, attempt binary conversion (eg +0B101) */
+        val = strtol0X(argval, &end, 'B', 2);
         if (end == argval) {
-            /* hex failed, attempt octal conversion (eg +0o123) */
-            val = strtol0X(argval, &end, 'O', 8);
-            if (end == argval) {
-                /* octal failed, attempt binary conversion (eg +0B101) */
-                val = strtol0X(argval, &end, 'B', 2);
-                if (end == argval) {
-                    /* binary failed, attempt decimal conversion with no prefix (eg 1234) */
-                    val = strtol(argval, (char**)&end, 10);
-                    if (end == argval) {
-                        /* all supported number formats failed */
-                        return ARG_ERR_BADINT;
-                    }
-                }
-            }
+          /* binary failed, attempt decimal conversion with no prefix (eg 1234)
+           */
+          val = strtol(argval, (char **)&end, 10);
+          if (end == argval) {
+            /* all supported number formats failed */
+            return ARG_ERR_BADINT;
+          }
         }
-
-        /* Safety check for integer overflow. WARNING: this check    */
-        /* achieves nothing on machines where size(int)==size(long). */
-        if (val > INT_MAX || val < INT_MIN)
-            errorcode = ARG_ERR_OVERFLOW;
-
-        /* Detect any suffixes (KB,MB,GB) and multiply argument value appropriately. */
-        /* We need to be mindful of integer overflows when using such big numbers.   */
-        if (detectsuffix(end, "KB")) /* kilobytes */
-        {
-            if (val > (INT_MAX / 1024) || val < (INT_MIN / 1024))
-                errorcode = ARG_ERR_OVERFLOW; /* Overflow would occur if we proceed */
-            else
-                val *= 1024;                /* 1KB = 1024 */
-        } else if (detectsuffix(end, "MB")) /* megabytes */
-        {
-            if (val > (INT_MAX / 1048576) || val < (INT_MIN / 1048576))
-                errorcode = ARG_ERR_OVERFLOW; /* Overflow would occur if we proceed */
-            else
-                val *= 1048576;             /* 1MB = 1024*1024 */
-        } else if (detectsuffix(end, "GB")) /* gigabytes */
-        {
-            if (val > (INT_MAX / 1073741824) || val < (INT_MIN / 1073741824))
-                errorcode = ARG_ERR_OVERFLOW; /* Overflow would occur if we proceed */
-            else
-                val *= 1073741824; /* 1GB = 1024*1024*1024 */
-        } else if (!detectsuffix(end, ""))
-            errorcode = ARG_ERR_BADINT; /* invalid suffix detected */
-
-        /* if success then store result in parent->ival[] array */
-        if (errorcode == 0)
-            parent->ival[parent->count++] = (int)val;
+      }
     }
 
-    /* printf("%s:scanfn(%p,%p) returns %d\n",__FILE__,parent,argval,errorcode); */
-    return errorcode;
+    /* Safety check for integer overflow. WARNING: this check    */
+    /* achieves nothing on machines where size(int)==size(long). */
+    if (val > INT_MAX || val < INT_MIN)
+      errorcode = ARG_ERR_OVERFLOW;
+
+    /* Detect any suffixes (KB,MB,GB) and multiply argument value appropriately.
+     */
+    /* We need to be mindful of integer overflows when using such big numbers.
+     */
+    if (detectsuffix(end, "KB")) /* kilobytes */
+    {
+      if (val > (INT_MAX / 1024) || val < (INT_MIN / 1024))
+        errorcode = ARG_ERR_OVERFLOW; /* Overflow would occur if we proceed */
+      else
+        val *= 1024;                    /* 1KB = 1024 */
+    } else if (detectsuffix(end, "MB")) /* megabytes */
+    {
+      if (val > (INT_MAX / 1048576) || val < (INT_MIN / 1048576))
+        errorcode = ARG_ERR_OVERFLOW; /* Overflow would occur if we proceed */
+      else
+        val *= 1048576;                 /* 1MB = 1024*1024 */
+    } else if (detectsuffix(end, "GB")) /* gigabytes */
+    {
+      if (val > (INT_MAX / 1073741824) || val < (INT_MIN / 1073741824))
+        errorcode = ARG_ERR_OVERFLOW; /* Overflow would occur if we proceed */
+      else
+        val *= 1073741824; /* 1GB = 1024*1024*1024 */
+    } else if (!detectsuffix(end, ""))
+      errorcode = ARG_ERR_BADINT; /* invalid suffix detected */
+
+    /* if success then store result in parent->ival[] array */
+    if (errorcode == 0)
+      parent->ival[parent->count++] = (int)val;
+  }
+
+  /* printf("%s:scanfn(%p,%p) returns %d\n",__FILE__,parent,argval,errorcode);
+   */
+  return errorcode;
 }
 
-static int arg_int_checkfn(struct arg_int* parent) {
-    int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
-    /*printf("%s:checkfn(%p) returns %d\n",__FILE__,parent,errorcode);*/
-    return errorcode;
+static int arg_int_checkfn(struct arg_int *parent) {
+  int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
+  /*printf("%s:checkfn(%p) returns %d\n",__FILE__,parent,errorcode);*/
+  return errorcode;
 }
 
-static void arg_int_errorfn(struct arg_int* parent, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
-    const char* shortopts = parent->hdr.shortopts;
-    const char* longopts = parent->hdr.longopts;
-    const char* datatype = parent->hdr.datatype;
+static void arg_int_errorfn(struct arg_int *parent, arg_dstr_t ds,
+                            int errorcode, const char *argval,
+                            const char *progname) {
+  const char *shortopts = parent->hdr.shortopts;
+  const char *longopts = parent->hdr.longopts;
+  const char *datatype = parent->hdr.datatype;
 
-    /* make argval NULL safe */
-    argval = argval ? argval : "";
+  /* make argval NULL safe */
+  argval = argval ? argval : "";
 
-    arg_dstr_catf(ds, "%s: ", progname);
-    switch (errorcode) {
-        case ARG_ERR_MINCOUNT:
-            arg_dstr_cat(ds, "missing option ");
-            arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
-            break;
+  arg_dstr_catf(ds, "%s: ", progname);
+  switch (errorcode) {
+  case ARG_ERR_MINCOUNT:
+    arg_dstr_cat(ds, "missing option ");
+    arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
+    break;
 
-        case ARG_ERR_MAXCOUNT:
-            arg_dstr_cat(ds, "excess option ");
-            arg_print_option_ds(ds, shortopts, longopts, argval, "\n");
-            break;
+  case ARG_ERR_MAXCOUNT:
+    arg_dstr_cat(ds, "excess option ");
+    arg_print_option_ds(ds, shortopts, longopts, argval, "\n");
+    break;
 
-        case ARG_ERR_BADINT:
-            arg_dstr_catf(ds, "invalid argument \"%s\" to option ", argval);
-            arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
-            break;
+  case ARG_ERR_BADINT:
+    arg_dstr_catf(ds, "invalid argument \"%s\" to option ", argval);
+    arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
+    break;
 
-        case ARG_ERR_OVERFLOW:
-            arg_dstr_cat(ds, "integer overflow at option ");
-            arg_print_option_ds(ds, shortopts, longopts, datatype, " ");
-            arg_dstr_catf(ds, "(%s is too large)\n", argval);
-            break;
-    }
+  case ARG_ERR_OVERFLOW:
+    arg_dstr_cat(ds, "integer overflow at option ");
+    arg_print_option_ds(ds, shortopts, longopts, datatype, " ");
+    arg_dstr_catf(ds, "(%s is too large)\n", argval);
+    break;
+  }
 }
 
-struct arg_int* arg_int0(const char* shortopts, const char* longopts, const char* datatype, const char* glossary) {
-    return arg_intn(shortopts, longopts, datatype, 0, 1, glossary);
+struct arg_int *arg_int0(const char *shortopts, const char *longopts,
+                         const char *datatype, const char *glossary) {
+  return arg_intn(shortopts, longopts, datatype, 0, 1, glossary);
 }
 
-struct arg_int* arg_int1(const char* shortopts, const char* longopts, const char* datatype, const char* glossary) {
-    return arg_intn(shortopts, longopts, datatype, 1, 1, glossary);
+struct arg_int *arg_int1(const char *shortopts, const char *longopts,
+                         const char *datatype, const char *glossary) {
+  return arg_intn(shortopts, longopts, datatype, 1, 1, glossary);
 }
 
-struct arg_int* arg_intn(const char* shortopts, const char* longopts, const char* datatype, int mincount, int maxcount, const char* glossary) {
-    size_t nbytes;
-    struct arg_int* result;
+struct arg_int *arg_intn(const char *shortopts, const char *longopts,
+                         const char *datatype, int mincount, int maxcount,
+                         const char *glossary) {
+  size_t nbytes;
+  struct arg_int *result;
 
-    /* foolproof things by ensuring maxcount is not less than mincount */
-    maxcount = (maxcount < mincount) ? mincount : maxcount;
+  /* foolproof things by ensuring maxcount is not less than mincount */
+  maxcount = (maxcount < mincount) ? mincount : maxcount;
 
-    nbytes = sizeof(struct arg_int)    /* storage for struct arg_int */
-             + (size_t)maxcount * sizeof(int); /* storage for ival[maxcount] array */
+  nbytes =
+      sizeof(struct arg_int)            /* storage for struct arg_int */
+      + (size_t)maxcount * sizeof(int); /* storage for ival[maxcount] array */
 
-    result = (struct arg_int*)xmalloc(nbytes);
+  result = (struct arg_int *)xmalloc(nbytes);
 
-    /* init the arg_hdr struct */
-    result->hdr.flag = ARG_HASVALUE;
-    result->hdr.shortopts = shortopts;
-    result->hdr.longopts = longopts;
-    result->hdr.datatype = datatype ? datatype : "<int>";
-    result->hdr.glossary = glossary;
-    result->hdr.mincount = mincount;
-    result->hdr.maxcount = maxcount;
-    result->hdr.parent = result;
-    result->hdr.resetfn = (arg_resetfn*)arg_int_resetfn;
-    result->hdr.scanfn = (arg_scanfn*)arg_int_scanfn;
-    result->hdr.checkfn = (arg_checkfn*)arg_int_checkfn;
-    result->hdr.errorfn = (arg_errorfn*)arg_int_errorfn;
+  /* init the arg_hdr struct */
+  result->hdr.flag = ARG_HASVALUE;
+  result->hdr.shortopts = shortopts;
+  result->hdr.longopts = longopts;
+  result->hdr.datatype = datatype ? datatype : "<int>";
+  result->hdr.glossary = glossary;
+  result->hdr.mincount = mincount;
+  result->hdr.maxcount = maxcount;
+  result->hdr.parent = result;
+  result->hdr.resetfn = (arg_resetfn *)arg_int_resetfn;
+  result->hdr.scanfn = (arg_scanfn *)arg_int_scanfn;
+  result->hdr.checkfn = (arg_checkfn *)arg_int_checkfn;
+  result->hdr.errorfn = (arg_errorfn *)arg_int_errorfn;
 
-    /* store the ival[maxcount] array immediately after the arg_int struct */
-    result->ival = (int*)(result + 1);
-    result->count = 0;
+  /* store the ival[maxcount] array immediately after the arg_int struct */
+  result->ival = (int *)(result + 1);
+  result->count = 0;
 
-    ARG_TRACE(("arg_intn() returns %p\n", result));
-    return result;
+  ARG_TRACE(("arg_intn() returns %p\n", result));
+  return result;
 }
 /*******************************************************************************
  * arg_lit: Implements the literature command-line option
@@ -3350,89 +3417,96 @@ struct arg_int* arg_intn(const char* shortopts, const char* longopts, const char
 #include "argtable3.h"
 
 #ifndef ARG_AMALGAMATION
-#include "argtable3_private.h"
+  #include "argtable3_private.h"
 #endif
 
 #include <stdlib.h>
 
-static void arg_lit_resetfn(struct arg_lit* parent) {
-    ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
-    parent->count = 0;
+static void arg_lit_resetfn(struct arg_lit *parent) {
+  ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
+  parent->count = 0;
 }
 
-static int arg_lit_scanfn(struct arg_lit* parent, const char* argval) {
-    int errorcode = 0;
-    if (parent->count < parent->hdr.maxcount)
-        parent->count++;
-    else
-        errorcode = ARG_ERR_MAXCOUNT;
+static int arg_lit_scanfn(struct arg_lit *parent, const char *argval) {
+  int errorcode = 0;
+  if (parent->count < parent->hdr.maxcount)
+    parent->count++;
+  else
+    errorcode = ARG_ERR_MAXCOUNT;
 
-    ARG_TRACE(("%s:scanfn(%p,%s) returns %d\n", __FILE__, parent, argval, errorcode));
-    return errorcode;
+  ARG_TRACE(
+      ("%s:scanfn(%p,%s) returns %d\n", __FILE__, parent, argval, errorcode));
+  return errorcode;
 }
 
-static int arg_lit_checkfn(struct arg_lit* parent) {
-    int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
-    ARG_TRACE(("%s:checkfn(%p) returns %d\n", __FILE__, parent, errorcode));
-    return errorcode;
+static int arg_lit_checkfn(struct arg_lit *parent) {
+  int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
+  ARG_TRACE(("%s:checkfn(%p) returns %d\n", __FILE__, parent, errorcode));
+  return errorcode;
 }
 
-static void arg_lit_errorfn(struct arg_lit* parent, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
-    const char* shortopts = parent->hdr.shortopts;
-    const char* longopts = parent->hdr.longopts;
-    const char* datatype = parent->hdr.datatype;
+static void arg_lit_errorfn(struct arg_lit *parent, arg_dstr_t ds,
+                            int errorcode, const char *argval,
+                            const char *progname) {
+  const char *shortopts = parent->hdr.shortopts;
+  const char *longopts = parent->hdr.longopts;
+  const char *datatype = parent->hdr.datatype;
 
-    switch (errorcode) {
-        case ARG_ERR_MINCOUNT:
-            arg_dstr_catf(ds, "%s: missing option ", progname);
-            arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
-            arg_dstr_cat(ds, "\n");
-            break;
+  switch (errorcode) {
+  case ARG_ERR_MINCOUNT:
+    arg_dstr_catf(ds, "%s: missing option ", progname);
+    arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
+    arg_dstr_cat(ds, "\n");
+    break;
 
-        case ARG_ERR_MAXCOUNT:
-            arg_dstr_catf(ds, "%s: extraneous option ", progname);
-            arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
-            break;
-    }
+  case ARG_ERR_MAXCOUNT:
+    arg_dstr_catf(ds, "%s: extraneous option ", progname);
+    arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
+    break;
+  }
 
-    ARG_TRACE(("%s:errorfn(%p, %p, %d, %s, %s)\n", __FILE__, parent, ds, errorcode, argval, progname));
+  ARG_TRACE(("%s:errorfn(%p, %p, %d, %s, %s)\n", __FILE__, parent, ds,
+             errorcode, argval, progname));
 }
 
-struct arg_lit* arg_lit0(const char* shortopts, const char* longopts, const char* glossary) {
-    return arg_litn(shortopts, longopts, 0, 1, glossary);
+struct arg_lit *arg_lit0(const char *shortopts, const char *longopts,
+                         const char *glossary) {
+  return arg_litn(shortopts, longopts, 0, 1, glossary);
 }
 
-struct arg_lit* arg_lit1(const char* shortopts, const char* longopts, const char* glossary) {
-    return arg_litn(shortopts, longopts, 1, 1, glossary);
+struct arg_lit *arg_lit1(const char *shortopts, const char *longopts,
+                         const char *glossary) {
+  return arg_litn(shortopts, longopts, 1, 1, glossary);
 }
 
-struct arg_lit* arg_litn(const char* shortopts, const char* longopts, int mincount, int maxcount, const char* glossary) {
-    struct arg_lit* result;
+struct arg_lit *arg_litn(const char *shortopts, const char *longopts,
+                         int mincount, int maxcount, const char *glossary) {
+  struct arg_lit *result;
 
-    /* foolproof things by ensuring maxcount is not less than mincount */
-    maxcount = (maxcount < mincount) ? mincount : maxcount;
+  /* foolproof things by ensuring maxcount is not less than mincount */
+  maxcount = (maxcount < mincount) ? mincount : maxcount;
 
-    result = (struct arg_lit*)xmalloc(sizeof(struct arg_lit));
+  result = (struct arg_lit *)xmalloc(sizeof(struct arg_lit));
 
-    /* init the arg_hdr struct */
-    result->hdr.flag = 0;
-    result->hdr.shortopts = shortopts;
-    result->hdr.longopts = longopts;
-    result->hdr.datatype = NULL;
-    result->hdr.glossary = glossary;
-    result->hdr.mincount = mincount;
-    result->hdr.maxcount = maxcount;
-    result->hdr.parent = result;
-    result->hdr.resetfn = (arg_resetfn*)arg_lit_resetfn;
-    result->hdr.scanfn = (arg_scanfn*)arg_lit_scanfn;
-    result->hdr.checkfn = (arg_checkfn*)arg_lit_checkfn;
-    result->hdr.errorfn = (arg_errorfn*)arg_lit_errorfn;
+  /* init the arg_hdr struct */
+  result->hdr.flag = 0;
+  result->hdr.shortopts = shortopts;
+  result->hdr.longopts = longopts;
+  result->hdr.datatype = NULL;
+  result->hdr.glossary = glossary;
+  result->hdr.mincount = mincount;
+  result->hdr.maxcount = maxcount;
+  result->hdr.parent = result;
+  result->hdr.resetfn = (arg_resetfn *)arg_lit_resetfn;
+  result->hdr.scanfn = (arg_scanfn *)arg_lit_scanfn;
+  result->hdr.checkfn = (arg_checkfn *)arg_lit_checkfn;
+  result->hdr.errorfn = (arg_errorfn *)arg_lit_errorfn;
 
-    /* init local variables */
-    result->count = 0;
+  /* init local variables */
+  result->count = 0;
 
-    ARG_TRACE(("arg_litn() returns %p\n", result));
-    return result;
+  ARG_TRACE(("arg_litn() returns %p\n", result));
+  return result;
 }
 /*******************************************************************************
  * arg_rem: Implements the rem command-line option
@@ -3469,29 +3543,29 @@ struct arg_lit* arg_litn(const char* shortopts, const char* longopts, int mincou
 #include "argtable3.h"
 
 #ifndef ARG_AMALGAMATION
-#include "argtable3_private.h"
+  #include "argtable3_private.h"
 #endif
 
 #include <stdlib.h>
 
-struct arg_rem* arg_rem(const char* datatype, const char* glossary) {
-    struct arg_rem* result = (struct arg_rem*)xmalloc(sizeof(struct arg_rem));
+struct arg_rem *arg_rem(const char *datatype, const char *glossary) {
+  struct arg_rem *result = (struct arg_rem *)xmalloc(sizeof(struct arg_rem));
 
-    result->hdr.flag = 0;
-    result->hdr.shortopts = NULL;
-    result->hdr.longopts = NULL;
-    result->hdr.datatype = datatype;
-    result->hdr.glossary = glossary;
-    result->hdr.mincount = 1;
-    result->hdr.maxcount = 1;
-    result->hdr.parent = result;
-    result->hdr.resetfn = NULL;
-    result->hdr.scanfn = NULL;
-    result->hdr.checkfn = NULL;
-    result->hdr.errorfn = NULL;
+  result->hdr.flag = 0;
+  result->hdr.shortopts = NULL;
+  result->hdr.longopts = NULL;
+  result->hdr.datatype = datatype;
+  result->hdr.glossary = glossary;
+  result->hdr.mincount = 1;
+  result->hdr.maxcount = 1;
+  result->hdr.parent = result;
+  result->hdr.resetfn = NULL;
+  result->hdr.scanfn = NULL;
+  result->hdr.checkfn = NULL;
+  result->hdr.errorfn = NULL;
 
-    ARG_TRACE(("arg_rem() returns %p\n", result));
-    return result;
+  ARG_TRACE(("arg_rem() returns %p\n", result));
+  return result;
 }
 /*******************************************************************************
  * arg_rex: Implements the regex command-line option
@@ -3528,14 +3602,14 @@ struct arg_rem* arg_rem(const char* datatype, const char* glossary) {
 #include "argtable3.h"
 
 #ifndef ARG_AMALGAMATION
-#include "argtable3_private.h"
+  #include "argtable3_private.h"
 #endif
 
 #include <stdlib.h>
 #include <string.h>
 
 #ifndef _TREX_H_
-#define _TREX_H_
+  #define _TREX_H_
 
 /*
  * This module uses the T-Rex regular expression library to implement the regex
@@ -3564,100 +3638,109 @@ struct arg_rem* arg_rem(const char* datatype, const char* glossary) {
  *      source distribution.
  */
 
-#ifdef __cplusplus
+  #ifdef __cplusplus
 extern "C" {
-#endif
+  #endif
 
-#define TRexChar char
-#define MAX_CHAR 0xFF
-#define _TREXC(c) (c)
-#define trex_strlen strlen
-#define trex_printf printf
+  #define TRexChar char
+  #define MAX_CHAR 0xFF
+  #define _TREXC(c) (c)
+  #define trex_strlen strlen
+  #define trex_printf printf
 
-#ifndef TREX_API
-#define TREX_API extern
-#endif
+  #ifndef TREX_API
+    #define TREX_API extern
+  #endif
 
-#define TRex_True 1
-#define TRex_False 0
+  #define TRex_True 1
+  #define TRex_False 0
 
-#define TREX_ICASE ARG_REX_ICASE
+  #define TREX_ICASE ARG_REX_ICASE
 
 typedef unsigned int TRexBool;
 typedef struct TRex TRex;
 
 typedef struct {
-    const TRexChar* begin;
-    int len;
+  const TRexChar *begin;
+  int len;
 } TRexMatch;
 
-#if defined(__clang__)
-TREX_API TRex* trex_compile(const TRexChar* pattern, const TRexChar** error, int flags) __attribute__((optnone));
-#elif defined(__GNUC__)
-TREX_API TRex* trex_compile(const TRexChar* pattern, const TRexChar** error, int flags) __attribute__((optimize(0)));
-#else
-TREX_API TRex* trex_compile(const TRexChar* pattern, const TRexChar** error, int flags);
-#endif
-TREX_API void trex_free(TRex* exp);
-TREX_API TRexBool trex_match(TRex* exp, const TRexChar* text);
-TREX_API TRexBool trex_search(TRex* exp, const TRexChar* text, const TRexChar** out_begin, const TRexChar** out_end);
-TREX_API TRexBool
-trex_searchrange(TRex* exp, const TRexChar* text_begin, const TRexChar* text_end, const TRexChar** out_begin, const TRexChar** out_end);
-TREX_API int trex_getsubexpcount(TRex* exp);
-TREX_API TRexBool trex_getsubexp(TRex* exp, int n, TRexMatch* subexp);
+  #if defined(__clang__)
+TREX_API TRex *trex_compile(const TRexChar *pattern, const TRexChar **error,
+                            int flags) __attribute__((optnone));
+  #elif defined(__GNUC__)
+TREX_API TRex *trex_compile(const TRexChar *pattern, const TRexChar **error,
+                            int flags) __attribute__((optimize(0)));
+  #else
+TREX_API TRex *trex_compile(const TRexChar *pattern, const TRexChar **error,
+                            int flags);
+  #endif
+TREX_API void trex_free(TRex *exp);
+TREX_API TRexBool trex_match(TRex *exp, const TRexChar *text);
+TREX_API TRexBool trex_search(TRex *exp, const TRexChar *text,
+                              const TRexChar **out_begin,
+                              const TRexChar **out_end);
+TREX_API TRexBool trex_searchrange(TRex *exp, const TRexChar *text_begin,
+                                   const TRexChar *text_end,
+                                   const TRexChar **out_begin,
+                                   const TRexChar **out_end);
+TREX_API int trex_getsubexpcount(TRex *exp);
+TREX_API TRexBool trex_getsubexp(TRex *exp, int n, TRexMatch *subexp);
 
-#ifdef __cplusplus
+  #ifdef __cplusplus
 }
-#endif
+  #endif
 
 #endif
 
 struct privhdr {
-    const char* pattern;
-    int flags;
+  const char *pattern;
+  int flags;
 };
 
-static void arg_rex_resetfn(struct arg_rex* parent) {
-    ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
-    parent->count = 0;
+static void arg_rex_resetfn(struct arg_rex *parent) {
+  ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
+  parent->count = 0;
 }
 
-static int arg_rex_scanfn(struct arg_rex* parent, const char* argval) {
-    int errorcode = 0;
-    const TRexChar* error = NULL;
-    TRex* rex = NULL;
-    TRexBool is_match = TRex_False;
+static int arg_rex_scanfn(struct arg_rex *parent, const char *argval) {
+  int errorcode = 0;
+  const TRexChar *error = NULL;
+  TRex *rex = NULL;
+  TRexBool is_match = TRex_False;
 
-    if (parent->count == parent->hdr.maxcount) {
-        /* maximum number of arguments exceeded */
-        errorcode = ARG_ERR_MAXCOUNT;
-    } else if (!argval) {
-        /* a valid argument with no argument value was given. */
-        /* This happens when an optional argument value was invoked. */
-        /* leave parent argument value unaltered but still count the argument. */
-        parent->count++;
-    } else {
-        struct privhdr* priv = (struct privhdr*)parent->hdr.priv;
+  if (parent->count == parent->hdr.maxcount) {
+    /* maximum number of arguments exceeded */
+    errorcode = ARG_ERR_MAXCOUNT;
+  } else if (!argval) {
+    /* a valid argument with no argument value was given. */
+    /* This happens when an optional argument value was invoked. */
+    /* leave parent argument value unaltered but still count the argument. */
+    parent->count++;
+  } else {
+    struct privhdr *priv = (struct privhdr *)parent->hdr.priv;
 
-        /* test the current argument value for a match with the regular expression */
-        /* if a match is detected, record the argument value in the arg_rex struct */
+    /* test the current argument value for a match with the regular expression
+     */
+    /* if a match is detected, record the argument value in the arg_rex struct
+     */
 
-        rex = trex_compile(priv->pattern, &error, priv->flags);
-        is_match = trex_match(rex, argval);
-        if (!is_match)
-            errorcode = ARG_ERR_REGNOMATCH;
-        else
-            parent->sval[parent->count++] = argval;
+    rex = trex_compile(priv->pattern, &error, priv->flags);
+    is_match = trex_match(rex, argval);
+    if (!is_match)
+      errorcode = ARG_ERR_REGNOMATCH;
+    else
+      parent->sval[parent->count++] = argval;
 
-        trex_free(rex);
-    }
+    trex_free(rex);
+  }
 
-    ARG_TRACE(("%s:scanfn(%p) returns %d\n", __FILE__, parent, errorcode));
-    return errorcode;
+  ARG_TRACE(("%s:scanfn(%p) returns %d\n", __FILE__, parent, errorcode));
+  return errorcode;
 }
 
-static int arg_rex_checkfn(struct arg_rex* parent) {
-    int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
+static int arg_rex_checkfn(struct arg_rex *parent) {
+  int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
 #if 0
     struct privhdr *priv = (struct privhdr*)parent->hdr.priv;
 
@@ -3666,125 +3749,132 @@ static int arg_rex_checkfn(struct arg_rex* parent) {
 
     /*printf("%s:checkfn(%p) returns %d\n",__FILE__,parent,errorcode);*/
 #endif
-    return errorcode;
+  return errorcode;
 }
 
-static void arg_rex_errorfn(struct arg_rex* parent, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
-    const char* shortopts = parent->hdr.shortopts;
-    const char* longopts = parent->hdr.longopts;
-    const char* datatype = parent->hdr.datatype;
+static void arg_rex_errorfn(struct arg_rex *parent, arg_dstr_t ds,
+                            int errorcode, const char *argval,
+                            const char *progname) {
+  const char *shortopts = parent->hdr.shortopts;
+  const char *longopts = parent->hdr.longopts;
+  const char *datatype = parent->hdr.datatype;
 
-    /* make argval NULL safe */
-    argval = argval ? argval : "";
+  /* make argval NULL safe */
+  argval = argval ? argval : "";
 
-    arg_dstr_catf(ds, "%s: ", progname);
-    switch (errorcode) {
-        case ARG_ERR_MINCOUNT:
-            arg_dstr_cat(ds, "missing option ");
-            arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
-            break;
+  arg_dstr_catf(ds, "%s: ", progname);
+  switch (errorcode) {
+  case ARG_ERR_MINCOUNT:
+    arg_dstr_cat(ds, "missing option ");
+    arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
+    break;
 
-        case ARG_ERR_MAXCOUNT:
-            arg_dstr_cat(ds, "excess option ");
-            arg_print_option_ds(ds, shortopts, longopts, argval, "\n");
-            break;
+  case ARG_ERR_MAXCOUNT:
+    arg_dstr_cat(ds, "excess option ");
+    arg_print_option_ds(ds, shortopts, longopts, argval, "\n");
+    break;
 
-        case ARG_ERR_REGNOMATCH:
-            arg_dstr_cat(ds, "illegal value  ");
-            arg_print_option_ds(ds, shortopts, longopts, argval, "\n");
-            break;
+  case ARG_ERR_REGNOMATCH:
+    arg_dstr_cat(ds, "illegal value  ");
+    arg_print_option_ds(ds, shortopts, longopts, argval, "\n");
+    break;
 
-        default: {
-        #if 0
+  default: {
+#if 0
             char errbuff[256];
             regerror(errorcode, NULL, errbuff, sizeof(errbuff));
             printf("%s\n", errbuff);
-        #endif
-        } break;
-    }
+#endif
+  } break;
+  }
 }
 
-struct arg_rex* arg_rex0(const char* shortopts, const char* longopts, const char* pattern, const char* datatype, int flags, const char* glossary) {
-    return arg_rexn(shortopts, longopts, pattern, datatype, 0, 1, flags, glossary);
+struct arg_rex *arg_rex0(const char *shortopts, const char *longopts,
+                         const char *pattern, const char *datatype, int flags,
+                         const char *glossary) {
+  return arg_rexn(shortopts, longopts, pattern, datatype, 0, 1, flags,
+                  glossary);
 }
 
-struct arg_rex* arg_rex1(const char* shortopts, const char* longopts, const char* pattern, const char* datatype, int flags, const char* glossary) {
-    return arg_rexn(shortopts, longopts, pattern, datatype, 1, 1, flags, glossary);
+struct arg_rex *arg_rex1(const char *shortopts, const char *longopts,
+                         const char *pattern, const char *datatype, int flags,
+                         const char *glossary) {
+  return arg_rexn(shortopts, longopts, pattern, datatype, 1, 1, flags,
+                  glossary);
 }
 
-struct arg_rex* arg_rexn(const char* shortopts,
-                         const char* longopts,
-                         const char* pattern,
-                         const char* datatype,
-                         int mincount,
-                         int maxcount,
-                         int flags,
-                         const char* glossary) {
-    size_t nbytes;
-    struct arg_rex* result;
-    struct privhdr* priv;
-    int i;
-    const TRexChar* error = NULL;
-    TRex* rex = NULL;
+struct arg_rex *arg_rexn(const char *shortopts, const char *longopts,
+                         const char *pattern, const char *datatype,
+                         int mincount, int maxcount, int flags,
+                         const char *glossary) {
+  size_t nbytes;
+  struct arg_rex *result;
+  struct privhdr *priv;
+  int i;
+  const TRexChar *error = NULL;
+  TRex *rex = NULL;
 
-    if (!pattern) {
-        printf("argtable: ERROR - illegal regular expression pattern \"(NULL)\"\n");
-        printf("argtable: Bad argument table.\n");
-        return NULL;
-    }
+  if (!pattern) {
+    printf("argtable: ERROR - illegal regular expression pattern \"(NULL)\"\n");
+    printf("argtable: Bad argument table.\n");
+    return NULL;
+  }
 
-    /* foolproof things by ensuring maxcount is not less than mincount */
-    maxcount = (maxcount < mincount) ? mincount : maxcount;
+  /* foolproof things by ensuring maxcount is not less than mincount */
+  maxcount = (maxcount < mincount) ? mincount : maxcount;
 
-    nbytes = sizeof(struct arg_rex)      /* storage for struct arg_rex */
-             + sizeof(struct privhdr)    /* storage for private arg_rex data */
-             + (size_t)maxcount * sizeof(char*); /* storage for sval[maxcount] array */
+  nbytes = sizeof(struct arg_rex)   /* storage for struct arg_rex */
+           + sizeof(struct privhdr) /* storage for private arg_rex data */
+           + (size_t)maxcount *
+                 sizeof(char *); /* storage for sval[maxcount] array */
 
-    /* init the arg_hdr struct */
-    result = (struct arg_rex*)xmalloc(nbytes);
-    result->hdr.flag = ARG_HASVALUE;
-    result->hdr.shortopts = shortopts;
-    result->hdr.longopts = longopts;
-    result->hdr.datatype = datatype ? datatype : pattern;
-    result->hdr.glossary = glossary;
-    result->hdr.mincount = mincount;
-    result->hdr.maxcount = maxcount;
-    result->hdr.parent = result;
-    result->hdr.resetfn = (arg_resetfn*)arg_rex_resetfn;
-    result->hdr.scanfn = (arg_scanfn*)arg_rex_scanfn;
-    result->hdr.checkfn = (arg_checkfn*)arg_rex_checkfn;
-    result->hdr.errorfn = (arg_errorfn*)arg_rex_errorfn;
+  /* init the arg_hdr struct */
+  result = (struct arg_rex *)xmalloc(nbytes);
+  result->hdr.flag = ARG_HASVALUE;
+  result->hdr.shortopts = shortopts;
+  result->hdr.longopts = longopts;
+  result->hdr.datatype = datatype ? datatype : pattern;
+  result->hdr.glossary = glossary;
+  result->hdr.mincount = mincount;
+  result->hdr.maxcount = maxcount;
+  result->hdr.parent = result;
+  result->hdr.resetfn = (arg_resetfn *)arg_rex_resetfn;
+  result->hdr.scanfn = (arg_scanfn *)arg_rex_scanfn;
+  result->hdr.checkfn = (arg_checkfn *)arg_rex_checkfn;
+  result->hdr.errorfn = (arg_errorfn *)arg_rex_errorfn;
 
-    /* store the arg_rex_priv struct immediately after the arg_rex struct */
-    result->hdr.priv = result + 1;
-    priv = (struct privhdr*)(result->hdr.priv);
-    priv->pattern = pattern;
-    priv->flags = flags;
+  /* store the arg_rex_priv struct immediately after the arg_rex struct */
+  result->hdr.priv = result + 1;
+  priv = (struct privhdr *)(result->hdr.priv);
+  priv->pattern = pattern;
+  priv->flags = flags;
 
-    /* store the sval[maxcount] array immediately after the arg_rex_priv struct */
-    result->sval = (const char**)(priv + 1);
-    result->count = 0;
+  /* store the sval[maxcount] array immediately after the arg_rex_priv struct */
+  result->sval = (const char **)(priv + 1);
+  result->count = 0;
 
-    /* foolproof the string pointers by initializing them to reference empty strings */
-    for (i = 0; i < maxcount; i++)
-        result->sval[i] = "";
+  /* foolproof the string pointers by initializing them to reference empty
+   * strings */
+  for (i = 0; i < maxcount; i++)
+    result->sval[i] = "";
 
-    /* here we construct and destroy a regex representation of the regular
-     * expression for no other reason than to force any regex errors to be
-     * trapped now rather than later. If we don't, then errors may go undetected
-     * until an argument is actually parsed.
-     */
+  /* here we construct and destroy a regex representation of the regular
+   * expression for no other reason than to force any regex errors to be
+   * trapped now rather than later. If we don't, then errors may go undetected
+   * until an argument is actually parsed.
+   */
 
-    rex = trex_compile(priv->pattern, &error, priv->flags);
-    if (rex == NULL) {
-        ARG_LOG(("argtable: %s \"%s\"\n", error ? error : _TREXC("undefined"), priv->pattern));
-        ARG_LOG(("argtable: Bad argument table.\n"));
-    }
+  rex = trex_compile(priv->pattern, &error, priv->flags);
+  if (rex == NULL) {
+    ARG_LOG(("argtable: %s \"%s\"\n", error ? error : _TREXC("undefined"),
+             priv->pattern));
+    ARG_LOG(("argtable: Bad argument table.\n"));
+  }
 
-    trex_free(rex);
+  trex_free(rex);
 
-    ARG_TRACE(("arg_rexn() returns %p\n", result));
-    return result;
+  ARG_TRACE(("arg_rexn() returns %p\n", result));
+  return result;
 }
 
 /* see copyright notice in trex.h */
@@ -3794,33 +3884,35 @@ struct arg_rex* arg_rexn(const char* shortopts,
 #include <string.h>
 
 #ifdef _UINCODE
-#define scisprint iswprint
-#define scstrlen wcslen
-#define scprintf wprintf
-#define _SC(x) L(x)
+  #define scisprint iswprint
+  #define scstrlen wcslen
+  #define scprintf wprintf
+  #define _SC(x) L(x)
 #else
-#define scisprint isprint
-#define scstrlen strlen
-#define scprintf printf
-#define _SC(x) (x)
+  #define scisprint isprint
+  #define scstrlen strlen
+  #define scprintf printf
+  #define _SC(x) (x)
 #endif
 
 #ifdef ARG_REX_DEBUG
-#include <stdio.h>
+  #include <stdio.h>
 
-static const TRexChar* g_nnames[] = {_SC("NONE"),    _SC("OP_GREEDY"), _SC("OP_OR"),     _SC("OP_EXPR"),   _SC("OP_NOCAPEXPR"),
-                                     _SC("OP_DOT"),  _SC("OP_CLASS"),  _SC("OP_CCLASS"), _SC("OP_NCLASS"), _SC("OP_RANGE"),
-                                     _SC("OP_CHAR"), _SC("OP_EOL"),    _SC("OP_BOL"),    _SC("OP_WB")};
+static const TRexChar *g_nnames[] = {
+    _SC("NONE"),         _SC("OP_GREEDY"), _SC("OP_OR"),    _SC("OP_EXPR"),
+    _SC("OP_NOCAPEXPR"), _SC("OP_DOT"),    _SC("OP_CLASS"), _SC("OP_CCLASS"),
+    _SC("OP_NCLASS"),    _SC("OP_RANGE"),  _SC("OP_CHAR"),  _SC("OP_EOL"),
+    _SC("OP_BOL"),       _SC("OP_WB")};
 
 #endif
-#define OP_GREEDY (MAX_CHAR + 1)  /*  * + ? {n} */
+#define OP_GREEDY (MAX_CHAR + 1) /*  * + ? {n} */
 #define OP_OR (MAX_CHAR + 2)
-#define OP_EXPR (MAX_CHAR + 3)       /* parentesis () */
-#define OP_NOCAPEXPR (MAX_CHAR + 4)  /* parentesis (?:) */
+#define OP_EXPR (MAX_CHAR + 3)      /* parentesis () */
+#define OP_NOCAPEXPR (MAX_CHAR + 4) /* parentesis (?:) */
 #define OP_DOT (MAX_CHAR + 5)
 #define OP_CLASS (MAX_CHAR + 6)
 #define OP_CCLASS (MAX_CHAR + 7)
-#define OP_NCLASS (MAX_CHAR + 8)  /* negates class the [^ */
+#define OP_NCLASS (MAX_CHAR + 8) /* negates class the [^ */
 #define OP_RANGE (MAX_CHAR + 9)
 #define OP_CHAR (MAX_CHAR + 10)
 #define OP_EOL (MAX_CHAR + 11)
@@ -3839,668 +3931,686 @@ static const TRexChar* g_nnames[] = {_SC("NONE"),    _SC("OP_GREEDY"), _SC("OP_O
 typedef int TRexNodeType;
 
 typedef struct tagTRexNode {
-    TRexNodeType type;
-    int left;
-    int right;
-    int next;
+  TRexNodeType type;
+  int left;
+  int right;
+  int next;
 } TRexNode;
 
 struct TRex {
-    const TRexChar* _eol;
-    const TRexChar* _bol;
-    const TRexChar* _p;
-    int _first;
-    int _op;
-    TRexNode* _nodes;
-    int _nallocated;
-    int _nsize;
-    int _nsubexpr;
-    TRexMatch* _matches;
-    int _currsubexp;
-    void* _jmpbuf;
-    const TRexChar** _error;
-    int _flags;
+  const TRexChar *_eol;
+  const TRexChar *_bol;
+  const TRexChar *_p;
+  int _first;
+  int _op;
+  TRexNode *_nodes;
+  int _nallocated;
+  int _nsize;
+  int _nsubexpr;
+  TRexMatch *_matches;
+  int _currsubexp;
+  void *_jmpbuf;
+  const TRexChar **_error;
+  int _flags;
 };
 
-static int trex_list(TRex* exp);
+static int trex_list(TRex *exp);
 
-static int trex_newnode(TRex* exp, TRexNodeType type) {
-    TRexNode n;
-    int newid;
-    n.type = type;
-    n.next = n.right = n.left = -1;
-    if (type == OP_EXPR)
-        n.right = exp->_nsubexpr++;
-    if (exp->_nallocated < (exp->_nsize + 1)) {
-        exp->_nallocated *= 2;
-        exp->_nodes = (TRexNode*)xrealloc(exp->_nodes, (size_t)exp->_nallocated * sizeof(TRexNode));
-    }
-    exp->_nodes[exp->_nsize++] = n;
-    newid = exp->_nsize - 1;
-    return (int)newid;
+static int trex_newnode(TRex *exp, TRexNodeType type) {
+  TRexNode n;
+  int newid;
+  n.type = type;
+  n.next = n.right = n.left = -1;
+  if (type == OP_EXPR)
+    n.right = exp->_nsubexpr++;
+  if (exp->_nallocated < (exp->_nsize + 1)) {
+    exp->_nallocated *= 2;
+    exp->_nodes = (TRexNode *)xrealloc(exp->_nodes, (size_t)exp->_nallocated *
+                                                        sizeof(TRexNode));
+  }
+  exp->_nodes[exp->_nsize++] = n;
+  newid = exp->_nsize - 1;
+  return (int)newid;
 }
 
-static void trex_error(TRex* exp, const TRexChar* error) {
-    if (exp->_error)
-        *exp->_error = error;
-    longjmp(*((jmp_buf*)exp->_jmpbuf), -1);
+static void trex_error(TRex *exp, const TRexChar *error) {
+  if (exp->_error)
+    *exp->_error = error;
+  longjmp(*((jmp_buf *)exp->_jmpbuf), -1);
 }
 
-static void trex_expect(TRex* exp, int n) {
-    if ((*exp->_p) != n)
-        trex_error(exp, _SC("expected paren"));
+static void trex_expect(TRex *exp, int n) {
+  if ((*exp->_p) != n)
+    trex_error(exp, _SC("expected paren"));
+  exp->_p++;
+}
+
+static TRexChar trex_escapechar(TRex *exp) {
+  if (*exp->_p == TREX_SYMBOL_ESCAPE_CHAR) {
     exp->_p++;
-}
-
-static TRexChar trex_escapechar(TRex* exp) {
-    if (*exp->_p == TREX_SYMBOL_ESCAPE_CHAR) {
-        exp->_p++;
-        switch (*exp->_p) {
-            case 'v':
-                exp->_p++;
-                return '\v';
-            case 'n':
-                exp->_p++;
-                return '\n';
-            case 't':
-                exp->_p++;
-                return '\t';
-            case 'r':
-                exp->_p++;
-                return '\r';
-            case 'f':
-                exp->_p++;
-                return '\f';
-            default:
-                return (*exp->_p++);
-        }
-    } else if (!scisprint((int)(*exp->_p)))
-        trex_error(exp, _SC("letter expected"));
-    return (*exp->_p++);
-}
-
-static int trex_charclass(TRex* exp, int classid) {
-    int n = trex_newnode(exp, OP_CCLASS);
-    exp->_nodes[n].left = classid;
-    return n;
-}
-
-static int trex_charnode(TRex* exp, TRexBool isclass) {
-    TRexChar t;
-    if (*exp->_p == TREX_SYMBOL_ESCAPE_CHAR) {
-        exp->_p++;
-        switch (*exp->_p) {
-            case 'n':
-                exp->_p++;
-                return trex_newnode(exp, '\n');
-            case 't':
-                exp->_p++;
-                return trex_newnode(exp, '\t');
-            case 'r':
-                exp->_p++;
-                return trex_newnode(exp, '\r');
-            case 'f':
-                exp->_p++;
-                return trex_newnode(exp, '\f');
-            case 'v':
-                exp->_p++;
-                return trex_newnode(exp, '\v');
-            case 'a':
-            case 'A':
-            case 'w':
-            case 'W':
-            case 's':
-            case 'S':
-            case 'd':
-            case 'D':
-            case 'x':
-            case 'X':
-            case 'c':
-            case 'C':
-            case 'p':
-            case 'P':
-            case 'l':
-            case 'u': {
-                t = *exp->_p;
-                exp->_p++;
-                return trex_charclass(exp, t);
-            }
-            case 'b':
-            case 'B':
-                if (!isclass) {
-                    int node = trex_newnode(exp, OP_WB);
-                    exp->_nodes[node].left = *exp->_p;
-                    exp->_p++;
-                    return node;
-                }
-                /* fall through */
-            default:
-                t = *exp->_p;
-                exp->_p++;
-                return trex_newnode(exp, t);
-        }
-    } else if (!scisprint((int)(*exp->_p))) {
-        trex_error(exp, _SC("letter expected"));
+    switch (*exp->_p) {
+    case 'v':
+      exp->_p++;
+      return '\v';
+    case 'n':
+      exp->_p++;
+      return '\n';
+    case 't':
+      exp->_p++;
+      return '\t';
+    case 'r':
+      exp->_p++;
+      return '\r';
+    case 'f':
+      exp->_p++;
+      return '\f';
+    default:
+      return (*exp->_p++);
     }
-    t = *exp->_p;
+  } else if (!scisprint((int)(*exp->_p)))
+    trex_error(exp, _SC("letter expected"));
+  return (*exp->_p++);
+}
+
+static int trex_charclass(TRex *exp, int classid) {
+  int n = trex_newnode(exp, OP_CCLASS);
+  exp->_nodes[n].left = classid;
+  return n;
+}
+
+static int trex_charnode(TRex *exp, TRexBool isclass) {
+  TRexChar t;
+  if (*exp->_p == TREX_SYMBOL_ESCAPE_CHAR) {
     exp->_p++;
-    return trex_newnode(exp, t);
-}
-static int trex_class(TRex* exp) {
-    int ret = -1;
-    int first = -1, chain;
-    if (*exp->_p == TREX_SYMBOL_BEGINNING_OF_STRING) {
-        ret = trex_newnode(exp, OP_NCLASS);
-        exp->_p++;
-    } else
-        ret = trex_newnode(exp, OP_CLASS);
-
-    if (*exp->_p == ']')
-        trex_error(exp, _SC("empty class"));
-    chain = ret;
-    while (*exp->_p != ']' && exp->_p != exp->_eol) {
-        if (*exp->_p == '-' && first != -1) {
-            int r, t;
-            if (*exp->_p++ == ']')
-                trex_error(exp, _SC("unfinished range"));
-            r = trex_newnode(exp, OP_RANGE);
-            if (first > *exp->_p)
-                trex_error(exp, _SC("invalid range"));
-            if (exp->_nodes[first].type == OP_CCLASS)
-                trex_error(exp, _SC("cannot use character classes in ranges"));
-            exp->_nodes[r].left = exp->_nodes[first].type;
-            t = trex_escapechar(exp);
-            exp->_nodes[r].right = t;
-            exp->_nodes[chain].next = r;
-            chain = r;
-            first = -1;
-        } else {
-            if (first != -1) {
-                int c = first;
-                exp->_nodes[chain].next = c;
-                chain = c;
-                first = trex_charnode(exp, TRex_True);
-            } else {
-                first = trex_charnode(exp, TRex_True);
-            }
-        }
+    switch (*exp->_p) {
+    case 'n':
+      exp->_p++;
+      return trex_newnode(exp, '\n');
+    case 't':
+      exp->_p++;
+      return trex_newnode(exp, '\t');
+    case 'r':
+      exp->_p++;
+      return trex_newnode(exp, '\r');
+    case 'f':
+      exp->_p++;
+      return trex_newnode(exp, '\f');
+    case 'v':
+      exp->_p++;
+      return trex_newnode(exp, '\v');
+    case 'a':
+    case 'A':
+    case 'w':
+    case 'W':
+    case 's':
+    case 'S':
+    case 'd':
+    case 'D':
+    case 'x':
+    case 'X':
+    case 'c':
+    case 'C':
+    case 'p':
+    case 'P':
+    case 'l':
+    case 'u': {
+      t = *exp->_p;
+      exp->_p++;
+      return trex_charclass(exp, t);
     }
-    if (first != -1) {
+    case 'b':
+    case 'B':
+      if (!isclass) {
+        int node = trex_newnode(exp, OP_WB);
+        exp->_nodes[node].left = *exp->_p;
+        exp->_p++;
+        return node;
+      }
+      /* fall through */
+    default:
+      t = *exp->_p;
+      exp->_p++;
+      return trex_newnode(exp, t);
+    }
+  } else if (!scisprint((int)(*exp->_p))) {
+    trex_error(exp, _SC("letter expected"));
+  }
+  t = *exp->_p;
+  exp->_p++;
+  return trex_newnode(exp, t);
+}
+static int trex_class(TRex *exp) {
+  int ret = -1;
+  int first = -1, chain;
+  if (*exp->_p == TREX_SYMBOL_BEGINNING_OF_STRING) {
+    ret = trex_newnode(exp, OP_NCLASS);
+    exp->_p++;
+  } else
+    ret = trex_newnode(exp, OP_CLASS);
+
+  if (*exp->_p == ']')
+    trex_error(exp, _SC("empty class"));
+  chain = ret;
+  while (*exp->_p != ']' && exp->_p != exp->_eol) {
+    if (*exp->_p == '-' && first != -1) {
+      int r, t;
+      if (*exp->_p++ == ']')
+        trex_error(exp, _SC("unfinished range"));
+      r = trex_newnode(exp, OP_RANGE);
+      if (first > *exp->_p)
+        trex_error(exp, _SC("invalid range"));
+      if (exp->_nodes[first].type == OP_CCLASS)
+        trex_error(exp, _SC("cannot use character classes in ranges"));
+      exp->_nodes[r].left = exp->_nodes[first].type;
+      t = trex_escapechar(exp);
+      exp->_nodes[r].right = t;
+      exp->_nodes[chain].next = r;
+      chain = r;
+      first = -1;
+    } else {
+      if (first != -1) {
         int c = first;
         exp->_nodes[chain].next = c;
         chain = c;
-        first = -1;
+        first = trex_charnode(exp, TRex_True);
+      } else {
+        first = trex_charnode(exp, TRex_True);
+      }
     }
-    /* hack? */
-    exp->_nodes[ret].left = exp->_nodes[ret].next;
-    exp->_nodes[ret].next = -1;
-    return ret;
+  }
+  if (first != -1) {
+    int c = first;
+    exp->_nodes[chain].next = c;
+    chain = c;
+    first = -1;
+  }
+  /* hack? */
+  exp->_nodes[ret].left = exp->_nodes[ret].next;
+  exp->_nodes[ret].next = -1;
+  return ret;
 }
 
-static int trex_parsenumber(TRex* exp) {
-    int ret = *exp->_p - '0';
-    int positions = 10;
+static int trex_parsenumber(TRex *exp) {
+  int ret = *exp->_p - '0';
+  int positions = 10;
+  exp->_p++;
+  while (isdigit((int)(*exp->_p))) {
+    ret = ret * 10 + (*exp->_p++ - '0');
+    if (positions == 1000000000)
+      trex_error(exp, _SC("overflow in numeric constant"));
+    positions *= 10;
+  };
+  return ret;
+}
+
+static int trex_element(TRex *exp) {
+  int ret = -1;
+  switch (*exp->_p) {
+  case '(': {
+    int expr, newn;
     exp->_p++;
-    while (isdigit((int)(*exp->_p))) {
-        ret = ret * 10 + (*exp->_p++ - '0');
-        if (positions == 1000000000)
-            trex_error(exp, _SC("overflow in numeric constant"));
-        positions *= 10;
-    };
-    return ret;
-}
 
-static int trex_element(TRex* exp) {
-    int ret = -1;
-    switch (*exp->_p) {
-        case '(': {
-            int expr, newn;
-            exp->_p++;
-
-            if (*exp->_p == '?') {
-                exp->_p++;
-                trex_expect(exp, ':');
-                expr = trex_newnode(exp, OP_NOCAPEXPR);
-            } else
-                expr = trex_newnode(exp, OP_EXPR);
-            newn = trex_list(exp);
-            exp->_nodes[expr].left = newn;
-            ret = expr;
-            trex_expect(exp, ')');
-        } break;
-        case '[':
-            exp->_p++;
-            ret = trex_class(exp);
-            trex_expect(exp, ']');
-            break;
-        case TREX_SYMBOL_END_OF_STRING:
-            exp->_p++;
-            ret = trex_newnode(exp, OP_EOL);
-            break;
-        case TREX_SYMBOL_ANY_CHAR:
-            exp->_p++;
-            ret = trex_newnode(exp, OP_DOT);
-            break;
-        default:
-            ret = trex_charnode(exp, TRex_False);
-            break;
-    }
-
-    {
-        TRexBool isgreedy = TRex_False;
-        unsigned short p0 = 0, p1 = 0;
-        switch (*exp->_p) {
-            case TREX_SYMBOL_GREEDY_ZERO_OR_MORE:
-                p0 = 0;
-                p1 = 0xFFFF;
-                exp->_p++;
-                isgreedy = TRex_True;
-                break;
-            case TREX_SYMBOL_GREEDY_ONE_OR_MORE:
-                p0 = 1;
-                p1 = 0xFFFF;
-                exp->_p++;
-                isgreedy = TRex_True;
-                break;
-            case TREX_SYMBOL_GREEDY_ZERO_OR_ONE:
-                p0 = 0;
-                p1 = 1;
-                exp->_p++;
-                isgreedy = TRex_True;
-                break;
-            case '{':
-                exp->_p++;
-                if (!isdigit((int)(*exp->_p)))
-                    trex_error(exp, _SC("number expected"));
-                p0 = (unsigned short)trex_parsenumber(exp);
-                /*******************************/
-                switch (*exp->_p) {
-                    case '}':
-                        p1 = p0;
-                        exp->_p++;
-                        break;
-                    case ',':
-                        exp->_p++;
-                        p1 = 0xFFFF;
-                        if (isdigit((int)(*exp->_p))) {
-                            p1 = (unsigned short)trex_parsenumber(exp);
-                        }
-                        trex_expect(exp, '}');
-                        break;
-                    default:
-                        trex_error(exp, _SC(", or } expected"));
-                }
-                /*******************************/
-                isgreedy = TRex_True;
-                break;
-        }
-        if (isgreedy) {
-            int nnode = trex_newnode(exp, OP_GREEDY);
-            exp->_nodes[nnode].left = ret;
-            exp->_nodes[nnode].right = ((p0) << 16) | p1;
-            ret = nnode;
-        }
-    }
-    if ((*exp->_p != TREX_SYMBOL_BRANCH) && (*exp->_p != ')') && (*exp->_p != TREX_SYMBOL_GREEDY_ZERO_OR_MORE) &&
-        (*exp->_p != TREX_SYMBOL_GREEDY_ONE_OR_MORE) && (*exp->_p != '\0')) {
-        int nnode = trex_element(exp);
-        exp->_nodes[ret].next = nnode;
-    }
-
-    return ret;
-}
-
-static int trex_list(TRex* exp) {
-    int ret = -1, e;
-    if (*exp->_p == TREX_SYMBOL_BEGINNING_OF_STRING) {
-        exp->_p++;
-        ret = trex_newnode(exp, OP_BOL);
-    }
-    e = trex_element(exp);
-    if (ret != -1) {
-        exp->_nodes[ret].next = e;
+    if (*exp->_p == '?') {
+      exp->_p++;
+      trex_expect(exp, ':');
+      expr = trex_newnode(exp, OP_NOCAPEXPR);
     } else
-        ret = e;
+      expr = trex_newnode(exp, OP_EXPR);
+    newn = trex_list(exp);
+    exp->_nodes[expr].left = newn;
+    ret = expr;
+    trex_expect(exp, ')');
+  } break;
+  case '[':
+    exp->_p++;
+    ret = trex_class(exp);
+    trex_expect(exp, ']');
+    break;
+  case TREX_SYMBOL_END_OF_STRING:
+    exp->_p++;
+    ret = trex_newnode(exp, OP_EOL);
+    break;
+  case TREX_SYMBOL_ANY_CHAR:
+    exp->_p++;
+    ret = trex_newnode(exp, OP_DOT);
+    break;
+  default:
+    ret = trex_charnode(exp, TRex_False);
+    break;
+  }
 
-    if (*exp->_p == TREX_SYMBOL_BRANCH) {
-        int temp, tright;
+  {
+    TRexBool isgreedy = TRex_False;
+    unsigned short p0 = 0, p1 = 0;
+    switch (*exp->_p) {
+    case TREX_SYMBOL_GREEDY_ZERO_OR_MORE:
+      p0 = 0;
+      p1 = 0xFFFF;
+      exp->_p++;
+      isgreedy = TRex_True;
+      break;
+    case TREX_SYMBOL_GREEDY_ONE_OR_MORE:
+      p0 = 1;
+      p1 = 0xFFFF;
+      exp->_p++;
+      isgreedy = TRex_True;
+      break;
+    case TREX_SYMBOL_GREEDY_ZERO_OR_ONE:
+      p0 = 0;
+      p1 = 1;
+      exp->_p++;
+      isgreedy = TRex_True;
+      break;
+    case '{':
+      exp->_p++;
+      if (!isdigit((int)(*exp->_p)))
+        trex_error(exp, _SC("number expected"));
+      p0 = (unsigned short)trex_parsenumber(exp);
+      /*******************************/
+      switch (*exp->_p) {
+      case '}':
+        p1 = p0;
         exp->_p++;
-        temp = trex_newnode(exp, OP_OR);
-        exp->_nodes[temp].left = ret;
-        tright = trex_list(exp);
-        exp->_nodes[temp].right = tright;
-        ret = temp;
+        break;
+      case ',':
+        exp->_p++;
+        p1 = 0xFFFF;
+        if (isdigit((int)(*exp->_p))) {
+          p1 = (unsigned short)trex_parsenumber(exp);
+        }
+        trex_expect(exp, '}');
+        break;
+      default:
+        trex_error(exp, _SC(", or } expected"));
+      }
+      /*******************************/
+      isgreedy = TRex_True;
+      break;
     }
-    return ret;
+    if (isgreedy) {
+      int nnode = trex_newnode(exp, OP_GREEDY);
+      exp->_nodes[nnode].left = ret;
+      exp->_nodes[nnode].right = ((p0) << 16) | p1;
+      ret = nnode;
+    }
+  }
+  if ((*exp->_p != TREX_SYMBOL_BRANCH) && (*exp->_p != ')') &&
+      (*exp->_p != TREX_SYMBOL_GREEDY_ZERO_OR_MORE) &&
+      (*exp->_p != TREX_SYMBOL_GREEDY_ONE_OR_MORE) && (*exp->_p != '\0')) {
+    int nnode = trex_element(exp);
+    exp->_nodes[ret].next = nnode;
+  }
+
+  return ret;
+}
+
+static int trex_list(TRex *exp) {
+  int ret = -1, e;
+  if (*exp->_p == TREX_SYMBOL_BEGINNING_OF_STRING) {
+    exp->_p++;
+    ret = trex_newnode(exp, OP_BOL);
+  }
+  e = trex_element(exp);
+  if (ret != -1) {
+    exp->_nodes[ret].next = e;
+  } else
+    ret = e;
+
+  if (*exp->_p == TREX_SYMBOL_BRANCH) {
+    int temp, tright;
+    exp->_p++;
+    temp = trex_newnode(exp, OP_OR);
+    exp->_nodes[temp].left = ret;
+    tright = trex_list(exp);
+    exp->_nodes[temp].right = tright;
+    ret = temp;
+  }
+  return ret;
 }
 
 static TRexBool trex_matchcclass(int cclass, TRexChar c) {
-    switch (cclass) {
-        case 'a':
-            return isalpha(c) ? TRex_True : TRex_False;
-        case 'A':
-            return !isalpha(c) ? TRex_True : TRex_False;
-        case 'w':
-            return (isalnum(c) || c == '_') ? TRex_True : TRex_False;
-        case 'W':
-            return (!isalnum(c) && c != '_') ? TRex_True : TRex_False;
-        case 's':
-            return isspace(c) ? TRex_True : TRex_False;
-        case 'S':
-            return !isspace(c) ? TRex_True : TRex_False;
-        case 'd':
-            return isdigit(c) ? TRex_True : TRex_False;
-        case 'D':
-            return !isdigit(c) ? TRex_True : TRex_False;
-        case 'x':
-            return isxdigit(c) ? TRex_True : TRex_False;
-        case 'X':
-            return !isxdigit(c) ? TRex_True : TRex_False;
-        case 'c':
-            return iscntrl(c) ? TRex_True : TRex_False;
-        case 'C':
-            return !iscntrl(c) ? TRex_True : TRex_False;
-        case 'p':
-            return ispunct(c) ? TRex_True : TRex_False;
-        case 'P':
-            return !ispunct(c) ? TRex_True : TRex_False;
-        case 'l':
-            return islower(c) ? TRex_True : TRex_False;
-        case 'u':
-            return isupper(c) ? TRex_True : TRex_False;
+  switch (cclass) {
+  case 'a':
+    return isalpha(c) ? TRex_True : TRex_False;
+  case 'A':
+    return !isalpha(c) ? TRex_True : TRex_False;
+  case 'w':
+    return (isalnum(c) || c == '_') ? TRex_True : TRex_False;
+  case 'W':
+    return (!isalnum(c) && c != '_') ? TRex_True : TRex_False;
+  case 's':
+    return isspace(c) ? TRex_True : TRex_False;
+  case 'S':
+    return !isspace(c) ? TRex_True : TRex_False;
+  case 'd':
+    return isdigit(c) ? TRex_True : TRex_False;
+  case 'D':
+    return !isdigit(c) ? TRex_True : TRex_False;
+  case 'x':
+    return isxdigit(c) ? TRex_True : TRex_False;
+  case 'X':
+    return !isxdigit(c) ? TRex_True : TRex_False;
+  case 'c':
+    return iscntrl(c) ? TRex_True : TRex_False;
+  case 'C':
+    return !iscntrl(c) ? TRex_True : TRex_False;
+  case 'p':
+    return ispunct(c) ? TRex_True : TRex_False;
+  case 'P':
+    return !ispunct(c) ? TRex_True : TRex_False;
+  case 'l':
+    return islower(c) ? TRex_True : TRex_False;
+  case 'u':
+    return isupper(c) ? TRex_True : TRex_False;
+  }
+  return TRex_False; /*cannot happen*/
+}
+
+static TRexBool trex_matchclass(TRex *exp, TRexNode *node, TRexChar c) {
+  do {
+    switch (node->type) {
+    case OP_RANGE:
+      if (exp->_flags & TREX_ICASE) {
+        if (c >= toupper(node->left) && c <= toupper(node->right))
+          return TRex_True;
+        if (c >= tolower(node->left) && c <= tolower(node->right))
+          return TRex_True;
+      } else {
+        if (c >= node->left && c <= node->right)
+          return TRex_True;
+      }
+      break;
+    case OP_CCLASS:
+      if (trex_matchcclass(node->left, c))
+        return TRex_True;
+      break;
+    default:
+      if (exp->_flags & TREX_ICASE) {
+        if (c == tolower(node->type) || c == toupper(node->type))
+          return TRex_True;
+      } else {
+        if (c == node->type)
+          return TRex_True;
+      }
     }
-    return TRex_False; /*cannot happen*/
+  } while ((node->next != -1) && ((node = &exp->_nodes[node->next]) != NULL));
+  return TRex_False;
 }
 
-static TRexBool trex_matchclass(TRex* exp, TRexNode* node, TRexChar c) {
-    do {
-        switch (node->type) {
-            case OP_RANGE:
-                if (exp->_flags & TREX_ICASE) {
-                    if (c >= toupper(node->left) && c <= toupper(node->right))
-                        return TRex_True;
-                    if (c >= tolower(node->left) && c <= tolower(node->right))
-                        return TRex_True;
-                } else {
-                    if (c >= node->left && c <= node->right)
-                        return TRex_True;
-                }
-                break;
-            case OP_CCLASS:
-                if (trex_matchcclass(node->left, c))
-                    return TRex_True;
-                break;
-            default:
-                if (exp->_flags & TREX_ICASE) {
-                    if (c == tolower(node->type) || c == toupper(node->type))
-                        return TRex_True;
-                } else {
-                    if (c == node->type)
-                        return TRex_True;
-                }
-        }
-    } while ((node->next != -1) && ((node = &exp->_nodes[node->next]) != NULL));
-    return TRex_False;
-}
+static const TRexChar *trex_matchnode(TRex *exp, TRexNode *node,
+                                      const TRexChar *str, TRexNode *next) {
+  TRexNodeType type = node->type;
+  switch (type) {
+  case OP_GREEDY: {
+    /* TRexNode *greedystop = (node->next != -1) ? &exp->_nodes[node->next] :
+     * NULL; */
+    TRexNode *greedystop = NULL;
+    int p0 = (node->right >> 16) & 0x0000FFFF, p1 = node->right & 0x0000FFFF,
+        nmaches = 0;
+    const TRexChar *s = str, *good = str;
 
-static const TRexChar* trex_matchnode(TRex* exp, TRexNode* node, const TRexChar* str, TRexNode* next) {
-    TRexNodeType type = node->type;
-    switch (type) {
-        case OP_GREEDY: {
-            /* TRexNode *greedystop = (node->next != -1) ? &exp->_nodes[node->next] : NULL; */
-            TRexNode* greedystop = NULL;
-            int p0 = (node->right >> 16) & 0x0000FFFF, p1 = node->right & 0x0000FFFF, nmaches = 0;
-            const TRexChar *s = str, *good = str;
+    if (node->next != -1) {
+      greedystop = &exp->_nodes[node->next];
+    } else {
+      greedystop = next;
+    }
 
-            if (node->next != -1) {
-                greedystop = &exp->_nodes[node->next];
-            } else {
-                greedystop = next;
-            }
-
-            while ((nmaches == 0xFFFF || nmaches < p1)) {
-                const TRexChar* stop;
-                if ((s = trex_matchnode(exp, &exp->_nodes[node->left], s, greedystop)) == NULL)
-                    break;
-                nmaches++;
-                good = s;
-                if (greedystop) {
-                    /* checks that 0 matches satisfy the expression(if so skips) */
-                    /* if not would always stop(for instance if is a '?') */
-                    if (greedystop->type != OP_GREEDY || (greedystop->type == OP_GREEDY && ((greedystop->right >> 16) & 0x0000FFFF) != 0)) {
-                        TRexNode* gnext = NULL;
-                        if (greedystop->next != -1) {
-                            gnext = &exp->_nodes[greedystop->next];
-                        } else if (next && next->next != -1) {
-                            gnext = &exp->_nodes[next->next];
-                        }
-                        stop = trex_matchnode(exp, greedystop, s, gnext);
-                        if (stop) {
-                            /* if satisfied stop it */
-                            if (p0 == p1 && p0 == nmaches)
-                                break;
-                            else if (nmaches >= p0 && p1 == 0xFFFF)
-                                break;
-                            else if (nmaches >= p0 && nmaches <= p1)
-                                break;
-                        }
-                    }
-                }
-
-                if (s >= exp->_eol)
-                    break;
-            }
+    while ((nmaches == 0xFFFF || nmaches < p1)) {
+      const TRexChar *stop;
+      if ((s = trex_matchnode(exp, &exp->_nodes[node->left], s, greedystop)) ==
+          NULL)
+        break;
+      nmaches++;
+      good = s;
+      if (greedystop) {
+        /* checks that 0 matches satisfy the expression(if so skips) */
+        /* if not would always stop(for instance if is a '?') */
+        if (greedystop->type != OP_GREEDY ||
+            (greedystop->type == OP_GREEDY &&
+             ((greedystop->right >> 16) & 0x0000FFFF) != 0)) {
+          TRexNode *gnext = NULL;
+          if (greedystop->next != -1) {
+            gnext = &exp->_nodes[greedystop->next];
+          } else if (next && next->next != -1) {
+            gnext = &exp->_nodes[next->next];
+          }
+          stop = trex_matchnode(exp, greedystop, s, gnext);
+          if (stop) {
+            /* if satisfied stop it */
             if (p0 == p1 && p0 == nmaches)
-                return good;
+              break;
             else if (nmaches >= p0 && p1 == 0xFFFF)
-                return good;
+              break;
             else if (nmaches >= p0 && nmaches <= p1)
-                return good;
-            return NULL;
+              break;
+          }
         }
-        case OP_OR: {
-            const TRexChar* asd = str;
-            TRexNode* temp = &exp->_nodes[node->left];
-            while ((asd = trex_matchnode(exp, temp, asd, NULL)) != NULL) {
-                if (temp->next != -1)
-                    temp = &exp->_nodes[temp->next];
-                else
-                    return asd;
-            }
-            asd = str;
-            temp = &exp->_nodes[node->right];
-            while ((asd = trex_matchnode(exp, temp, asd, NULL)) != NULL) {
-                if (temp->next != -1)
-                    temp = &exp->_nodes[temp->next];
-                else
-                    return asd;
-            }
-            return NULL;
-            break;
-        }
-        case OP_EXPR:
-        case OP_NOCAPEXPR: {
-            TRexNode* n = &exp->_nodes[node->left];
-            const TRexChar* cur = str;
-            int capture = -1;
-            if (node->type != OP_NOCAPEXPR && node->right == exp->_currsubexp) {
-                capture = exp->_currsubexp;
-                exp->_matches[capture].begin = cur;
-                exp->_currsubexp++;
-            }
+      }
 
-            do {
-                TRexNode* subnext = NULL;
-                if (n->next != -1) {
-                    subnext = &exp->_nodes[n->next];
-                } else {
-                    subnext = next;
-                }
-                if ((cur = trex_matchnode(exp, n, cur, subnext)) == NULL) {
-                    if (capture != -1) {
-                        exp->_matches[capture].begin = 0;
-                        exp->_matches[capture].len = 0;
-                    }
-                    return NULL;
-                }
-            } while ((n->next != -1) && ((n = &exp->_nodes[n->next]) != NULL));
-
-            if (capture != -1)
-                exp->_matches[capture].len = (int)(cur - exp->_matches[capture].begin);
-            return cur;
-        }
-        case OP_WB:
-            if ((str == exp->_bol && !isspace((int)(*str))) || (str == exp->_eol && !isspace((int)(*(str - 1)))) || (!isspace((int)(*str)) && isspace((int)(*(str + 1)))) ||
-                (isspace((int)(*str)) && !isspace((int)(*(str + 1))))) {
-                return (node->left == 'b') ? str : NULL;
-            }
-            return (node->left == 'b') ? NULL : str;
-        case OP_BOL:
-            if (str == exp->_bol)
-                return str;
-            return NULL;
-        case OP_EOL:
-            if (str == exp->_eol)
-                return str;
-            return NULL;
-        case OP_DOT: {
-            str++;
-        }
-            return str;
-        case OP_NCLASS:
-        case OP_CLASS:
-            if (trex_matchclass(exp, &exp->_nodes[node->left], *str) ? (type == OP_CLASS ? TRex_True : TRex_False)
-                                                                     : (type == OP_NCLASS ? TRex_True : TRex_False)) {
-                str++;
-                return str;
-            }
-            return NULL;
-        case OP_CCLASS:
-            if (trex_matchcclass(node->left, *str)) {
-                str++;
-                return str;
-            }
-            return NULL;
-        default: /* char */
-            if (exp->_flags & TREX_ICASE) {
-                if (*str != tolower(node->type) && *str != toupper(node->type))
-                    return NULL;
-            } else {
-                if (*str != node->type)
-                    return NULL;
-            }
-            str++;
-            return str;
+      if (s >= exp->_eol)
+        break;
     }
+    if (p0 == p1 && p0 == nmaches)
+      return good;
+    else if (nmaches >= p0 && p1 == 0xFFFF)
+      return good;
+    else if (nmaches >= p0 && nmaches <= p1)
+      return good;
+    return NULL;
+  }
+  case OP_OR: {
+    const TRexChar *asd = str;
+    TRexNode *temp = &exp->_nodes[node->left];
+    while ((asd = trex_matchnode(exp, temp, asd, NULL)) != NULL) {
+      if (temp->next != -1)
+        temp = &exp->_nodes[temp->next];
+      else
+        return asd;
+    }
+    asd = str;
+    temp = &exp->_nodes[node->right];
+    while ((asd = trex_matchnode(exp, temp, asd, NULL)) != NULL) {
+      if (temp->next != -1)
+        temp = &exp->_nodes[temp->next];
+      else
+        return asd;
+    }
+    return NULL;
+    break;
+  }
+  case OP_EXPR:
+  case OP_NOCAPEXPR: {
+    TRexNode *n = &exp->_nodes[node->left];
+    const TRexChar *cur = str;
+    int capture = -1;
+    if (node->type != OP_NOCAPEXPR && node->right == exp->_currsubexp) {
+      capture = exp->_currsubexp;
+      exp->_matches[capture].begin = cur;
+      exp->_currsubexp++;
+    }
+
+    do {
+      TRexNode *subnext = NULL;
+      if (n->next != -1) {
+        subnext = &exp->_nodes[n->next];
+      } else {
+        subnext = next;
+      }
+      if ((cur = trex_matchnode(exp, n, cur, subnext)) == NULL) {
+        if (capture != -1) {
+          exp->_matches[capture].begin = 0;
+          exp->_matches[capture].len = 0;
+        }
+        return NULL;
+      }
+    } while ((n->next != -1) && ((n = &exp->_nodes[n->next]) != NULL));
+
+    if (capture != -1)
+      exp->_matches[capture].len = (int)(cur - exp->_matches[capture].begin);
+    return cur;
+  }
+  case OP_WB:
+    if ((str == exp->_bol && !isspace((int)(*str))) ||
+        (str == exp->_eol && !isspace((int)(*(str - 1)))) ||
+        (!isspace((int)(*str)) && isspace((int)(*(str + 1)))) ||
+        (isspace((int)(*str)) && !isspace((int)(*(str + 1))))) {
+      return (node->left == 'b') ? str : NULL;
+    }
+    return (node->left == 'b') ? NULL : str;
+  case OP_BOL:
+    if (str == exp->_bol)
+      return str;
+    return NULL;
+  case OP_EOL:
+    if (str == exp->_eol)
+      return str;
+    return NULL;
+  case OP_DOT: {
+    str++;
+  }
+    return str;
+  case OP_NCLASS:
+  case OP_CLASS:
+    if (trex_matchclass(exp, &exp->_nodes[node->left], *str)
+            ? (type == OP_CLASS ? TRex_True : TRex_False)
+            : (type == OP_NCLASS ? TRex_True : TRex_False)) {
+      str++;
+      return str;
+    }
+    return NULL;
+  case OP_CCLASS:
+    if (trex_matchcclass(node->left, *str)) {
+      str++;
+      return str;
+    }
+    return NULL;
+  default: /* char */
+    if (exp->_flags & TREX_ICASE) {
+      if (*str != tolower(node->type) && *str != toupper(node->type))
+        return NULL;
+    } else {
+      if (*str != node->type)
+        return NULL;
+    }
+    str++;
+    return str;
+  }
 }
 
 /* public api */
-TRex* trex_compile(const TRexChar* pattern, const TRexChar** error, int flags) {
-    TRex* exp = (TRex*)xmalloc(sizeof(TRex));
-    exp->_eol = exp->_bol = NULL;
-    exp->_p = pattern;
-    exp->_nallocated = (int)(scstrlen(pattern) * sizeof(TRexChar));
-    exp->_nodes = (TRexNode*)xmalloc((size_t)exp->_nallocated * sizeof(TRexNode));
-    exp->_nsize = 0;
-    exp->_matches = 0;
-    exp->_nsubexpr = 0;
-    exp->_first = trex_newnode(exp, OP_EXPR);
-    exp->_error = error;
-    exp->_jmpbuf = xmalloc(sizeof(jmp_buf));
-    exp->_flags = flags;
-    if (setjmp(*((jmp_buf*)exp->_jmpbuf)) == 0) {
-        int res = trex_list(exp);
-        exp->_nodes[exp->_first].left = res;
-        if (*exp->_p != '\0')
-            trex_error(exp, _SC("unexpected character"));
+TRex *trex_compile(const TRexChar *pattern, const TRexChar **error, int flags) {
+  TRex *exp = (TRex *)xmalloc(sizeof(TRex));
+  exp->_eol = exp->_bol = NULL;
+  exp->_p = pattern;
+  exp->_nallocated = (int)(scstrlen(pattern) * sizeof(TRexChar));
+  exp->_nodes =
+      (TRexNode *)xmalloc((size_t)exp->_nallocated * sizeof(TRexNode));
+  exp->_nsize = 0;
+  exp->_matches = 0;
+  exp->_nsubexpr = 0;
+  exp->_first = trex_newnode(exp, OP_EXPR);
+  exp->_error = error;
+  exp->_jmpbuf = xmalloc(sizeof(jmp_buf));
+  exp->_flags = flags;
+  if (setjmp(*((jmp_buf *)exp->_jmpbuf)) == 0) {
+    int res = trex_list(exp);
+    exp->_nodes[exp->_first].left = res;
+    if (*exp->_p != '\0')
+      trex_error(exp, _SC("unexpected character"));
 #ifdef ARG_REX_DEBUG
-        {
-            int nsize, i;
-            nsize = exp->_nsize;
-            scprintf(_SC("\n"));
-            for (i = 0; i < nsize; i++) {
-                if (exp->_nodes[i].type > MAX_CHAR)
-                    scprintf(_SC("[%02d] %10s "), i, g_nnames[exp->_nodes[i].type - MAX_CHAR]);
-                else
-                    scprintf(_SC("[%02d] %10c "), i, exp->_nodes[i].type);
-                scprintf(_SC("left %02d right %02d next %02d\n"), exp->_nodes[i].left, exp->_nodes[i].right, exp->_nodes[i].next);
-            }
-            scprintf(_SC("\n"));
-        }
+    {
+      int nsize, i;
+      nsize = exp->_nsize;
+      scprintf(_SC("\n"));
+      for (i = 0; i < nsize; i++) {
+        if (exp->_nodes[i].type > MAX_CHAR)
+          scprintf(_SC("[%02d] %10s "), i,
+                   g_nnames[exp->_nodes[i].type - MAX_CHAR]);
+        else
+          scprintf(_SC("[%02d] %10c "), i, exp->_nodes[i].type);
+        scprintf(_SC("left %02d right %02d next %02d\n"), exp->_nodes[i].left,
+                 exp->_nodes[i].right, exp->_nodes[i].next);
+      }
+      scprintf(_SC("\n"));
+    }
 #endif
-        exp->_matches = (TRexMatch*)xmalloc((size_t)exp->_nsubexpr * sizeof(TRexMatch));
-        memset(exp->_matches, 0, (size_t)exp->_nsubexpr * sizeof(TRexMatch));
-    } else {
-        trex_free(exp);
-        return NULL;
+    exp->_matches =
+        (TRexMatch *)xmalloc((size_t)exp->_nsubexpr * sizeof(TRexMatch));
+    memset(exp->_matches, 0, (size_t)exp->_nsubexpr * sizeof(TRexMatch));
+  } else {
+    trex_free(exp);
+    return NULL;
+  }
+  return exp;
+}
+
+void trex_free(TRex *exp) {
+  if (exp) {
+    xfree(exp->_nodes);
+    xfree(exp->_jmpbuf);
+    xfree(exp->_matches);
+    xfree(exp);
+  }
+}
+
+TRexBool trex_match(TRex *exp, const TRexChar *text) {
+  const TRexChar *res = NULL;
+  exp->_bol = text;
+  exp->_eol = text + scstrlen(text);
+  exp->_currsubexp = 0;
+  res = trex_matchnode(exp, exp->_nodes, text, NULL);
+  if (res == NULL || res != exp->_eol)
+    return TRex_False;
+  return TRex_True;
+}
+
+TRexBool trex_searchrange(TRex *exp, const TRexChar *text_begin,
+                          const TRexChar *text_end, const TRexChar **out_begin,
+                          const TRexChar **out_end) {
+  const TRexChar *cur = NULL;
+  int node = exp->_first;
+  if (text_begin >= text_end)
+    return TRex_False;
+  exp->_bol = text_begin;
+  exp->_eol = text_end;
+  do {
+    cur = text_begin;
+    while (node != -1) {
+      exp->_currsubexp = 0;
+      cur = trex_matchnode(exp, &exp->_nodes[node], cur, NULL);
+      if (!cur)
+        break;
+      node = exp->_nodes[node].next;
     }
-    return exp;
+    text_begin++;
+  } while (cur == NULL && text_begin != text_end);
+
+  if (cur == NULL)
+    return TRex_False;
+
+  --text_begin;
+
+  if (out_begin)
+    *out_begin = text_begin;
+  if (out_end)
+    *out_end = cur;
+  return TRex_True;
 }
 
-void trex_free(TRex* exp) {
-    if (exp) {
-        xfree(exp->_nodes);
-        xfree(exp->_jmpbuf);
-        xfree(exp->_matches);
-        xfree(exp);
-    }
+TRexBool trex_search(TRex *exp, const TRexChar *text,
+                     const TRexChar **out_begin, const TRexChar **out_end) {
+  return trex_searchrange(exp, text, text + scstrlen(text), out_begin, out_end);
 }
 
-TRexBool trex_match(TRex* exp, const TRexChar* text) {
-    const TRexChar* res = NULL;
-    exp->_bol = text;
-    exp->_eol = text + scstrlen(text);
-    exp->_currsubexp = 0;
-    res = trex_matchnode(exp, exp->_nodes, text, NULL);
-    if (res == NULL || res != exp->_eol)
-        return TRex_False;
-    return TRex_True;
+int trex_getsubexpcount(TRex *exp) {
+  return exp->_nsubexpr;
 }
 
-TRexBool trex_searchrange(TRex* exp, const TRexChar* text_begin, const TRexChar* text_end, const TRexChar** out_begin, const TRexChar** out_end) {
-    const TRexChar* cur = NULL;
-    int node = exp->_first;
-    if (text_begin >= text_end)
-        return TRex_False;
-    exp->_bol = text_begin;
-    exp->_eol = text_end;
-    do {
-        cur = text_begin;
-        while (node != -1) {
-            exp->_currsubexp = 0;
-            cur = trex_matchnode(exp, &exp->_nodes[node], cur, NULL);
-            if (!cur)
-                break;
-            node = exp->_nodes[node].next;
-        }
-        text_begin++;
-    } while (cur == NULL && text_begin != text_end);
-
-    if (cur == NULL)
-        return TRex_False;
-
-    --text_begin;
-
-    if (out_begin)
-        *out_begin = text_begin;
-    if (out_end)
-        *out_end = cur;
-    return TRex_True;
-}
-
-TRexBool trex_search(TRex* exp, const TRexChar* text, const TRexChar** out_begin, const TRexChar** out_end) {
-    return trex_searchrange(exp, text, text + scstrlen(text), out_begin, out_end);
-}
-
-int trex_getsubexpcount(TRex* exp) {
-    return exp->_nsubexpr;
-}
-
-TRexBool trex_getsubexp(TRex* exp, int n, TRexMatch* subexp) {
-    if (n < 0 || n >= exp->_nsubexpr)
-        return TRex_False;
-    *subexp = exp->_matches[n];
-    return TRex_True;
+TRexBool trex_getsubexp(TRex *exp, int n, TRexMatch *subexp) {
+  if (n < 0 || n >= exp->_nsubexpr)
+    return TRex_False;
+  *subexp = exp->_matches[n];
+  return TRex_True;
 }
 /*******************************************************************************
  * arg_str: Implements the str command-line option
@@ -4537,116 +4647,124 @@ TRexBool trex_getsubexp(TRex* exp, int n, TRexMatch* subexp) {
 #include "argtable3.h"
 
 #ifndef ARG_AMALGAMATION
-#include "argtable3_private.h"
+  #include "argtable3_private.h"
 #endif
 
 #include <stdlib.h>
 
-static void arg_str_resetfn(struct arg_str* parent) {
-    int i;
+static void arg_str_resetfn(struct arg_str *parent) {
+  int i;
 
-    ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
-    for (i = 0; i < parent->count; i++) {
-        parent->sval[i] = "";
-    }
-    parent->count = 0;
+  ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
+  for (i = 0; i < parent->count; i++) {
+    parent->sval[i] = "";
+  }
+  parent->count = 0;
 }
 
-static int arg_str_scanfn(struct arg_str* parent, const char* argval) {
-    int errorcode = 0;
+static int arg_str_scanfn(struct arg_str *parent, const char *argval) {
+  int errorcode = 0;
 
-    if (parent->count == parent->hdr.maxcount) {
-        /* maximum number of arguments exceeded */
-        errorcode = ARG_ERR_MAXCOUNT;
-    } else if (!argval) {
-        /* a valid argument with no argument value was given. */
-        /* This happens when an optional argument value was invoked. */
-        /* leave parent argument value unaltered but still count the argument. */
-        parent->count++;
-    } else {
-        parent->sval[parent->count++] = argval;
-    }
+  if (parent->count == parent->hdr.maxcount) {
+    /* maximum number of arguments exceeded */
+    errorcode = ARG_ERR_MAXCOUNT;
+  } else if (!argval) {
+    /* a valid argument with no argument value was given. */
+    /* This happens when an optional argument value was invoked. */
+    /* leave parent argument value unaltered but still count the argument. */
+    parent->count++;
+  } else {
+    parent->sval[parent->count++] = argval;
+  }
 
-    ARG_TRACE(("%s:scanfn(%p) returns %d\n", __FILE__, parent, errorcode));
-    return errorcode;
+  ARG_TRACE(("%s:scanfn(%p) returns %d\n", __FILE__, parent, errorcode));
+  return errorcode;
 }
 
-static int arg_str_checkfn(struct arg_str* parent) {
-    int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
+static int arg_str_checkfn(struct arg_str *parent) {
+  int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
 
-    ARG_TRACE(("%s:checkfn(%p) returns %d\n", __FILE__, parent, errorcode));
-    return errorcode;
+  ARG_TRACE(("%s:checkfn(%p) returns %d\n", __FILE__, parent, errorcode));
+  return errorcode;
 }
 
-static void arg_str_errorfn(struct arg_str* parent, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
-    const char* shortopts = parent->hdr.shortopts;
-    const char* longopts = parent->hdr.longopts;
-    const char* datatype = parent->hdr.datatype;
+static void arg_str_errorfn(struct arg_str *parent, arg_dstr_t ds,
+                            int errorcode, const char *argval,
+                            const char *progname) {
+  const char *shortopts = parent->hdr.shortopts;
+  const char *longopts = parent->hdr.longopts;
+  const char *datatype = parent->hdr.datatype;
 
-    /* make argval NULL safe */
-    argval = argval ? argval : "";
+  /* make argval NULL safe */
+  argval = argval ? argval : "";
 
-    arg_dstr_catf(ds, "%s: ", progname);
-    switch (errorcode) {
-        case ARG_ERR_MINCOUNT:
-            arg_dstr_cat(ds, "missing option ");
-            arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
-            break;
+  arg_dstr_catf(ds, "%s: ", progname);
+  switch (errorcode) {
+  case ARG_ERR_MINCOUNT:
+    arg_dstr_cat(ds, "missing option ");
+    arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
+    break;
 
-        case ARG_ERR_MAXCOUNT:
-            arg_dstr_cat(ds, "excess option ");
-            arg_print_option_ds(ds, shortopts, longopts, argval, "\n");
-            break;
-    }
+  case ARG_ERR_MAXCOUNT:
+    arg_dstr_cat(ds, "excess option ");
+    arg_print_option_ds(ds, shortopts, longopts, argval, "\n");
+    break;
+  }
 }
 
-struct arg_str* arg_str0(const char* shortopts, const char* longopts, const char* datatype, const char* glossary) {
-    return arg_strn(shortopts, longopts, datatype, 0, 1, glossary);
+struct arg_str *arg_str0(const char *shortopts, const char *longopts,
+                         const char *datatype, const char *glossary) {
+  return arg_strn(shortopts, longopts, datatype, 0, 1, glossary);
 }
 
-struct arg_str* arg_str1(const char* shortopts, const char* longopts, const char* datatype, const char* glossary) {
-    return arg_strn(shortopts, longopts, datatype, 1, 1, glossary);
+struct arg_str *arg_str1(const char *shortopts, const char *longopts,
+                         const char *datatype, const char *glossary) {
+  return arg_strn(shortopts, longopts, datatype, 1, 1, glossary);
 }
 
-struct arg_str* arg_strn(const char* shortopts, const char* longopts, const char* datatype, int mincount, int maxcount, const char* glossary) {
-    size_t nbytes;
-    struct arg_str* result;
-    int i;
+struct arg_str *arg_strn(const char *shortopts, const char *longopts,
+                         const char *datatype, int mincount, int maxcount,
+                         const char *glossary) {
+  size_t nbytes;
+  struct arg_str *result;
+  int i;
 
-    /* should not allow this stupid error */
-    /* we should return an error code warning this logic error */
-    /* foolproof things by ensuring maxcount is not less than mincount */
-    maxcount = (maxcount < mincount) ? mincount : maxcount;
+  /* should not allow this stupid error */
+  /* we should return an error code warning this logic error */
+  /* foolproof things by ensuring maxcount is not less than mincount */
+  maxcount = (maxcount < mincount) ? mincount : maxcount;
 
-    nbytes = sizeof(struct arg_str)      /* storage for struct arg_str */
-             + (size_t)maxcount * sizeof(char*); /* storage for sval[maxcount] array */
+  nbytes = sizeof(struct arg_str) /* storage for struct arg_str */
+           + (size_t)maxcount *
+                 sizeof(char *); /* storage for sval[maxcount] array */
 
-    result = (struct arg_str*)xmalloc(nbytes);
+  result = (struct arg_str *)xmalloc(nbytes);
 
-    /* init the arg_hdr struct */
-    result->hdr.flag = ARG_HASVALUE;
-    result->hdr.shortopts = shortopts;
-    result->hdr.longopts = longopts;
-    result->hdr.datatype = datatype ? datatype : "<string>";
-    result->hdr.glossary = glossary;
-    result->hdr.mincount = mincount;
-    result->hdr.maxcount = maxcount;
-    result->hdr.parent = result;
-    result->hdr.resetfn = (arg_resetfn*)arg_str_resetfn;
-    result->hdr.scanfn = (arg_scanfn*)arg_str_scanfn;
-    result->hdr.checkfn = (arg_checkfn*)arg_str_checkfn;
-    result->hdr.errorfn = (arg_errorfn*)arg_str_errorfn;
+  /* init the arg_hdr struct */
+  result->hdr.flag = ARG_HASVALUE;
+  result->hdr.shortopts = shortopts;
+  result->hdr.longopts = longopts;
+  result->hdr.datatype = datatype ? datatype : "<string>";
+  result->hdr.glossary = glossary;
+  result->hdr.mincount = mincount;
+  result->hdr.maxcount = maxcount;
+  result->hdr.parent = result;
+  result->hdr.resetfn = (arg_resetfn *)arg_str_resetfn;
+  result->hdr.scanfn = (arg_scanfn *)arg_str_scanfn;
+  result->hdr.checkfn = (arg_checkfn *)arg_str_checkfn;
+  result->hdr.errorfn = (arg_errorfn *)arg_str_errorfn;
 
-    /* store the sval[maxcount] array immediately after the arg_str struct */
-    result->sval = (const char**)(result + 1);
-    result->count = 0;
+  /* store the sval[maxcount] array immediately after the arg_str struct */
+  result->sval = (const char **)(result + 1);
+  result->count = 0;
 
-    /* foolproof the string pointers by initializing them to reference empty strings */
-    for (i = 0; i < maxcount; i++)
-        result->sval[i] = "";
+  /* foolproof the string pointers by initializing them to reference empty
+   * strings */
+  for (i = 0; i < maxcount; i++)
+    result->sval[i] = "";
 
-    ARG_TRACE(("arg_strn() returns %p\n", result));
-    return result;
+  ARG_TRACE(("arg_strn() returns %p\n", result));
+  return result;
 }
 /*******************************************************************************
  * arg_cmd: Provides the sub-command mechanism
@@ -4683,7 +4801,7 @@ struct arg_str* arg_strn(const char* shortopts, const char* longopts, const char
 #include "argtable3.h"
 
 #ifndef ARG_AMALGAMATION
-#include "argtable3_private.h"
+  #include "argtable3_private.h"
 #endif
 
 #include <assert.h>
@@ -4692,241 +4810,253 @@ struct arg_str* arg_strn(const char* shortopts, const char* longopts, const char
 
 #define MAX_MODULE_VERSION_SIZE 128
 
-static arg_hashtable_t* s_hashtable = NULL;
-static char* s_module_name = NULL;
+static arg_hashtable_t *s_hashtable = NULL;
+static char *s_module_name = NULL;
 static int s_mod_ver_major = 0;
 static int s_mod_ver_minor = 0;
 static int s_mod_ver_patch = 0;
-static char* s_mod_ver_tag = NULL;
-static char* s_mod_ver = NULL;
+static char *s_mod_ver_tag = NULL;
+static char *s_mod_ver = NULL;
 
-void arg_set_module_name(const char* name) {
-    size_t slen;
+void arg_set_module_name(const char *name) {
+  size_t slen;
 
-    xfree(s_module_name);
-    slen = strlen(name);
-    s_module_name = (char*)xmalloc(slen + 1);
-    memset(s_module_name, 0, slen + 1);
+  xfree(s_module_name);
+  slen = strlen(name);
+  s_module_name = (char *)xmalloc(slen + 1);
+  memset(s_module_name, 0, slen + 1);
 
-#if (defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) || (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__))
-    strncpy_s(s_module_name, slen + 1, name, slen);
+#if (defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) ||         \
+    (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__))
+  strncpy_s(s_module_name, slen + 1, name, slen);
 #else
-    memcpy(s_module_name, name, slen);
+  memcpy(s_module_name, name, slen);
 #endif
 }
 
-void arg_set_module_version(int major, int minor, int patch, const char* tag) {
-    size_t slen_tag, slen_ds;
-    arg_dstr_t ds;
+void arg_set_module_version(int major, int minor, int patch, const char *tag) {
+  size_t slen_tag, slen_ds;
+  arg_dstr_t ds;
 
-    s_mod_ver_major = major;
-    s_mod_ver_minor = minor;
-    s_mod_ver_patch = patch;
+  s_mod_ver_major = major;
+  s_mod_ver_minor = minor;
+  s_mod_ver_patch = patch;
 
-    xfree(s_mod_ver_tag);
-    slen_tag = strlen(tag);
-    s_mod_ver_tag = (char*)xmalloc(slen_tag + 1);
-    memset(s_mod_ver_tag, 0, slen_tag + 1);
+  xfree(s_mod_ver_tag);
+  slen_tag = strlen(tag);
+  s_mod_ver_tag = (char *)xmalloc(slen_tag + 1);
+  memset(s_mod_ver_tag, 0, slen_tag + 1);
 
-#if (defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) || (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__))
-    strncpy_s(s_mod_ver_tag, slen_tag + 1, tag, slen_tag);
+#if (defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) ||         \
+    (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__))
+  strncpy_s(s_mod_ver_tag, slen_tag + 1, tag, slen_tag);
 #else
-    memcpy(s_mod_ver_tag, tag, slen_tag);
+  memcpy(s_mod_ver_tag, tag, slen_tag);
 #endif
 
-    ds = arg_dstr_create();
-    arg_dstr_catf(ds, "%d.", s_mod_ver_major);
-    arg_dstr_catf(ds, "%d.", s_mod_ver_minor);
-    arg_dstr_catf(ds, "%d.", s_mod_ver_patch);
-    arg_dstr_cat(ds, s_mod_ver_tag);
+  ds = arg_dstr_create();
+  arg_dstr_catf(ds, "%d.", s_mod_ver_major);
+  arg_dstr_catf(ds, "%d.", s_mod_ver_minor);
+  arg_dstr_catf(ds, "%d.", s_mod_ver_patch);
+  arg_dstr_cat(ds, s_mod_ver_tag);
 
-    xfree(s_mod_ver);
-    slen_ds = strlen(arg_dstr_cstr(ds));
-    s_mod_ver = (char*)xmalloc(slen_ds + 1);
-    memset(s_mod_ver, 0, slen_ds + 1);
+  xfree(s_mod_ver);
+  slen_ds = strlen(arg_dstr_cstr(ds));
+  s_mod_ver = (char *)xmalloc(slen_ds + 1);
+  memset(s_mod_ver, 0, slen_ds + 1);
 
-#if (defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) || (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__))
-    strncpy_s(s_mod_ver, slen_ds + 1, arg_dstr_cstr(ds), slen_ds);
+#if (defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) ||         \
+    (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__))
+  strncpy_s(s_mod_ver, slen_ds + 1, arg_dstr_cstr(ds), slen_ds);
 #else
-    memcpy(s_mod_ver, arg_dstr_cstr(ds), slen_ds);
+  memcpy(s_mod_ver, arg_dstr_cstr(ds), slen_ds);
 #endif
 
-    arg_dstr_destroy(ds);
+  arg_dstr_destroy(ds);
 }
 
-static unsigned int hash_key(const void* key) {
-    const char* str = (const char*)key;
-    int c;
-    unsigned int hash = 5381;
+static unsigned int hash_key(const void *key) {
+  const char *str = (const char *)key;
+  int c;
+  unsigned int hash = 5381;
 
-    while ((c = *str++) != 0)
-        hash = ((hash << 5) + hash) + (unsigned int)c; /* hash * 33 + c */
+  while ((c = *str++) != 0)
+    hash = ((hash << 5) + hash) + (unsigned int)c; /* hash * 33 + c */
 
-    return hash;
+  return hash;
 }
 
-static int equal_keys(const void* key1, const void* key2) {
-    char* k1 = (char*)key1;
-    char* k2 = (char*)key2;
-    return (0 == strcmp(k1, k2));
+static int equal_keys(const void *key1, const void *key2) {
+  char *k1 = (char *)key1;
+  char *k2 = (char *)key2;
+  return (0 == strcmp(k1, k2));
 }
 
 void arg_cmd_init(void) {
-    s_hashtable = arg_hashtable_create(32, hash_key, equal_keys);
+  s_hashtable = arg_hashtable_create(32, hash_key, equal_keys);
 }
 
 void arg_cmd_uninit(void) {
-    arg_hashtable_destroy(s_hashtable, 1);
+  arg_hashtable_destroy(s_hashtable, 1);
 }
 
-void arg_cmd_register(const char* name, arg_cmdfn* proc, const char* description) {
-    arg_cmd_info_t* cmd_info;
-    size_t slen_name;
-    void* k;
+void arg_cmd_register(const char *name, arg_cmdfn *proc,
+                      const char *description) {
+  arg_cmd_info_t *cmd_info;
+  size_t slen_name;
+  void *k;
 
-    assert(strlen(name) < ARG_CMD_NAME_LEN);
-    assert(strlen(description) < ARG_CMD_DESCRIPTION_LEN);
+  assert(strlen(name) < ARG_CMD_NAME_LEN);
+  assert(strlen(description) < ARG_CMD_DESCRIPTION_LEN);
 
-    /* Check if the command already exists. */
-    /* If the command exists, replace the existing command. */
-    /* If the command doesn't exist, insert the command. */
-    cmd_info = (arg_cmd_info_t*)arg_hashtable_search(s_hashtable, name);
-    if (cmd_info) {
-        arg_hashtable_remove(s_hashtable, name);
-        cmd_info = NULL;
-    }
-
-    cmd_info = (arg_cmd_info_t*)xmalloc(sizeof(arg_cmd_info_t));
-    memset(cmd_info, 0, sizeof(arg_cmd_info_t));
-
-#if (defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) || (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__))
-    strncpy_s(cmd_info->name, ARG_CMD_NAME_LEN, name, strlen(name));
-    strncpy_s(cmd_info->description, ARG_CMD_DESCRIPTION_LEN, description, strlen(description));
-#else
-    memcpy(cmd_info->name, name, strlen(name));
-    memcpy(cmd_info->description, description, strlen(description));
-#endif
-
-    cmd_info->proc = proc;
-
-    slen_name = strlen(name);
-    k = xmalloc(slen_name + 1);
-    memset(k, 0, slen_name + 1);
-
-#if (defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) || (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__))
-    strncpy_s((char*)k, slen_name + 1, name, slen_name);
-#else
-    memcpy((char*)k, name, slen_name);
-#endif
-
-    arg_hashtable_insert(s_hashtable, k, cmd_info);
-}
-
-void arg_cmd_unregister(const char* name) {
+  /* Check if the command already exists. */
+  /* If the command exists, replace the existing command. */
+  /* If the command doesn't exist, insert the command. */
+  cmd_info = (arg_cmd_info_t *)arg_hashtable_search(s_hashtable, name);
+  if (cmd_info) {
     arg_hashtable_remove(s_hashtable, name);
+    cmd_info = NULL;
+  }
+
+  cmd_info = (arg_cmd_info_t *)xmalloc(sizeof(arg_cmd_info_t));
+  memset(cmd_info, 0, sizeof(arg_cmd_info_t));
+
+#if (defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) ||         \
+    (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__))
+  strncpy_s(cmd_info->name, ARG_CMD_NAME_LEN, name, strlen(name));
+  strncpy_s(cmd_info->description, ARG_CMD_DESCRIPTION_LEN, description,
+            strlen(description));
+#else
+  memcpy(cmd_info->name, name, strlen(name));
+  memcpy(cmd_info->description, description, strlen(description));
+#endif
+
+  cmd_info->proc = proc;
+
+  slen_name = strlen(name);
+  k = xmalloc(slen_name + 1);
+  memset(k, 0, slen_name + 1);
+
+#if (defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) ||         \
+    (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__))
+  strncpy_s((char *)k, slen_name + 1, name, slen_name);
+#else
+  memcpy((char *)k, name, slen_name);
+#endif
+
+  arg_hashtable_insert(s_hashtable, k, cmd_info);
 }
 
-int arg_cmd_dispatch(const char* name, int argc, char* argv[], arg_dstr_t res) {
-    arg_cmd_info_t* cmd_info = arg_cmd_info(name);
-
-    assert(cmd_info != NULL);
-    assert(cmd_info->proc != NULL);
-
-    return cmd_info->proc(argc, argv, res);
+void arg_cmd_unregister(const char *name) {
+  arg_hashtable_remove(s_hashtable, name);
 }
 
-arg_cmd_info_t* arg_cmd_info(const char* name) {
-    return (arg_cmd_info_t*)arg_hashtable_search(s_hashtable, name);
+int arg_cmd_dispatch(const char *name, int argc, char *argv[], arg_dstr_t res) {
+  arg_cmd_info_t *cmd_info = arg_cmd_info(name);
+
+  assert(cmd_info != NULL);
+  assert(cmd_info->proc != NULL);
+
+  return cmd_info->proc(argc, argv, res);
+}
+
+arg_cmd_info_t *arg_cmd_info(const char *name) {
+  return (arg_cmd_info_t *)arg_hashtable_search(s_hashtable, name);
 }
 
 unsigned int arg_cmd_count(void) {
-    return arg_hashtable_count(s_hashtable);
+  return arg_hashtable_count(s_hashtable);
 }
 
 arg_cmd_itr_t arg_cmd_itr_create(void) {
-    return (arg_cmd_itr_t)arg_hashtable_itr_create(s_hashtable);
+  return (arg_cmd_itr_t)arg_hashtable_itr_create(s_hashtable);
 }
 
 int arg_cmd_itr_advance(arg_cmd_itr_t itr) {
-    return arg_hashtable_itr_advance((arg_hashtable_itr_t*)itr);
+  return arg_hashtable_itr_advance((arg_hashtable_itr_t *)itr);
 }
 
-char* arg_cmd_itr_key(arg_cmd_itr_t itr) {
-    return (char*)arg_hashtable_itr_key((arg_hashtable_itr_t*)itr);
+char *arg_cmd_itr_key(arg_cmd_itr_t itr) {
+  return (char *)arg_hashtable_itr_key((arg_hashtable_itr_t *)itr);
 }
 
-arg_cmd_info_t* arg_cmd_itr_value(arg_cmd_itr_t itr) {
-    return (arg_cmd_info_t*)arg_hashtable_itr_value((arg_hashtable_itr_t*)itr);
+arg_cmd_info_t *arg_cmd_itr_value(arg_cmd_itr_t itr) {
+  return (arg_cmd_info_t *)arg_hashtable_itr_value((arg_hashtable_itr_t *)itr);
 }
 
 void arg_cmd_itr_destroy(arg_cmd_itr_t itr) {
-    arg_hashtable_itr_destroy((arg_hashtable_itr_t*)itr);
+  arg_hashtable_itr_destroy((arg_hashtable_itr_t *)itr);
 }
 
-int arg_cmd_itr_search(arg_cmd_itr_t itr, void* k) {
-    return arg_hashtable_itr_search((arg_hashtable_itr_t*)itr, s_hashtable, k);
+int arg_cmd_itr_search(arg_cmd_itr_t itr, void *k) {
+  return arg_hashtable_itr_search((arg_hashtable_itr_t *)itr, s_hashtable, k);
 }
 
-static const char* module_name(void) {
-    if (s_module_name == NULL || strlen(s_module_name) == 0)
-        return "<name>";
+static const char *module_name(void) {
+  if (s_module_name == NULL || strlen(s_module_name) == 0)
+    return "<name>";
 
-    return s_module_name;
+  return s_module_name;
 }
 
-static const char* module_version(void) {
-    if (s_mod_ver == NULL || strlen(s_mod_ver) == 0)
-        return "0.0.0.0";
+static const char *module_version(void) {
+  if (s_mod_ver == NULL || strlen(s_mod_ver) == 0)
+    return "0.0.0.0";
 
-    return s_mod_ver;
+  return s_mod_ver;
 }
 
 void arg_make_get_help_msg(arg_dstr_t res) {
-    arg_dstr_catf(res, "%s v%s\n", module_name(), module_version());
-    arg_dstr_catf(res, "Please type '%s help' to get more information.\n", module_name());
+  arg_dstr_catf(res, "%s v%s\n", module_name(), module_version());
+  arg_dstr_catf(res, "Please type '%s help' to get more information.\n",
+                module_name());
 }
 
-void arg_make_help_msg(arg_dstr_t ds, char* cmd_name, void** argtable) {
-    arg_cmd_info_t* cmd_info = (arg_cmd_info_t*)arg_hashtable_search(s_hashtable, cmd_name);
-    if (cmd_info) {
-        arg_dstr_catf(ds, "%s: %s\n", cmd_name, cmd_info->description);
-    }
+void arg_make_help_msg(arg_dstr_t ds, char *cmd_name, void **argtable) {
+  arg_cmd_info_t *cmd_info =
+      (arg_cmd_info_t *)arg_hashtable_search(s_hashtable, cmd_name);
+  if (cmd_info) {
+    arg_dstr_catf(ds, "%s: %s\n", cmd_name, cmd_info->description);
+  }
 
-    arg_dstr_cat(ds, "Usage:\n");
-    arg_dstr_catf(ds, "  %s", module_name());
+  arg_dstr_cat(ds, "Usage:\n");
+  arg_dstr_catf(ds, "  %s", module_name());
 
-    arg_print_syntaxv_ds(ds, argtable, "\n \nAvailable options:\n");
-    arg_print_glossary_ds(ds, argtable, "  %-23s %s\n");
+  arg_print_syntaxv_ds(ds, argtable, "\n \nAvailable options:\n");
+  arg_print_glossary_ds(ds, argtable, "  %-23s %s\n");
 
-    arg_dstr_cat(ds, "\n");
+  arg_dstr_cat(ds, "\n");
 }
 
-void arg_make_syntax_err_msg(arg_dstr_t ds, void** argtable, struct arg_end* end) {
-    arg_print_errors_ds(ds, end, module_name());
-    arg_dstr_cat(ds, "Usage: \n");
-    arg_dstr_catf(ds, "  %s", module_name());
-    arg_print_syntaxv_ds(ds, argtable, "\n");
-    arg_dstr_cat(ds, "\n");
+void arg_make_syntax_err_msg(arg_dstr_t ds, void **argtable,
+                             struct arg_end *end) {
+  arg_print_errors_ds(ds, end, module_name());
+  arg_dstr_cat(ds, "Usage: \n");
+  arg_dstr_catf(ds, "  %s", module_name());
+  arg_print_syntaxv_ds(ds, argtable, "\n");
+  arg_dstr_cat(ds, "\n");
 }
 
-int arg_make_syntax_err_help_msg(arg_dstr_t ds, char* name, int help, int nerrors, void** argtable, struct arg_end* end, int* exitcode) {
-    /* help handling
-     * note: '-h|--help' takes precedence over error reporting
-     */
-    if (help > 0) {
-        arg_make_help_msg(ds, name, argtable);
-        *exitcode = EXIT_SUCCESS;
-        return 1;
-    }
+int arg_make_syntax_err_help_msg(arg_dstr_t ds, char *name, int help,
+                                 int nerrors, void **argtable,
+                                 struct arg_end *end, int *exitcode) {
+  /* help handling
+   * note: '-h|--help' takes precedence over error reporting
+   */
+  if (help > 0) {
+    arg_make_help_msg(ds, name, argtable);
+    *exitcode = EXIT_SUCCESS;
+    return 1;
+  }
 
-    /* syntax error handling */
-    if (nerrors > 0) {
-        arg_make_syntax_err_msg(ds, argtable, end);
-        *exitcode = EXIT_FAILURE;
-        return 1;
-    }
+  /* syntax error handling */
+  if (nerrors > 0) {
+    arg_make_syntax_err_msg(ds, argtable, end);
+    *exitcode = EXIT_FAILURE;
+    return 1;
+  }
 
-    return 0;
+  return 0;
 }
 /*******************************************************************************
  * argtable3: Implements the main interfaces of the library
@@ -4963,22 +5093,22 @@ int arg_make_syntax_err_help_msg(arg_dstr_t ds, char* name, int help, int nerror
 #include "argtable3.h"
 
 #ifndef ARG_AMALGAMATION
-#include "argtable3_private.h"
-#if ARG_REPLACE_GETOPT == 1
-#include "arg_getopt.h"
+  #include "argtable3_private.h"
+  #if ARG_REPLACE_GETOPT == 1
+    #include "arg_getopt.h"
+  #else
+    #include <getopt.h>
+  #endif
 #else
-#include <getopt.h>
-#endif
-#else
-#if ARG_REPLACE_GETOPT == 0
-#include <getopt.h>
-#endif
+  #if ARG_REPLACE_GETOPT == 0
+    #include <getopt.h>
+  #endif
 #endif
 
 #ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#undef WIN32_LEAN_AND_MEAN
+  #define WIN32_LEAN_AND_MEAN
+  #include <windows.h>
+  #undef WIN32_LEAN_AND_MEAN
 #endif
 
 #include <assert.h>
@@ -4987,37 +5117,39 @@ int arg_make_syntax_err_help_msg(arg_dstr_t ds, char* name, int help, int nerror
 #include <stdlib.h>
 #include <string.h>
 
-static void arg_register_error(struct arg_end* end, void* parent, int error, const char* argval) {
-    /* printf("arg_register_error(%p,%p,%d,%s)\n",end,parent,error,argval); */
-    if (end->count < end->hdr.maxcount) {
-        end->error[end->count] = error;
-        end->parent[end->count] = parent;
-        end->argval[end->count] = argval;
-        end->count++;
-    } else {
-        end->error[end->hdr.maxcount - 1] = ARG_ELIMIT;
-        end->parent[end->hdr.maxcount - 1] = end;
-        end->argval[end->hdr.maxcount - 1] = NULL;
-    }
+static void arg_register_error(struct arg_end *end, void *parent, int error,
+                               const char *argval) {
+  /* printf("arg_register_error(%p,%p,%d,%s)\n",end,parent,error,argval); */
+  if (end->count < end->hdr.maxcount) {
+    end->error[end->count] = error;
+    end->parent[end->count] = parent;
+    end->argval[end->count] = argval;
+    end->count++;
+  } else {
+    end->error[end->hdr.maxcount - 1] = ARG_ELIMIT;
+    end->parent[end->hdr.maxcount - 1] = end;
+    end->argval[end->hdr.maxcount - 1] = NULL;
+  }
 }
 
 /*
  * Return index of first table entry with a matching short option
  * or -1 if no match was found.
  */
-static int find_shortoption(struct arg_hdr** table, char shortopt) {
-    int tabindex;
-    for (tabindex = 0; !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
-        if (table[tabindex]->shortopts && strchr(table[tabindex]->shortopts, shortopt))
-            return tabindex;
-    }
-    return -1;
+static int find_shortoption(struct arg_hdr **table, char shortopt) {
+  int tabindex;
+  for (tabindex = 0; !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
+    if (table[tabindex]->shortopts &&
+        strchr(table[tabindex]->shortopts, shortopt))
+      return tabindex;
+  }
+  return -1;
 }
 
 struct longoptions {
-    int getoptval;
-    int noptions;
-    struct option* options;
+  int getoptval;
+  int noptions;
+  struct option *options;
 };
 
 #if 0
@@ -5039,374 +5171,389 @@ void dump_longoptions(struct longoptions * longoptions)
 }
 #endif
 
-static struct longoptions* alloc_longoptions(struct arg_hdr** table) {
-    struct longoptions* result;
-    size_t nbytes;
-    int noptions = 1;
-    size_t longoptlen = 0;
-    int tabindex;
-    int option_index = 0;
-    char* store;
+static struct longoptions *alloc_longoptions(struct arg_hdr **table) {
+  struct longoptions *result;
+  size_t nbytes;
+  int noptions = 1;
+  size_t longoptlen = 0;
+  int tabindex;
+  int option_index = 0;
+  char *store;
 
-    /*
-     * Determine the total number of option structs required
-     * by counting the number of comma separated long options
-     * in all table entries and return the count in noptions.
-     * note: noptions starts at 1 not 0 because we getoptlong
-     * requires a NULL option entry to terminate the option array.
-     * While we are at it, count the number of chars required
-     * to store private copies of all the longoption strings
-     * and return that count in logoptlen.
-     */
-    tabindex = 0;
-    do {
-        const char* longopts = table[tabindex]->longopts;
-        longoptlen += (longopts ? strlen(longopts) : 0) + 1;
-        while (longopts) {
-            noptions++;
-            longopts = strchr(longopts + 1, ',');
-        }
-    } while (!(table[tabindex++]->flag & ARG_TERMINATOR));
-    /*printf("%d long options consuming %d chars in total\n",noptions,longoptlen);*/
-
-    /* allocate storage for return data structure as: */
-    /* (struct longoptions) + (struct options)[noptions] + char[longoptlen] */
-    nbytes = sizeof(struct longoptions) + sizeof(struct option) * (size_t)noptions + longoptlen;
-    result = (struct longoptions*)xmalloc(nbytes);
-
-    result->getoptval = 0;
-    result->noptions = noptions;
-    result->options = (struct option*)(result + 1);
-    store = (char*)(result->options + noptions);
-
-    for (tabindex = 0; !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
-        const char* longopts = table[tabindex]->longopts;
-
-        while (longopts && *longopts) {
-            char* storestart = store;
-
-            /* copy progressive longopt strings into the store */
-            while (*longopts != 0 && *longopts != ',')
-                *store++ = *longopts++;
-            *store++ = 0;
-            if (*longopts == ',')
-                longopts++;
-            /*fprintf(stderr,"storestart=\"%s\"\n",storestart);*/
-
-            result->options[option_index].name = storestart;
-            result->options[option_index].flag = &(result->getoptval);
-            result->options[option_index].val = tabindex;
-            if (table[tabindex]->flag & ARG_HASOPTVALUE)
-                result->options[option_index].has_arg = 2;
-            else if (table[tabindex]->flag & ARG_HASVALUE)
-                result->options[option_index].has_arg = 1;
-            else
-                result->options[option_index].has_arg = 0;
-
-            option_index++;
-        }
+  /*
+   * Determine the total number of option structs required
+   * by counting the number of comma separated long options
+   * in all table entries and return the count in noptions.
+   * note: noptions starts at 1 not 0 because we getoptlong
+   * requires a NULL option entry to terminate the option array.
+   * While we are at it, count the number of chars required
+   * to store private copies of all the longoption strings
+   * and return that count in logoptlen.
+   */
+  tabindex = 0;
+  do {
+    const char *longopts = table[tabindex]->longopts;
+    longoptlen += (longopts ? strlen(longopts) : 0) + 1;
+    while (longopts) {
+      noptions++;
+      longopts = strchr(longopts + 1, ',');
     }
-    /* terminate the options array with a zero-filled entry */
-    result->options[option_index].name = 0;
-    result->options[option_index].has_arg = 0;
-    result->options[option_index].flag = 0;
-    result->options[option_index].val = 0;
+  } while (!(table[tabindex++]->flag & ARG_TERMINATOR));
+  /*printf("%d long options consuming %d chars in
+   * total\n",noptions,longoptlen);*/
 
-    /*dump_longoptions(result);*/
-    return result;
+  /* allocate storage for return data structure as: */
+  /* (struct longoptions) + (struct options)[noptions] + char[longoptlen] */
+  nbytes = sizeof(struct longoptions) +
+           sizeof(struct option) * (size_t)noptions + longoptlen;
+  result = (struct longoptions *)xmalloc(nbytes);
+
+  result->getoptval = 0;
+  result->noptions = noptions;
+  result->options = (struct option *)(result + 1);
+  store = (char *)(result->options + noptions);
+
+  for (tabindex = 0; !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
+    const char *longopts = table[tabindex]->longopts;
+
+    while (longopts && *longopts) {
+      char *storestart = store;
+
+      /* copy progressive longopt strings into the store */
+      while (*longopts != 0 && *longopts != ',')
+        *store++ = *longopts++;
+      *store++ = 0;
+      if (*longopts == ',')
+        longopts++;
+      /*fprintf(stderr,"storestart=\"%s\"\n",storestart);*/
+
+      result->options[option_index].name = storestart;
+      result->options[option_index].flag = &(result->getoptval);
+      result->options[option_index].val = tabindex;
+      if (table[tabindex]->flag & ARG_HASOPTVALUE)
+        result->options[option_index].has_arg = 2;
+      else if (table[tabindex]->flag & ARG_HASVALUE)
+        result->options[option_index].has_arg = 1;
+      else
+        result->options[option_index].has_arg = 0;
+
+      option_index++;
+    }
+  }
+  /* terminate the options array with a zero-filled entry */
+  result->options[option_index].name = 0;
+  result->options[option_index].has_arg = 0;
+  result->options[option_index].flag = 0;
+  result->options[option_index].val = 0;
+
+  /*dump_longoptions(result);*/
+  return result;
 }
 
-static char* alloc_shortoptions(struct arg_hdr** table) {
-    char* result;
-    size_t len = 2;
-    int tabindex;
-    char* res;
+static char *alloc_shortoptions(struct arg_hdr **table) {
+  char *result;
+  size_t len = 2;
+  int tabindex;
+  char *res;
 
-    /* determine the total number of option chars required */
-    for (tabindex = 0; !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
-        struct arg_hdr* hdr = table[tabindex];
-        len += 3 * (hdr->shortopts ? strlen(hdr->shortopts) : 0);
+  /* determine the total number of option chars required */
+  for (tabindex = 0; !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
+    struct arg_hdr *hdr = table[tabindex];
+    len += 3 * (hdr->shortopts ? strlen(hdr->shortopts) : 0);
+  }
+
+  result = xmalloc(len);
+
+  res = result;
+
+  /* add a leading ':' so getopt return codes distinguish    */
+  /* unrecognised option and options missing argument values */
+  *res++ = ':';
+
+  for (tabindex = 0; !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
+    struct arg_hdr *hdr = table[tabindex];
+    const char *shortopts = hdr->shortopts;
+    while (shortopts && *shortopts) {
+      *res++ = *shortopts++;
+      if (hdr->flag & ARG_HASVALUE)
+        *res++ = ':';
+      if (hdr->flag & ARG_HASOPTVALUE)
+        *res++ = ':';
     }
+  }
+  /* null terminate the string */
+  *res = 0;
 
-    result = xmalloc(len);
-
-    res = result;
-
-    /* add a leading ':' so getopt return codes distinguish    */
-    /* unrecognised option and options missing argument values */
-    *res++ = ':';
-
-    for (tabindex = 0; !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
-        struct arg_hdr* hdr = table[tabindex];
-        const char* shortopts = hdr->shortopts;
-        while (shortopts && *shortopts) {
-            *res++ = *shortopts++;
-            if (hdr->flag & ARG_HASVALUE)
-                *res++ = ':';
-            if (hdr->flag & ARG_HASOPTVALUE)
-                *res++ = ':';
-        }
-    }
-    /* null terminate the string */
-    *res = 0;
-
-    /*printf("alloc_shortoptions() returns \"%s\"\n",(result?result:"NULL"));*/
-    return result;
+  /*printf("alloc_shortoptions() returns \"%s\"\n",(result?result:"NULL"));*/
+  return result;
 }
 
 /* return index of the table terminator entry */
-static int arg_endindex(struct arg_hdr** table) {
-    int tabindex = 0;
-    while (!(table[tabindex]->flag & ARG_TERMINATOR))
-        tabindex++;
-    return tabindex;
+static int arg_endindex(struct arg_hdr **table) {
+  int tabindex = 0;
+  while (!(table[tabindex]->flag & ARG_TERMINATOR))
+    tabindex++;
+  return tabindex;
 }
 
-static void arg_parse_tagged(int argc, char** argv, struct arg_hdr** table, struct arg_end* endtable) {
-    struct longoptions* longoptions;
-    char* shortoptions;
-    int copt;
+static void arg_parse_tagged(int argc, char **argv, struct arg_hdr **table,
+                             struct arg_end *endtable) {
+  struct longoptions *longoptions;
+  char *shortoptions;
+  int copt;
 
-    /*printf("arg_parse_tagged(%d,%p,%p,%p)\n",argc,argv,table,endtable);*/
+  /*printf("arg_parse_tagged(%d,%p,%p,%p)\n",argc,argv,table,endtable);*/
 
-    /* allocate short and long option arrays for the given opttable[].   */
-    /* if the allocs fail then put an error msg in the last table entry. */
-    longoptions = alloc_longoptions(table);
-    shortoptions = alloc_shortoptions(table);
+  /* allocate short and long option arrays for the given opttable[].   */
+  /* if the allocs fail then put an error msg in the last table entry. */
+  longoptions = alloc_longoptions(table);
+  shortoptions = alloc_shortoptions(table);
 
-    /*dump_longoptions(longoptions);*/
+  /*dump_longoptions(longoptions);*/
 
-    /* reset getopts internal option-index to zero, and disable error reporting */
-    optind = 0;
-    opterr = 0;
+  /* reset getopts internal option-index to zero, and disable error reporting */
+  optind = 0;
+  opterr = 0;
 
-    /* fetch and process args using getopt_long */
+  /* fetch and process args using getopt_long */
 #ifdef ARG_LONG_ONLY
-    while ((copt = getopt_long_only(argc, argv, shortoptions, longoptions->options, NULL)) != -1) {
+  while ((copt = getopt_long_only(argc, argv, shortoptions,
+                                  longoptions->options, NULL)) != -1) {
 #else
-    while ((copt = getopt_long(argc, argv, shortoptions, longoptions->options, NULL)) != -1) {
+  while ((copt = getopt_long(argc, argv, shortoptions, longoptions->options,
+                             NULL)) != -1) {
 #endif
-        /*
-           printf("optarg='%s'\n",optarg);
-           printf("optind=%d\n",optind);
-           printf("copt=%c\n",(char)copt);
-           printf("optopt=%c (%d)\n",optopt, (int)(optopt));
-         */
-        switch (copt) {
-            case 0: {
-                int tabindex = longoptions->getoptval;
-                void* parent = table[tabindex]->parent;
-                /*printf("long option detected from argtable[%d]\n", tabindex);*/
-                if (optarg && optarg[0] == 0 && (table[tabindex]->flag & ARG_HASVALUE)) {
-                    /* printf(": long option %s requires an argument\n",argv[optind-1]); */
-                    arg_register_error(endtable, endtable, ARG_EMISSARG, argv[optind - 1]);
-                    /* continue to scan the (empty) argument value to enforce argument count checking */
-                }
-                if (table[tabindex]->scanfn) {
-                    int errorcode = table[tabindex]->scanfn(parent, optarg);
-                    if (errorcode != 0)
-                        arg_register_error(endtable, parent, errorcode, optarg);
-                }
-            } break;
-
-            case '?':
-                /*
-                 * getopt_long() found an unrecognised short option.
-                 * if it was a short option its value is in optopt
-                 * if it was a long option then optopt=0
-                 */
-                switch (optopt) {
-                    case 0:
-                        /*printf("?0 unrecognised long option %s\n",argv[optind-1]);*/
-                        arg_register_error(endtable, endtable, ARG_ELONGOPT, argv[optind - 1]);
-                        break;
-                    default:
-                        /*printf("?* unrecognised short option '%c'\n",optopt);*/
-                        arg_register_error(endtable, endtable, optopt, NULL);
-                        break;
-                }
-                break;
-
-            case ':':
-                /*
-                 * getopt_long() found an option with its argument missing.
-                 */
-                /*printf(": option %s requires an argument\n",argv[optind-1]); */
-                arg_register_error(endtable, endtable, ARG_EMISSARG, argv[optind - 1]);
-                break;
-
-            default: {
-                /* getopt_long() found a valid short option */
-                int tabindex = find_shortoption(table, (char)copt);
-                /*printf("short option detected from argtable[%d]\n", tabindex);*/
-                if (tabindex == -1) {
-                    /* should never get here - but handle it just in case */
-                    /*printf("unrecognised short option %d\n",copt);*/
-                    arg_register_error(endtable, endtable, copt, NULL);
-                } else {
-                    if (table[tabindex]->scanfn) {
-                        void* parent = table[tabindex]->parent;
-                        int errorcode = table[tabindex]->scanfn(parent, optarg);
-                        if (errorcode != 0)
-                            arg_register_error(endtable, parent, errorcode, optarg);
-                    }
-                }
-                break;
-            }
-        }
-    }
-
-    xfree(shortoptions);
-    xfree(longoptions);
-}
-
-static void arg_parse_untagged(int argc, char** argv, struct arg_hdr** table, struct arg_end* endtable) {
-    int tabindex = 0;
-    int errorlast = 0;
-    const char* optarglast = NULL;
-    void* parentlast = NULL;
-
-    /*printf("arg_parse_untagged(%d,%p,%p,%p)\n",argc,argv,table,endtable);*/
-    while (!(table[tabindex]->flag & ARG_TERMINATOR)) {
-        void* parent;
-        int errorcode;
-
-        /* if we have exhausted our argv[optind] entries then we have finished */
-        if (optind >= argc) {
-            /*printf("arg_parse_untagged(): argv[] exhausted\n");*/
-            return;
-        }
-
-        /* skip table entries with non-null long or short options (they are not untagged entries) */
-        if (table[tabindex]->longopts || table[tabindex]->shortopts) {
-            /*printf("arg_parse_untagged(): skipping argtable[%d] (tagged argument)\n",tabindex);*/
-            tabindex++;
-            continue;
-        }
-
-        /* skip table entries with NULL scanfn */
-        if (!(table[tabindex]->scanfn)) {
-            /*printf("arg_parse_untagged(): skipping argtable[%d] (NULL scanfn)\n",tabindex);*/
-            tabindex++;
-            continue;
-        }
-
-        /* attempt to scan the current argv[optind] with the current     */
-        /* table[tabindex] entry. If it succeeds then keep it, otherwise */
-        /* try again with the next table[] entry.                        */
-        parent = table[tabindex]->parent;
-        errorcode = table[tabindex]->scanfn(parent, argv[optind]);
-        if (errorcode == 0) {
-            /* success, move onto next argv[optind] but stay with same table[tabindex] */
-            /*printf("arg_parse_untagged(): argtable[%d] successfully matched\n",tabindex);*/
-            optind++;
-
-            /* clear the last tentative error */
-            errorlast = 0;
-        } else {
-            /* failure, try same argv[optind] with next table[tabindex] entry */
-            /*printf("arg_parse_untagged(): argtable[%d] failed match\n",tabindex);*/
-            tabindex++;
-
-            /* remember this as a tentative error we may wish to reinstate later */
-            errorlast = errorcode;
-            optarglast = argv[optind];
-            parentlast = parent;
-        }
-    }
-
-    /* if a tenative error still remains at this point then register it as a proper error */
-    if (errorlast) {
-        arg_register_error(endtable, parentlast, errorlast, optarglast);
-        optind++;
-    }
-
-    /* only get here when not all argv[] entries were consumed */
-    /* register an error for each unused argv[] entry */
-    while (optind < argc) {
-        /*printf("arg_parse_untagged(): argv[%d]=\"%s\" not consumed\n",optind,argv[optind]);*/
-        arg_register_error(endtable, endtable, ARG_ENOMATCH, argv[optind++]);
-    }
-
-    return;
-}
-
-static void arg_parse_check(struct arg_hdr** table, struct arg_end* endtable) {
-    int tabindex = 0;
-    /* printf("arg_parse_check()\n"); */
-    do {
-        if (table[tabindex]->checkfn) {
-            void* parent = table[tabindex]->parent;
-            int errorcode = table[tabindex]->checkfn(parent);
-            if (errorcode != 0)
-                arg_register_error(endtable, parent, errorcode, NULL);
-        }
-    } while (!(table[tabindex++]->flag & ARG_TERMINATOR));
-}
-
-static void arg_reset(void** argtable) {
-    struct arg_hdr** table = (struct arg_hdr**)argtable;
-    int tabindex = 0;
-    /*printf("arg_reset(%p)\n",argtable);*/
-    do {
-        if (table[tabindex]->resetfn)
-            table[tabindex]->resetfn(table[tabindex]->parent);
-    } while (!(table[tabindex++]->flag & ARG_TERMINATOR));
-}
-
-int arg_parse(int argc, char** argv, void** argtable) {
-    struct arg_hdr** table = (struct arg_hdr**)argtable;
-    struct arg_end* endtable;
-    int endindex;
-    char** argvcopy = NULL;
-    int i;
-
-    /*printf("arg_parse(%d,%p,%p)\n",argc,argv,argtable);*/
-
-    /* reset any argtable data from previous invocations */
-    arg_reset(argtable);
-
-    /* locate the first end-of-table marker within the array */
-    endindex = arg_endindex(table);
-    endtable = (struct arg_end*)table[endindex];
-
-    /* Special case of argc==0.  This can occur on Texas Instruments DSP. */
-    /* Failure to trap this case results in an unwanted NULL result from  */
-    /* the malloc for argvcopy (next code block).                         */
-    if (argc == 0) {
-        /* We must still perform post-parse checks despite the absence of command line arguments */
-        arg_parse_check(table, endtable);
-
-        /* Now we are finished */
-        return endtable->count;
-    }
-
-    argvcopy = (char**)xmalloc(sizeof(char*) * (size_t)(argc + 1));
-
     /*
-        Fill in the local copy of argv[]. We need a local copy
-        because getopt rearranges argv[] which adversely affects
-        susbsequent parsing attempts.
-        */
-    for (i = 0; i < argc; i++)
-        argvcopy[i] = argv[i];
+       printf("optarg='%s'\n",optarg);
+       printf("optind=%d\n",optind);
+       printf("copt=%c\n",(char)copt);
+       printf("optopt=%c (%d)\n",optopt, (int)(optopt));
+     */
+    switch (copt) {
+    case 0: {
+      int tabindex = longoptions->getoptval;
+      void *parent = table[tabindex]->parent;
+      /*printf("long option detected from argtable[%d]\n", tabindex);*/
+      if (optarg && optarg[0] == 0 && (table[tabindex]->flag & ARG_HASVALUE)) {
+        /* printf(": long option %s requires an argument\n",argv[optind-1]); */
+        arg_register_error(endtable, endtable, ARG_EMISSARG, argv[optind - 1]);
+        /* continue to scan the (empty) argument value to enforce argument count
+         * checking */
+      }
+      if (table[tabindex]->scanfn) {
+        int errorcode = table[tabindex]->scanfn(parent, optarg);
+        if (errorcode != 0)
+          arg_register_error(endtable, parent, errorcode, optarg);
+      }
+    } break;
 
-    argvcopy[argc] = NULL;
+    case '?':
+      /*
+       * getopt_long() found an unrecognised short option.
+       * if it was a short option its value is in optopt
+       * if it was a long option then optopt=0
+       */
+      switch (optopt) {
+      case 0:
+        /*printf("?0 unrecognised long option %s\n",argv[optind-1]);*/
+        arg_register_error(endtable, endtable, ARG_ELONGOPT, argv[optind - 1]);
+        break;
+      default:
+        /*printf("?* unrecognised short option '%c'\n",optopt);*/
+        arg_register_error(endtable, endtable, optopt, NULL);
+        break;
+      }
+      break;
 
-    /* parse the command line (local copy) for tagged options */
-    arg_parse_tagged(argc, argvcopy, table, endtable);
+    case ':':
+      /*
+       * getopt_long() found an option with its argument missing.
+       */
+      /*printf(": option %s requires an argument\n",argv[optind-1]); */
+      arg_register_error(endtable, endtable, ARG_EMISSARG, argv[optind - 1]);
+      break;
 
-    /* parse the command line (local copy) for untagged options */
-    arg_parse_untagged(argc, argvcopy, table, endtable);
+    default: {
+      /* getopt_long() found a valid short option */
+      int tabindex = find_shortoption(table, (char)copt);
+      /*printf("short option detected from argtable[%d]\n", tabindex);*/
+      if (tabindex == -1) {
+        /* should never get here - but handle it just in case */
+        /*printf("unrecognised short option %d\n",copt);*/
+        arg_register_error(endtable, endtable, copt, NULL);
+      } else {
+        if (table[tabindex]->scanfn) {
+          void *parent = table[tabindex]->parent;
+          int errorcode = table[tabindex]->scanfn(parent, optarg);
+          if (errorcode != 0)
+            arg_register_error(endtable, parent, errorcode, optarg);
+        }
+      }
+      break;
+    }
+    }
+  }
 
-    /* if no errors so far then perform post-parse checks otherwise dont bother */
-    if (endtable->count == 0)
-        arg_parse_check(table, endtable);
+  xfree(shortoptions);
+  xfree(longoptions);
+}
 
-    /* release the local copt of argv[] */
-    xfree(argvcopy);
+static void arg_parse_untagged(int argc, char **argv, struct arg_hdr **table,
+                               struct arg_end *endtable) {
+  int tabindex = 0;
+  int errorlast = 0;
+  const char *optarglast = NULL;
+  void *parentlast = NULL;
 
+  /*printf("arg_parse_untagged(%d,%p,%p,%p)\n",argc,argv,table,endtable);*/
+  while (!(table[tabindex]->flag & ARG_TERMINATOR)) {
+    void *parent;
+    int errorcode;
+
+    /* if we have exhausted our argv[optind] entries then we have finished */
+    if (optind >= argc) {
+      /*printf("arg_parse_untagged(): argv[] exhausted\n");*/
+      return;
+    }
+
+    /* skip table entries with non-null long or short options (they are not
+     * untagged entries) */
+    if (table[tabindex]->longopts || table[tabindex]->shortopts) {
+      /*printf("arg_parse_untagged(): skipping argtable[%d] (tagged
+       * argument)\n",tabindex);*/
+      tabindex++;
+      continue;
+    }
+
+    /* skip table entries with NULL scanfn */
+    if (!(table[tabindex]->scanfn)) {
+      /*printf("arg_parse_untagged(): skipping argtable[%d] (NULL
+       * scanfn)\n",tabindex);*/
+      tabindex++;
+      continue;
+    }
+
+    /* attempt to scan the current argv[optind] with the current     */
+    /* table[tabindex] entry. If it succeeds then keep it, otherwise */
+    /* try again with the next table[] entry.                        */
+    parent = table[tabindex]->parent;
+    errorcode = table[tabindex]->scanfn(parent, argv[optind]);
+    if (errorcode == 0) {
+      /* success, move onto next argv[optind] but stay with same table[tabindex]
+       */
+      /*printf("arg_parse_untagged(): argtable[%d] successfully
+       * matched\n",tabindex);*/
+      optind++;
+
+      /* clear the last tentative error */
+      errorlast = 0;
+    } else {
+      /* failure, try same argv[optind] with next table[tabindex] entry */
+      /*printf("arg_parse_untagged(): argtable[%d] failed match\n",tabindex);*/
+      tabindex++;
+
+      /* remember this as a tentative error we may wish to reinstate later */
+      errorlast = errorcode;
+      optarglast = argv[optind];
+      parentlast = parent;
+    }
+  }
+
+  /* if a tenative error still remains at this point then register it as a
+   * proper error */
+  if (errorlast) {
+    arg_register_error(endtable, parentlast, errorlast, optarglast);
+    optind++;
+  }
+
+  /* only get here when not all argv[] entries were consumed */
+  /* register an error for each unused argv[] entry */
+  while (optind < argc) {
+    /*printf("arg_parse_untagged(): argv[%d]=\"%s\" not
+     * consumed\n",optind,argv[optind]);*/
+    arg_register_error(endtable, endtable, ARG_ENOMATCH, argv[optind++]);
+  }
+
+  return;
+}
+
+static void arg_parse_check(struct arg_hdr **table, struct arg_end *endtable) {
+  int tabindex = 0;
+  /* printf("arg_parse_check()\n"); */
+  do {
+    if (table[tabindex]->checkfn) {
+      void *parent = table[tabindex]->parent;
+      int errorcode = table[tabindex]->checkfn(parent);
+      if (errorcode != 0)
+        arg_register_error(endtable, parent, errorcode, NULL);
+    }
+  } while (!(table[tabindex++]->flag & ARG_TERMINATOR));
+}
+
+static void arg_reset(void **argtable) {
+  struct arg_hdr **table = (struct arg_hdr **)argtable;
+  int tabindex = 0;
+  /*printf("arg_reset(%p)\n",argtable);*/
+  do {
+    if (table[tabindex]->resetfn)
+      table[tabindex]->resetfn(table[tabindex]->parent);
+  } while (!(table[tabindex++]->flag & ARG_TERMINATOR));
+}
+
+int arg_parse(int argc, char **argv, void **argtable) {
+  struct arg_hdr **table = (struct arg_hdr **)argtable;
+  struct arg_end *endtable;
+  int endindex;
+  char **argvcopy = NULL;
+  int i;
+
+  /*printf("arg_parse(%d,%p,%p)\n",argc,argv,argtable);*/
+
+  /* reset any argtable data from previous invocations */
+  arg_reset(argtable);
+
+  /* locate the first end-of-table marker within the array */
+  endindex = arg_endindex(table);
+  endtable = (struct arg_end *)table[endindex];
+
+  /* Special case of argc==0.  This can occur on Texas Instruments DSP. */
+  /* Failure to trap this case results in an unwanted NULL result from  */
+  /* the malloc for argvcopy (next code block).                         */
+  if (argc == 0) {
+    /* We must still perform post-parse checks despite the absence of command
+     * line arguments */
+    arg_parse_check(table, endtable);
+
+    /* Now we are finished */
     return endtable->count;
+  }
+
+  argvcopy = (char **)xmalloc(sizeof(char *) * (size_t)(argc + 1));
+
+  /*
+      Fill in the local copy of argv[]. We need a local copy
+      because getopt rearranges argv[] which adversely affects
+      susbsequent parsing attempts.
+      */
+  for (i = 0; i < argc; i++)
+    argvcopy[i] = argv[i];
+
+  argvcopy[argc] = NULL;
+
+  /* parse the command line (local copy) for tagged options */
+  arg_parse_tagged(argc, argvcopy, table, endtable);
+
+  /* parse the command line (local copy) for untagged options */
+  arg_parse_untagged(argc, argvcopy, table, endtable);
+
+  /* if no errors so far then perform post-parse checks otherwise dont bother */
+  if (endtable->count == 0)
+    arg_parse_check(table, endtable);
+
+  /* release the local copt of argv[] */
+  xfree(argvcopy);
+
+  return endtable->count;
 }
 
 /*
@@ -5429,161 +5576,173 @@ int arg_parse(int argc, char** argv, void** argtable) {
  *   dest[] == "goodbye cruel world!"
  *   ndest  == 10
  */
-static void arg_cat(char** pdest, const char* src, size_t* pndest) {
-    char* dest = *pdest;
-    char* end = dest + *pndest;
+static void arg_cat(char **pdest, const char *src, size_t *pndest) {
+  char *dest = *pdest;
+  char *end = dest + *pndest;
 
-    /*locate null terminator of dest string */
-    while (dest < end-1 && *dest != 0)
-        dest++;
+  /*locate null terminator of dest string */
+  while (dest < end - 1 && *dest != 0)
+    dest++;
 
-    /* concat src string to dest string */
-    while (dest < end-1 && *src != 0)
-        *dest++ = *src++;
+  /* concat src string to dest string */
+  while (dest < end - 1 && *src != 0)
+    *dest++ = *src++;
 
-    /* null terminate dest string */
-    *dest = 0;
+  /* null terminate dest string */
+  *dest = 0;
 
-    /* update *pdest and *pndest */
-    *pndest = (size_t)(end - dest);
-    *pdest = dest;
+  /* update *pdest and *pndest */
+  *pndest = (size_t)(end - dest);
+  *pdest = dest;
 }
 
-static void arg_cat_option(char* dest, size_t ndest, const char* shortopts, const char* longopts, const char* datatype, int optvalue) {
-    if (shortopts) {
-        char option[3];
+static void arg_cat_option(char *dest, size_t ndest, const char *shortopts,
+                           const char *longopts, const char *datatype,
+                           int optvalue) {
+  if (shortopts) {
+    char option[3];
 
-        /* note: option array[] is initialiazed dynamically here to satisfy   */
-        /* a deficiency in the watcom compiler wrt static array initializers. */
-        option[0] = '-';
-        option[1] = shortopts[0];
-        option[2] = 0;
+    /* note: option array[] is initialiazed dynamically here to satisfy   */
+    /* a deficiency in the watcom compiler wrt static array initializers. */
+    option[0] = '-';
+    option[1] = shortopts[0];
+    option[2] = 0;
 
-        arg_cat(&dest, option, &ndest);
-        if (datatype) {
-            arg_cat(&dest, " ", &ndest);
-            if (optvalue) {
-                arg_cat(&dest, "[", &ndest);
-                arg_cat(&dest, datatype, &ndest);
-                arg_cat(&dest, "]", &ndest);
-            } else
-                arg_cat(&dest, datatype, &ndest);
-        }
-    } else if (longopts) {
-        size_t ncspn;
+    arg_cat(&dest, option, &ndest);
+    if (datatype) {
+      arg_cat(&dest, " ", &ndest);
+      if (optvalue) {
+        arg_cat(&dest, "[", &ndest);
+        arg_cat(&dest, datatype, &ndest);
+        arg_cat(&dest, "]", &ndest);
+      } else
+        arg_cat(&dest, datatype, &ndest);
+    }
+  } else if (longopts) {
+    size_t ncspn;
 
-        /* add "--" tag prefix */
-        arg_cat(&dest, "--", &ndest);
+    /* add "--" tag prefix */
+    arg_cat(&dest, "--", &ndest);
 
-        /* add comma separated option tag */
-        ncspn = strcspn(longopts, ",");
-#if (defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) || (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__))
-        strncat_s(dest, ndest, longopts, (ncspn < ndest) ? ncspn : ndest);
+    /* add comma separated option tag */
+    ncspn = strcspn(longopts, ",");
+#if (defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) ||         \
+    (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__))
+    strncat_s(dest, ndest, longopts, (ncspn < ndest) ? ncspn : ndest);
 #else
-        strncat(dest, longopts, (ncspn < ndest) ? ncspn : ndest);
+    strncat(dest, longopts, (ncspn < ndest) ? ncspn : ndest);
 #endif
-
-        if (datatype) {
-            arg_cat(&dest, "=", &ndest);
-            if (optvalue) {
-                arg_cat(&dest, "[", &ndest);
-                arg_cat(&dest, datatype, &ndest);
-                arg_cat(&dest, "]", &ndest);
-            } else
-                arg_cat(&dest, datatype, &ndest);
-        }
-    } else if (datatype) {
-        if (optvalue) {
-            arg_cat(&dest, "[", &ndest);
-            arg_cat(&dest, datatype, &ndest);
-            arg_cat(&dest, "]", &ndest);
-        } else
-            arg_cat(&dest, datatype, &ndest);
-    }
-}
-
-static void arg_cat_optionv(char* dest, size_t ndest, const char* shortopts, const char* longopts, const char* datatype, int optvalue, const char* separator) {
-    separator = separator ? separator : "";
-
-    if (shortopts) {
-        const char* c = shortopts;
-        while (*c) {
-            /* "-a|-b|-c" */
-            char shortopt[3];
-
-            /* note: shortopt array[] is initialiazed dynamically here to satisfy */
-            /* a deficiency in the watcom compiler wrt static array initializers. */
-            shortopt[0] = '-';
-            shortopt[1] = *c;
-            shortopt[2] = 0;
-
-            arg_cat(&dest, shortopt, &ndest);
-            if (*++c)
-                arg_cat(&dest, separator, &ndest);
-        }
-    }
-
-    /* put separator between long opts and short opts */
-    if (shortopts && longopts)
-        arg_cat(&dest, separator, &ndest);
-
-    if (longopts) {
-        const char* c = longopts;
-        while (*c) {
-            size_t ncspn;
-
-            /* add "--" tag prefix */
-            arg_cat(&dest, "--", &ndest);
-
-            /* add comma separated option tag */
-            ncspn = strcspn(c, ",");
-#if (defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) || (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__))
-            strncat_s(dest, ndest, c, (ncspn < ndest) ? ncspn : ndest);
-#else
-            strncat(dest, c, (ncspn < ndest) ? ncspn : ndest);
-#endif
-            c += ncspn;
-
-            /* add given separator in place of comma */
-            if (*c == ',') {
-                arg_cat(&dest, separator, &ndest);
-                c++;
-            }
-        }
-    }
 
     if (datatype) {
-        if (longopts)
-            arg_cat(&dest, "=", &ndest);
-        else if (shortopts)
-            arg_cat(&dest, " ", &ndest);
-
-        if (optvalue) {
-            arg_cat(&dest, "[", &ndest);
-            arg_cat(&dest, datatype, &ndest);
-            arg_cat(&dest, "]", &ndest);
-        } else
-            arg_cat(&dest, datatype, &ndest);
+      arg_cat(&dest, "=", &ndest);
+      if (optvalue) {
+        arg_cat(&dest, "[", &ndest);
+        arg_cat(&dest, datatype, &ndest);
+        arg_cat(&dest, "]", &ndest);
+      } else
+        arg_cat(&dest, datatype, &ndest);
     }
+  } else if (datatype) {
+    if (optvalue) {
+      arg_cat(&dest, "[", &ndest);
+      arg_cat(&dest, datatype, &ndest);
+      arg_cat(&dest, "]", &ndest);
+    } else
+      arg_cat(&dest, datatype, &ndest);
+  }
 }
 
-void arg_print_option_ds(arg_dstr_t ds, const char* shortopts, const char* longopts, const char* datatype, const char* suffix) {
-    char syntax[200] = "";
-    suffix = suffix ? suffix : "";
+static void arg_cat_optionv(char *dest, size_t ndest, const char *shortopts,
+                            const char *longopts, const char *datatype,
+                            int optvalue, const char *separator) {
+  separator = separator ? separator : "";
 
-    /* there is no way of passing the proper optvalue for optional argument values here, so we must ignore it */
-    arg_cat_optionv(syntax, sizeof(syntax) - 1, shortopts, longopts, datatype, 0, "|");
+  if (shortopts) {
+    const char *c = shortopts;
+    while (*c) {
+      /* "-a|-b|-c" */
+      char shortopt[3];
 
-    arg_dstr_cat(ds, syntax);
-    arg_dstr_cat(ds, (char*)suffix);
+      /* note: shortopt array[] is initialiazed dynamically here to satisfy */
+      /* a deficiency in the watcom compiler wrt static array initializers. */
+      shortopt[0] = '-';
+      shortopt[1] = *c;
+      shortopt[2] = 0;
+
+      arg_cat(&dest, shortopt, &ndest);
+      if (*++c)
+        arg_cat(&dest, separator, &ndest);
+    }
+  }
+
+  /* put separator between long opts and short opts */
+  if (shortopts && longopts)
+    arg_cat(&dest, separator, &ndest);
+
+  if (longopts) {
+    const char *c = longopts;
+    while (*c) {
+      size_t ncspn;
+
+      /* add "--" tag prefix */
+      arg_cat(&dest, "--", &ndest);
+
+      /* add comma separated option tag */
+      ncspn = strcspn(c, ",");
+#if (defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) ||         \
+    (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__))
+      strncat_s(dest, ndest, c, (ncspn < ndest) ? ncspn : ndest);
+#else
+      strncat(dest, c, (ncspn < ndest) ? ncspn : ndest);
+#endif
+      c += ncspn;
+
+      /* add given separator in place of comma */
+      if (*c == ',') {
+        arg_cat(&dest, separator, &ndest);
+        c++;
+      }
+    }
+  }
+
+  if (datatype) {
+    if (longopts)
+      arg_cat(&dest, "=", &ndest);
+    else if (shortopts)
+      arg_cat(&dest, " ", &ndest);
+
+    if (optvalue) {
+      arg_cat(&dest, "[", &ndest);
+      arg_cat(&dest, datatype, &ndest);
+      arg_cat(&dest, "]", &ndest);
+    } else
+      arg_cat(&dest, datatype, &ndest);
+  }
 }
 
-/* this function should be deprecated because it doesn't consider optional argument values (ARG_HASOPTVALUE) */
-void arg_print_option(FILE* fp, const char* shortopts, const char* longopts, const char* datatype, const char* suffix) {
-    arg_dstr_t ds = arg_dstr_create();
-    arg_print_option_ds(ds, shortopts, longopts, datatype, suffix);
-    fputs(arg_dstr_cstr(ds), fp);
-    arg_dstr_destroy(ds);
+void arg_print_option_ds(arg_dstr_t ds, const char *shortopts,
+                         const char *longopts, const char *datatype,
+                         const char *suffix) {
+  char syntax[200] = "";
+  suffix = suffix ? suffix : "";
+
+  /* there is no way of passing the proper optvalue for optional argument values
+   * here, so we must ignore it */
+  arg_cat_optionv(syntax, sizeof(syntax) - 1, shortopts, longopts, datatype, 0,
+                  "|");
+
+  arg_dstr_cat(ds, syntax);
+  arg_dstr_cat(ds, (char *)suffix);
+}
+
+/* this function should be deprecated because it doesn't consider optional
+ * argument values (ARG_HASOPTVALUE) */
+void arg_print_option(FILE *fp, const char *shortopts, const char *longopts,
+                      const char *datatype, const char *suffix) {
+  arg_dstr_t ds = arg_dstr_create();
+  arg_print_option_ds(ds, shortopts, longopts, datatype, suffix);
+  fputs(arg_dstr_cstr(ds), fp);
+  arg_dstr_destroy(ds);
 }
 
 /*
@@ -5591,201 +5750,214 @@ void arg_print_option(FILE* fp, const char* shortopts, const char* longopts, con
  * do not take argument values are presented in abbreviated form, as
  * in: -xvfsd, or -xvf[sd], or [-xvsfd]
  */
-static void arg_print_gnuswitch_ds(arg_dstr_t ds, struct arg_hdr** table) {
-    int tabindex;
-    const char* format1 = " -%c";
-    const char* format2 = " [-%c";
-    const char* suffix = "";
+static void arg_print_gnuswitch_ds(arg_dstr_t ds, struct arg_hdr **table) {
+  int tabindex;
+  const char *format1 = " -%c";
+  const char *format2 = " [-%c";
+  const char *suffix = "";
 
-    /* print all mandatory switches that are without argument values */
-    for (tabindex = 0; table[tabindex] && !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
-        /* skip optional options */
-        if (table[tabindex]->mincount < 1)
-            continue;
+  /* print all mandatory switches that are without argument values */
+  for (tabindex = 0;
+       table[tabindex] && !(table[tabindex]->flag & ARG_TERMINATOR);
+       tabindex++) {
+    /* skip optional options */
+    if (table[tabindex]->mincount < 1)
+      continue;
 
-        /* skip non-short options */
-        if (table[tabindex]->shortopts == NULL)
-            continue;
+    /* skip non-short options */
+    if (table[tabindex]->shortopts == NULL)
+      continue;
 
-        /* skip options that take argument values */
-        if (table[tabindex]->flag & ARG_HASVALUE)
-            continue;
+    /* skip options that take argument values */
+    if (table[tabindex]->flag & ARG_HASVALUE)
+      continue;
 
-        /* print the short option (only the first short option char, ignore multiple choices)*/
-        arg_dstr_catf(ds, format1, table[tabindex]->shortopts[0]);
-        format1 = "%c";
-        format2 = "[%c";
-    }
+    /* print the short option (only the first short option char, ignore multiple
+     * choices)*/
+    arg_dstr_catf(ds, format1, table[tabindex]->shortopts[0]);
+    format1 = "%c";
+    format2 = "[%c";
+  }
 
-    /* print all optional switches that are without argument values */
-    for (tabindex = 0; table[tabindex] && !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
-        /* skip mandatory args */
-        if (table[tabindex]->mincount > 0)
-            continue;
+  /* print all optional switches that are without argument values */
+  for (tabindex = 0;
+       table[tabindex] && !(table[tabindex]->flag & ARG_TERMINATOR);
+       tabindex++) {
+    /* skip mandatory args */
+    if (table[tabindex]->mincount > 0)
+      continue;
 
-        /* skip args without short options */
-        if (table[tabindex]->shortopts == NULL)
-            continue;
+    /* skip args without short options */
+    if (table[tabindex]->shortopts == NULL)
+      continue;
 
-        /* skip args with values */
-        if (table[tabindex]->flag & ARG_HASVALUE)
-            continue;
+    /* skip args with values */
+    if (table[tabindex]->flag & ARG_HASVALUE)
+      continue;
 
-        /* print first short option */
-        arg_dstr_catf(ds, format2, table[tabindex]->shortopts[0]);
-        format2 = "%c";
-        suffix = "]";
-    }
+    /* print first short option */
+    arg_dstr_catf(ds, format2, table[tabindex]->shortopts[0]);
+    format2 = "%c";
+    suffix = "]";
+  }
 
-    arg_dstr_catf(ds, "%s", suffix);
+  arg_dstr_catf(ds, "%s", suffix);
 }
 
-void arg_print_syntax_ds(arg_dstr_t ds, void** argtable, const char* suffix) {
-    struct arg_hdr** table = (struct arg_hdr**)argtable;
-    int i, tabindex;
+void arg_print_syntax_ds(arg_dstr_t ds, void **argtable, const char *suffix) {
+  struct arg_hdr **table = (struct arg_hdr **)argtable;
+  int i, tabindex;
 
-    /* print GNU style [OPTION] string */
-    arg_print_gnuswitch_ds(ds, table);
+  /* print GNU style [OPTION] string */
+  arg_print_gnuswitch_ds(ds, table);
 
-    /* print remaining options in abbreviated style */
-    for (tabindex = 0; table[tabindex] && !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
-        char syntax[200] = "";
-        const char *shortopts, *longopts, *datatype;
+  /* print remaining options in abbreviated style */
+  for (tabindex = 0;
+       table[tabindex] && !(table[tabindex]->flag & ARG_TERMINATOR);
+       tabindex++) {
+    char syntax[200] = "";
+    const char *shortopts, *longopts, *datatype;
 
-        /* skip short options without arg values (they were printed by arg_print_gnu_switch) */
-        if (table[tabindex]->shortopts && !(table[tabindex]->flag & ARG_HASVALUE))
-            continue;
+    /* skip short options without arg values (they were printed by
+     * arg_print_gnu_switch) */
+    if (table[tabindex]->shortopts && !(table[tabindex]->flag & ARG_HASVALUE))
+      continue;
 
-        shortopts = table[tabindex]->shortopts;
-        longopts = table[tabindex]->longopts;
-        datatype = table[tabindex]->datatype;
-        arg_cat_option(syntax, sizeof(syntax) - 1, shortopts, longopts, datatype, table[tabindex]->flag & ARG_HASOPTVALUE);
+    shortopts = table[tabindex]->shortopts;
+    longopts = table[tabindex]->longopts;
+    datatype = table[tabindex]->datatype;
+    arg_cat_option(syntax, sizeof(syntax) - 1, shortopts, longopts, datatype,
+                   table[tabindex]->flag & ARG_HASOPTVALUE);
 
-        if (strlen(syntax) > 0) {
-            /* print mandatory instances of this option */
-            for (i = 0; i < table[tabindex]->mincount; i++) {
-                arg_dstr_cat(ds, " ");
-                arg_dstr_cat(ds, syntax);
-            }
+    if (strlen(syntax) > 0) {
+      /* print mandatory instances of this option */
+      for (i = 0; i < table[tabindex]->mincount; i++) {
+        arg_dstr_cat(ds, " ");
+        arg_dstr_cat(ds, syntax);
+      }
 
-            /* print optional instances enclosed in "[..]" */
-            switch (table[tabindex]->maxcount - table[tabindex]->mincount) {
-                case 0:
-                    break;
-                case 1:
-                    arg_dstr_cat(ds, " [");
-                    arg_dstr_cat(ds, syntax);
-                    arg_dstr_cat(ds, "]");
-                    break;
-                case 2:
-                    arg_dstr_cat(ds, " [");
-                    arg_dstr_cat(ds, syntax);
-                    arg_dstr_cat(ds, "]");
-                    arg_dstr_cat(ds, " [");
-                    arg_dstr_cat(ds, syntax);
-                    arg_dstr_cat(ds, "]");
-                    break;
-                default:
-                    arg_dstr_cat(ds, " [");
-                    arg_dstr_cat(ds, syntax);
-                    arg_dstr_cat(ds, "]...");
-                    break;
-            }
-        }
+      /* print optional instances enclosed in "[..]" */
+      switch (table[tabindex]->maxcount - table[tabindex]->mincount) {
+      case 0:
+        break;
+      case 1:
+        arg_dstr_cat(ds, " [");
+        arg_dstr_cat(ds, syntax);
+        arg_dstr_cat(ds, "]");
+        break;
+      case 2:
+        arg_dstr_cat(ds, " [");
+        arg_dstr_cat(ds, syntax);
+        arg_dstr_cat(ds, "]");
+        arg_dstr_cat(ds, " [");
+        arg_dstr_cat(ds, syntax);
+        arg_dstr_cat(ds, "]");
+        break;
+      default:
+        arg_dstr_cat(ds, " [");
+        arg_dstr_cat(ds, syntax);
+        arg_dstr_cat(ds, "]...");
+        break;
+      }
     }
+  }
 
-    if (suffix) {
-        arg_dstr_cat(ds, (char*)suffix);
-    }
+  if (suffix) {
+    arg_dstr_cat(ds, (char *)suffix);
+  }
 }
 
-void arg_print_syntax(FILE* fp, void** argtable, const char* suffix) {
-    arg_dstr_t ds = arg_dstr_create();
-    arg_print_syntax_ds(ds, argtable, suffix);
-    fputs(arg_dstr_cstr(ds), fp);
-    arg_dstr_destroy(ds);
+void arg_print_syntax(FILE *fp, void **argtable, const char *suffix) {
+  arg_dstr_t ds = arg_dstr_create();
+  arg_print_syntax_ds(ds, argtable, suffix);
+  fputs(arg_dstr_cstr(ds), fp);
+  arg_dstr_destroy(ds);
 }
 
-void arg_print_syntaxv_ds(arg_dstr_t ds, void** argtable, const char* suffix) {
-    struct arg_hdr** table = (struct arg_hdr**)argtable;
-    int i, tabindex;
+void arg_print_syntaxv_ds(arg_dstr_t ds, void **argtable, const char *suffix) {
+  struct arg_hdr **table = (struct arg_hdr **)argtable;
+  int i, tabindex;
 
-    /* print remaining options in abbreviated style */
-    for (tabindex = 0; table[tabindex] && !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
-        char syntax[200] = "";
-        const char *shortopts, *longopts, *datatype;
+  /* print remaining options in abbreviated style */
+  for (tabindex = 0;
+       table[tabindex] && !(table[tabindex]->flag & ARG_TERMINATOR);
+       tabindex++) {
+    char syntax[200] = "";
+    const char *shortopts, *longopts, *datatype;
 
-        shortopts = table[tabindex]->shortopts;
-        longopts = table[tabindex]->longopts;
-        datatype = table[tabindex]->datatype;
-        arg_cat_optionv(syntax, sizeof(syntax) - 1, shortopts, longopts, datatype, table[tabindex]->flag & ARG_HASOPTVALUE, "|");
+    shortopts = table[tabindex]->shortopts;
+    longopts = table[tabindex]->longopts;
+    datatype = table[tabindex]->datatype;
+    arg_cat_optionv(syntax, sizeof(syntax) - 1, shortopts, longopts, datatype,
+                    table[tabindex]->flag & ARG_HASOPTVALUE, "|");
 
-        /* print mandatory options */
-        for (i = 0; i < table[tabindex]->mincount; i++) {
-            arg_dstr_cat(ds, " ");
-            arg_dstr_cat(ds, syntax);
-        }
-
-        /* print optional args enclosed in "[..]" */
-        switch (table[tabindex]->maxcount - table[tabindex]->mincount) {
-            case 0:
-                break;
-            case 1:
-                arg_dstr_cat(ds, " [");
-                arg_dstr_cat(ds, syntax);
-                arg_dstr_cat(ds, "]");
-                break;
-            case 2:
-                arg_dstr_cat(ds, " [");
-                arg_dstr_cat(ds, syntax);
-                arg_dstr_cat(ds, "]");
-                arg_dstr_cat(ds, " [");
-                arg_dstr_cat(ds, syntax);
-                arg_dstr_cat(ds, "]");
-                break;
-            default:
-                arg_dstr_cat(ds, " [");
-                arg_dstr_cat(ds, syntax);
-                arg_dstr_cat(ds, "]...");
-                break;
-        }
+    /* print mandatory options */
+    for (i = 0; i < table[tabindex]->mincount; i++) {
+      arg_dstr_cat(ds, " ");
+      arg_dstr_cat(ds, syntax);
     }
 
-    if (suffix) {
-        arg_dstr_cat(ds, (char*)suffix);
+    /* print optional args enclosed in "[..]" */
+    switch (table[tabindex]->maxcount - table[tabindex]->mincount) {
+    case 0:
+      break;
+    case 1:
+      arg_dstr_cat(ds, " [");
+      arg_dstr_cat(ds, syntax);
+      arg_dstr_cat(ds, "]");
+      break;
+    case 2:
+      arg_dstr_cat(ds, " [");
+      arg_dstr_cat(ds, syntax);
+      arg_dstr_cat(ds, "]");
+      arg_dstr_cat(ds, " [");
+      arg_dstr_cat(ds, syntax);
+      arg_dstr_cat(ds, "]");
+      break;
+    default:
+      arg_dstr_cat(ds, " [");
+      arg_dstr_cat(ds, syntax);
+      arg_dstr_cat(ds, "]...");
+      break;
     }
+  }
+
+  if (suffix) {
+    arg_dstr_cat(ds, (char *)suffix);
+  }
 }
 
-void arg_print_syntaxv(FILE* fp, void** argtable, const char* suffix) {
-    arg_dstr_t ds = arg_dstr_create();
-    arg_print_syntaxv_ds(ds, argtable, suffix);
-    fputs(arg_dstr_cstr(ds), fp);
-    arg_dstr_destroy(ds);
+void arg_print_syntaxv(FILE *fp, void **argtable, const char *suffix) {
+  arg_dstr_t ds = arg_dstr_create();
+  arg_print_syntaxv_ds(ds, argtable, suffix);
+  fputs(arg_dstr_cstr(ds), fp);
+  arg_dstr_destroy(ds);
 }
 
-void arg_print_glossary_ds(arg_dstr_t ds, void** argtable, const char* format) {
-    struct arg_hdr** table = (struct arg_hdr**)argtable;
-    int tabindex;
+void arg_print_glossary_ds(arg_dstr_t ds, void **argtable, const char *format) {
+  struct arg_hdr **table = (struct arg_hdr **)argtable;
+  int tabindex;
 
-    format = format ? format : "  %-20s %s\n";
-    for (tabindex = 0; !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
-        if (table[tabindex]->glossary) {
-            char syntax[200] = "";
-            const char* shortopts = table[tabindex]->shortopts;
-            const char* longopts = table[tabindex]->longopts;
-            const char* datatype = table[tabindex]->datatype;
-            const char* glossary = table[tabindex]->glossary;
-            arg_cat_optionv(syntax, sizeof(syntax) - 1, shortopts, longopts, datatype, table[tabindex]->flag & ARG_HASOPTVALUE, ", ");
-            arg_dstr_catf(ds, format, syntax, glossary);
-        }
+  format = format ? format : "  %-20s %s\n";
+  for (tabindex = 0; !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
+    if (table[tabindex]->glossary) {
+      char syntax[200] = "";
+      const char *shortopts = table[tabindex]->shortopts;
+      const char *longopts = table[tabindex]->longopts;
+      const char *datatype = table[tabindex]->datatype;
+      const char *glossary = table[tabindex]->glossary;
+      arg_cat_optionv(syntax, sizeof(syntax) - 1, shortopts, longopts, datatype,
+                      table[tabindex]->flag & ARG_HASOPTVALUE, ", ");
+      arg_dstr_catf(ds, format, syntax, glossary);
     }
+  }
 }
 
-void arg_print_glossary(FILE* fp, void** argtable, const char* format) {
-    arg_dstr_t ds = arg_dstr_create();
-    arg_print_glossary_ds(ds, argtable, format);
-    fputs(arg_dstr_cstr(ds), fp);
-    arg_dstr_destroy(ds);
+void arg_print_glossary(FILE *fp, void **argtable, const char *format) {
+  arg_dstr_t ds = arg_dstr_create();
+  arg_print_glossary_ds(ds, argtable, format);
+  fputs(arg_dstr_cstr(ds), fp);
+  arg_dstr_destroy(ds);
 }
 
 /**
@@ -5820,76 +5992,81 @@ void arg_print_glossary(FILE* fp, void** argtable, const char* format) {
  *
  * Author: Uli Fouquet
  */
-static void arg_print_formatted_ds(arg_dstr_t ds, const unsigned lmargin, const unsigned rmargin, const char* text) {
-    const unsigned int textlen = (unsigned int)strlen(text);
-    unsigned int line_start = 0;
-    unsigned int line_end = textlen;
-    const unsigned int colwidth = (rmargin - lmargin) + 1;
+static void arg_print_formatted_ds(arg_dstr_t ds, const unsigned lmargin,
+                                   const unsigned rmargin, const char *text) {
+  const unsigned int textlen = (unsigned int)strlen(text);
+  unsigned int line_start = 0;
+  unsigned int line_end = textlen;
+  const unsigned int colwidth = (rmargin - lmargin) + 1;
 
-    assert(strlen(text) < UINT_MAX);
+  assert(strlen(text) < UINT_MAX);
 
-    /* Someone doesn't like us... */
-    if (line_end < line_start) {
-        arg_dstr_catf(ds, "%s\n", text);
+  /* Someone doesn't like us... */
+  if (line_end < line_start) {
+    arg_dstr_catf(ds, "%s\n", text);
+  }
+
+  while (line_end > line_start) {
+    /* Eat leading white spaces. This is essential because while
+       wrapping lines, there will often be a whitespace at beginning
+       of line. Preserve newlines */
+    while (isspace((int)(*(text + line_start))) &&
+           *(text + line_start) != '\n') {
+      line_start++;
     }
 
-    while (line_end > line_start) {
-        /* Eat leading white spaces. This is essential because while
-           wrapping lines, there will often be a whitespace at beginning
-           of line. Preserve newlines */
-        while (isspace((int)(*(text + line_start))) && *(text + line_start) != '\n') {
-            line_start++;
+    /* Find last whitespace, that fits into line */
+    if (line_end - line_start > colwidth) {
+      line_end = line_start + colwidth;
+
+      while ((line_end > line_start) && !isspace((int)(*(text + line_end)))) {
+        line_end--;
+      }
+
+      /* If no whitespace could be found, eg. the text is one long word, break
+       * the word */
+      if (line_end == line_start) {
+        /* Set line_end to previous value */
+        line_end = line_start + colwidth;
+      } else {
+        /* Consume trailing spaces, except newlines */
+        while ((line_end > line_start) && isspace((int)(*(text + line_end))) &&
+               *(text + line_start) != '\n') {
+          line_end--;
         }
 
-        /* Find last whitespace, that fits into line */
-        if (line_end - line_start > colwidth) {
-            line_end = line_start + colwidth;
+        /* Restore the last non-space character */
+        line_end++;
+      }
+    }
 
-            while ((line_end > line_start) && !isspace((int)(*(text + line_end)))) {
-                line_end--;
-            }
+    /* Output line of text */
+    while (line_start < line_end) {
+      char c = *(text + line_start);
 
-            /* If no whitespace could be found, eg. the text is one long word, break the word */
-            if (line_end == line_start) {
-                /* Set line_end to previous value */
-                line_end = line_start + colwidth;
-            } else {
-                /* Consume trailing spaces, except newlines */
-                while ((line_end > line_start) && isspace((int)(*(text + line_end))) && *(text + line_start) != '\n') {
-                    line_end--;
-                }
+      /* If character is newline stop printing, skip this character, as a
+       * newline will be printed below. */
+      if (c == '\n') {
+        line_start++;
+        break;
+      }
 
-                /* Restore the last non-space character */
-                line_end++;
-            }
-        }
+      arg_dstr_catc(ds, c);
+      line_start++;
+    }
+    arg_dstr_cat(ds, "\n");
 
-        /* Output line of text */
-        while (line_start < line_end) {
-            char c = *(text + line_start);
+    /* Initialize another line */
+    if (line_end < textlen) {
+      unsigned i;
 
-            /* If character is newline stop printing, skip this character, as a newline will be printed below. */
-            if (c == '\n') {
-                line_start++;
-                break;
-            }
+      for (i = 0; i < lmargin; i++) {
+        arg_dstr_cat(ds, " ");
+      }
 
-            arg_dstr_catc(ds, c);
-            line_start++;
-        }
-        arg_dstr_cat(ds, "\n");
-
-        /* Initialize another line */
-        if (line_end < textlen) {
-            unsigned i;
-
-            for (i = 0; i < lmargin; i++) {
-                arg_dstr_cat(ds, " ");
-            }
-
-            line_end = textlen;
-        }
-    } /* lines of text */
+      line_end = textlen;
+    }
+  } /* lines of text */
 }
 
 /**
@@ -5901,121 +6078,124 @@ static void arg_print_formatted_ds(arg_dstr_t ds, const unsigned lmargin, const 
  *
  * Contributed by Uli Fouquet
  */
-void arg_print_glossary_gnu_ds(arg_dstr_t ds, void** argtable) {
-    struct arg_hdr** table = (struct arg_hdr**)argtable;
-    int tabindex;
+void arg_print_glossary_gnu_ds(arg_dstr_t ds, void **argtable) {
+  struct arg_hdr **table = (struct arg_hdr **)argtable;
+  int tabindex;
 
-    for (tabindex = 0; !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
-        if (table[tabindex]->glossary) {
-            char syntax[200] = "";
-            const char* shortopts = table[tabindex]->shortopts;
-            const char* longopts = table[tabindex]->longopts;
-            const char* datatype = table[tabindex]->datatype;
-            const char* glossary = table[tabindex]->glossary;
+  for (tabindex = 0; !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
+    if (table[tabindex]->glossary) {
+      char syntax[200] = "";
+      const char *shortopts = table[tabindex]->shortopts;
+      const char *longopts = table[tabindex]->longopts;
+      const char *datatype = table[tabindex]->datatype;
+      const char *glossary = table[tabindex]->glossary;
 
-            if (!shortopts && longopts) {
-                /* Indent trailing line by 4 spaces... */
-                memset(syntax, ' ', 4);
-                *(syntax + 4) = '\0';
-            }
+      if (!shortopts && longopts) {
+        /* Indent trailing line by 4 spaces... */
+        memset(syntax, ' ', 4);
+        *(syntax + 4) = '\0';
+      }
 
-            arg_cat_optionv(syntax, sizeof(syntax) - 1, shortopts, longopts, datatype, table[tabindex]->flag & ARG_HASOPTVALUE, ", ");
+      arg_cat_optionv(syntax, sizeof(syntax) - 1, shortopts, longopts, datatype,
+                      table[tabindex]->flag & ARG_HASOPTVALUE, ", ");
 
-            /* If syntax fits not into column, print glossary in new line... */
-            if (strlen(syntax) > 25) {
-                arg_dstr_catf(ds, "  %-25s %s\n", syntax, "");
-                *syntax = '\0';
-            }
+      /* If syntax fits not into column, print glossary in new line... */
+      if (strlen(syntax) > 25) {
+        arg_dstr_catf(ds, "  %-25s %s\n", syntax, "");
+        *syntax = '\0';
+      }
 
-            arg_dstr_catf(ds, "  %-25s ", syntax);
-            arg_print_formatted_ds(ds, 28, 79, glossary);
-        }
-    } /* for each table entry */
+      arg_dstr_catf(ds, "  %-25s ", syntax);
+      arg_print_formatted_ds(ds, 28, 79, glossary);
+    }
+  } /* for each table entry */
 
-    arg_dstr_cat(ds, "\n");
+  arg_dstr_cat(ds, "\n");
 }
 
-void arg_print_glossary_gnu(FILE* fp, void** argtable) {
-    arg_dstr_t ds = arg_dstr_create();
-    arg_print_glossary_gnu_ds(ds, argtable);
-    fputs(arg_dstr_cstr(ds), fp);
-    arg_dstr_destroy(ds);
+void arg_print_glossary_gnu(FILE *fp, void **argtable) {
+  arg_dstr_t ds = arg_dstr_create();
+  arg_print_glossary_gnu_ds(ds, argtable);
+  fputs(arg_dstr_cstr(ds), fp);
+  arg_dstr_destroy(ds);
 }
 
 /**
  * Checks the argtable[] array for NULL entries and returns 1
  * if any are found, zero otherwise.
  */
-int arg_nullcheck(void** argtable) {
-    struct arg_hdr** table = (struct arg_hdr**)argtable;
-    int tabindex;
-    /*printf("arg_nullcheck(%p)\n",argtable);*/
+int arg_nullcheck(void **argtable) {
+  struct arg_hdr **table = (struct arg_hdr **)argtable;
+  int tabindex;
+  /*printf("arg_nullcheck(%p)\n",argtable);*/
 
-    if (!table)
-        return 1;
+  if (!table)
+    return 1;
 
-    tabindex = 0;
-    do {
-        /*printf("argtable[%d]=%p\n",tabindex,argtable[tabindex]);*/
-        if (!table[tabindex])
-            return 1;
-    } while (!(table[tabindex++]->flag & ARG_TERMINATOR));
+  tabindex = 0;
+  do {
+    /*printf("argtable[%d]=%p\n",tabindex,argtable[tabindex]);*/
+    if (!table[tabindex])
+      return 1;
+  } while (!(table[tabindex++]->flag & ARG_TERMINATOR));
 
-    return 0;
+  return 0;
 }
 
 /*
- * arg_free() is deprecated in favour of arg_freetable() due to a flaw in its design.
- * The flaw results in memory leak in the (very rare) case that an intermediate
- * entry in the argtable array failed its memory allocation while others following
- * that entry were still allocated ok. Those subsequent allocations will not be
- * deallocated by arg_free().
- * Despite the unlikeliness of the problem occurring, and the even unlikelier event
- * that it has any deliterious effect, it is fixed regardless by replacing arg_free()
- * with the newer arg_freetable() function.
- * We still keep arg_free() for backwards compatibility.
+ * arg_free() is deprecated in favour of arg_freetable() due to a flaw in its
+ * design. The flaw results in memory leak in the (very rare) case that an
+ * intermediate entry in the argtable array failed its memory allocation while
+ * others following that entry were still allocated ok. Those subsequent
+ * allocations will not be deallocated by arg_free(). Despite the unlikeliness
+ * of the problem occurring, and the even unlikelier event that it has any
+ * deliterious effect, it is fixed regardless by replacing arg_free() with the
+ * newer arg_freetable() function. We still keep arg_free() for backwards
+ * compatibility.
  */
-void arg_free(void** argtable) {
-    struct arg_hdr** table = (struct arg_hdr**)argtable;
-    int tabindex = 0;
-    int flag;
-    /*printf("arg_free(%p)\n",argtable);*/
-    do {
-        /*
-           if we encounter a NULL entry then somewhat incorrectly we presume
-           we have come to the end of the array. It isnt strictly true because
-           an intermediate entry could be NULL with other non-NULL entries to follow.
-           The subsequent argtable entries would then not be freed as they should.
-         */
-        if (table[tabindex] == NULL)
-            break;
+void arg_free(void **argtable) {
+  struct arg_hdr **table = (struct arg_hdr **)argtable;
+  int tabindex = 0;
+  int flag;
+  /*printf("arg_free(%p)\n",argtable);*/
+  do {
+    /*
+       if we encounter a NULL entry then somewhat incorrectly we presume
+       we have come to the end of the array. It isnt strictly true because
+       an intermediate entry could be NULL with other non-NULL entries to
+       follow. The subsequent argtable entries would then not be freed as they
+       should.
+     */
+    if (table[tabindex] == NULL)
+      break;
 
-        flag = table[tabindex]->flag;
-        xfree(table[tabindex]);
-        table[tabindex++] = NULL;
+    flag = table[tabindex]->flag;
+    xfree(table[tabindex]);
+    table[tabindex++] = NULL;
 
-    } while (!(flag & ARG_TERMINATOR));
+  } while (!(flag & ARG_TERMINATOR));
 }
 
-/* frees each non-NULL element of argtable[], where n is the size of the number of entries in the array */
-void arg_freetable(void** argtable, size_t n) {
-    struct arg_hdr** table = (struct arg_hdr**)argtable;
-    size_t tabindex = 0;
-    /*printf("arg_freetable(%p)\n",argtable);*/
-    for (tabindex = 0; tabindex < n; tabindex++) {
-        if (table[tabindex] == NULL)
-            continue;
+/* frees each non-NULL element of argtable[], where n is the size of the number
+ * of entries in the array */
+void arg_freetable(void **argtable, size_t n) {
+  struct arg_hdr **table = (struct arg_hdr **)argtable;
+  size_t tabindex = 0;
+  /*printf("arg_freetable(%p)\n",argtable);*/
+  for (tabindex = 0; tabindex < n; tabindex++) {
+    if (table[tabindex] == NULL)
+      continue;
 
-        xfree(table[tabindex]);
-        table[tabindex] = NULL;
-    };
+    xfree(table[tabindex]);
+    table[tabindex] = NULL;
+  };
 }
 
 #ifdef _WIN32
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
-    return TRUE;
-    UNREFERENCED_PARAMETER(hinstDLL);
-    UNREFERENCED_PARAMETER(fdwReason);
-    UNREFERENCED_PARAMETER(lpvReserved);
+  return TRUE;
+  UNREFERENCED_PARAMETER(hinstDLL);
+  UNREFERENCED_PARAMETER(fdwReason);
+  UNREFERENCED_PARAMETER(lpvReserved);
 }
 #endif

--- a/argtable3.h
+++ b/argtable3.h
@@ -46,7 +46,8 @@ extern "C" {
 #define ARG_CMD_DESCRIPTION_LEN 256
 
 #ifndef ARG_REPLACE_GETOPT
-#define ARG_REPLACE_GETOPT 1 /* use the embedded getopt as the system getopt(3) */
+  #define ARG_REPLACE_GETOPT                                                   \
+    1  /* use the embedded getopt as the system getopt(3) */
 #endif /* ARG_REPLACE_GETOPT */
 
 /* bit masks for arg_hdr.flag */
@@ -64,16 +65,17 @@ enum { ARG_TERMINATOR = 0x1, ARG_HASVALUE = 0x2, ARG_HASOPTVALUE = 0x4 };
   #define ARG_EXTERN
 #endif
 
-typedef struct _internal_arg_dstr* arg_dstr_t;
-typedef void* arg_cmd_itr_t;
+typedef struct _internal_arg_dstr *arg_dstr_t;
+typedef void *arg_cmd_itr_t;
 
-typedef void(arg_resetfn)(void* parent);
-typedef int(arg_scanfn)(void* parent, const char* argval);
-typedef int(arg_checkfn)(void* parent);
-typedef void(arg_errorfn)(void* parent, arg_dstr_t ds, int error, const char* argval, const char* progname);
-typedef void(arg_dstr_freefn)(char* buf);
-typedef int(arg_cmdfn)(int argc, char* argv[], arg_dstr_t res);
-typedef int(arg_comparefn)(const void* k1, const void* k2);
+typedef void(arg_resetfn)(void *parent);
+typedef int(arg_scanfn)(void *parent, const char *argval);
+typedef int(arg_checkfn)(void *parent);
+typedef void(arg_errorfn)(void *parent, arg_dstr_t ds, int error,
+                          const char *argval, const char *progname);
+typedef void(arg_dstr_freefn)(char *buf);
+typedef int(arg_cmdfn)(int argc, char *argv[], arg_dstr_t res);
+typedef int(arg_comparefn)(const void *k1, const void *k2);
 
 /*
  * The arg_hdr struct defines properties that are common to all arg_xxx structs.
@@ -93,179 +95,234 @@ typedef int(arg_comparefn)(const void* k1, const void* k2);
  * constructor and left unaltered.
  */
 typedef struct arg_hdr {
-    char flag;             /* Modifier flags: ARG_TERMINATOR, ARG_HASVALUE. */
-    const char* shortopts; /* String defining the short options */
-    const char* longopts;  /* String defiing the long options */
-    const char* datatype;  /* Description of the argument data type */
-    const char* glossary;  /* Description of the option as shown by arg_print_glossary function */
-    int mincount;          /* Minimum number of occurences of this option accepted */
-    int maxcount;          /* Maximum number of occurences if this option accepted */
-    void* parent;          /* Pointer to parent arg_xxx struct */
-    arg_resetfn* resetfn;  /* Pointer to parent arg_xxx reset function */
-    arg_scanfn* scanfn;    /* Pointer to parent arg_xxx scan function */
-    arg_checkfn* checkfn;  /* Pointer to parent arg_xxx check function */
-    arg_errorfn* errorfn;  /* Pointer to parent arg_xxx error function */
-    void* priv;            /* Pointer to private header data for use by arg_xxx functions */
+  char flag;             /* Modifier flags: ARG_TERMINATOR, ARG_HASVALUE. */
+  const char *shortopts; /* String defining the short options */
+  const char *longopts;  /* String defiing the long options */
+  const char *datatype;  /* Description of the argument data type */
+  const char *glossary;  /* Description of the option as shown by
+                            arg_print_glossary function */
+  int mincount; /* Minimum number of occurences of this option accepted */
+  int maxcount; /* Maximum number of occurences if this option accepted */
+  void *parent; /* Pointer to parent arg_xxx struct */
+  arg_resetfn *resetfn; /* Pointer to parent arg_xxx reset function */
+  arg_scanfn *scanfn;   /* Pointer to parent arg_xxx scan function */
+  arg_checkfn *checkfn; /* Pointer to parent arg_xxx check function */
+  arg_errorfn *errorfn; /* Pointer to parent arg_xxx error function */
+  void *priv; /* Pointer to private header data for use by arg_xxx functions */
 } arg_hdr_t;
 
 typedef struct arg_rem {
-    struct arg_hdr hdr; /* The mandatory argtable header struct */
+  struct arg_hdr hdr; /* The mandatory argtable header struct */
 } arg_rem_t;
 
 typedef struct arg_lit {
-    struct arg_hdr hdr; /* The mandatory argtable header struct */
-    int count;          /* Number of matching command line args */
+  struct arg_hdr hdr; /* The mandatory argtable header struct */
+  int count;          /* Number of matching command line args */
 } arg_lit_t;
 
 typedef struct arg_int {
-    struct arg_hdr hdr; /* The mandatory argtable header struct */
-    int count;          /* Number of matching command line args */
-    int* ival;          /* Array of parsed argument values */
+  struct arg_hdr hdr; /* The mandatory argtable header struct */
+  int count;          /* Number of matching command line args */
+  int *ival;          /* Array of parsed argument values */
 } arg_int_t;
 
 typedef struct arg_dbl {
-    struct arg_hdr hdr; /* The mandatory argtable header struct */
-    int count;          /* Number of matching command line args */
-    double* dval;       /* Array of parsed argument values */
+  struct arg_hdr hdr; /* The mandatory argtable header struct */
+  int count;          /* Number of matching command line args */
+  double *dval;       /* Array of parsed argument values */
 } arg_dbl_t;
 
 typedef struct arg_str {
-    struct arg_hdr hdr; /* The mandatory argtable header struct */
-    int count;          /* Number of matching command line args */
-    const char** sval;  /* Array of parsed argument values */
+  struct arg_hdr hdr; /* The mandatory argtable header struct */
+  int count;          /* Number of matching command line args */
+  const char **sval;  /* Array of parsed argument values */
 } arg_str_t;
 
 typedef struct arg_rex {
-    struct arg_hdr hdr; /* The mandatory argtable header struct */
-    int count;          /* Number of matching command line args */
-    const char** sval;  /* Array of parsed argument values */
+  struct arg_hdr hdr; /* The mandatory argtable header struct */
+  int count;          /* Number of matching command line args */
+  const char **sval;  /* Array of parsed argument values */
 } arg_rex_t;
 
 typedef struct arg_file {
-    struct arg_hdr hdr;     /* The mandatory argtable header struct */
-    int count;              /* Number of matching command line args*/
-    const char** filename;  /* Array of parsed filenames  (eg: /home/foo.bar) */
-    const char** basename;  /* Array of parsed basenames  (eg: foo.bar) */
-    const char** extension; /* Array of parsed extensions (eg: .bar) */
+  struct arg_hdr hdr;     /* The mandatory argtable header struct */
+  int count;              /* Number of matching command line args*/
+  const char **filename;  /* Array of parsed filenames  (eg: /home/foo.bar) */
+  const char **basename;  /* Array of parsed basenames  (eg: foo.bar) */
+  const char **extension; /* Array of parsed extensions (eg: .bar) */
 } arg_file_t;
 
 typedef struct arg_date {
-    struct arg_hdr hdr; /* The mandatory argtable header struct */
-    const char* format; /* strptime format string used to parse the date */
-    int count;          /* Number of matching command line args */
-    struct tm* tmval;   /* Array of parsed time values */
+  struct arg_hdr hdr; /* The mandatory argtable header struct */
+  const char *format; /* strptime format string used to parse the date */
+  int count;          /* Number of matching command line args */
+  struct tm *tmval;   /* Array of parsed time values */
 } arg_date_t;
 
 enum { ARG_ELIMIT = 1, ARG_EMALLOC, ARG_ENOMATCH, ARG_ELONGOPT, ARG_EMISSARG };
 typedef struct arg_end {
-    struct arg_hdr hdr;  /* The mandatory argtable header struct */
-    int count;           /* Number of errors encountered */
-    int* error;          /* Array of error codes */
-    void** parent;       /* Array of pointers to offending arg_xxx struct */
-    const char** argval; /* Array of pointers to offending argv[] string */
+  struct arg_hdr hdr;  /* The mandatory argtable header struct */
+  int count;           /* Number of errors encountered */
+  int *error;          /* Array of error codes */
+  void **parent;       /* Array of pointers to offending arg_xxx struct */
+  const char **argval; /* Array of pointers to offending argv[] string */
 } arg_end_t;
 
 typedef struct arg_cmd_info {
-    char name[ARG_CMD_NAME_LEN];
-    char description[ARG_CMD_DESCRIPTION_LEN];
-    arg_cmdfn* proc;
+  char name[ARG_CMD_NAME_LEN];
+  char description[ARG_CMD_DESCRIPTION_LEN];
+  arg_cmdfn *proc;
 } arg_cmd_info_t;
 
 /**** arg_xxx constructor functions *********************************/
 
-ARG_EXTERN struct arg_rem* arg_rem(const char* datatype, const char* glossary);
+ARG_EXTERN struct arg_rem *arg_rem(const char *datatype, const char *glossary);
 
-ARG_EXTERN struct arg_lit* arg_lit0(const char* shortopts, const char* longopts, const char* glossary);
-ARG_EXTERN struct arg_lit* arg_lit1(const char* shortopts, const char* longopts, const char* glossary);
-ARG_EXTERN struct arg_lit* arg_litn(const char* shortopts, const char* longopts, int mincount, int maxcount, const char* glossary);
+ARG_EXTERN struct arg_lit *arg_lit0(const char *shortopts, const char *longopts,
+                                    const char *glossary);
+ARG_EXTERN struct arg_lit *arg_lit1(const char *shortopts, const char *longopts,
+                                    const char *glossary);
+ARG_EXTERN struct arg_lit *arg_litn(const char *shortopts, const char *longopts,
+                                    int mincount, int maxcount,
+                                    const char *glossary);
 
-ARG_EXTERN struct arg_int* arg_int0(const char* shortopts, const char* longopts, const char* datatype, const char* glossary);
-ARG_EXTERN struct arg_int* arg_int1(const char* shortopts, const char* longopts, const char* datatype, const char* glossary);
-ARG_EXTERN struct arg_int* arg_intn(const char* shortopts, const char* longopts, const char* datatype, int mincount, int maxcount, const char* glossary);
+ARG_EXTERN struct arg_int *arg_int0(const char *shortopts, const char *longopts,
+                                    const char *datatype, const char *glossary);
+ARG_EXTERN struct arg_int *arg_int1(const char *shortopts, const char *longopts,
+                                    const char *datatype, const char *glossary);
+ARG_EXTERN struct arg_int *arg_intn(const char *shortopts, const char *longopts,
+                                    const char *datatype, int mincount,
+                                    int maxcount, const char *glossary);
 
-ARG_EXTERN struct arg_dbl* arg_dbl0(const char* shortopts, const char* longopts, const char* datatype, const char* glossary);
-ARG_EXTERN struct arg_dbl* arg_dbl1(const char* shortopts, const char* longopts, const char* datatype, const char* glossary);
-ARG_EXTERN struct arg_dbl* arg_dbln(const char* shortopts, const char* longopts, const char* datatype, int mincount, int maxcount, const char* glossary);
+ARG_EXTERN struct arg_dbl *arg_dbl0(const char *shortopts, const char *longopts,
+                                    const char *datatype, const char *glossary);
+ARG_EXTERN struct arg_dbl *arg_dbl1(const char *shortopts, const char *longopts,
+                                    const char *datatype, const char *glossary);
+ARG_EXTERN struct arg_dbl *arg_dbln(const char *shortopts, const char *longopts,
+                                    const char *datatype, int mincount,
+                                    int maxcount, const char *glossary);
 
-ARG_EXTERN struct arg_str* arg_str0(const char* shortopts, const char* longopts, const char* datatype, const char* glossary);
-ARG_EXTERN struct arg_str* arg_str1(const char* shortopts, const char* longopts, const char* datatype, const char* glossary);
-ARG_EXTERN struct arg_str* arg_strn(const char* shortopts, const char* longopts, const char* datatype, int mincount, int maxcount, const char* glossary);
+ARG_EXTERN struct arg_str *arg_str0(const char *shortopts, const char *longopts,
+                                    const char *datatype, const char *glossary);
+ARG_EXTERN struct arg_str *arg_str1(const char *shortopts, const char *longopts,
+                                    const char *datatype, const char *glossary);
+ARG_EXTERN struct arg_str *arg_strn(const char *shortopts, const char *longopts,
+                                    const char *datatype, int mincount,
+                                    int maxcount, const char *glossary);
 
-ARG_EXTERN struct arg_rex* arg_rex0(const char* shortopts, const char* longopts, const char* pattern, const char* datatype, int flags, const char* glossary);
-ARG_EXTERN struct arg_rex* arg_rex1(const char* shortopts, const char* longopts, const char* pattern, const char* datatype, int flags, const char* glossary);
-ARG_EXTERN struct arg_rex* arg_rexn(const char* shortopts,
-                         const char* longopts,
-                         const char* pattern,
-                         const char* datatype,
-                         int mincount,
-                         int maxcount,
-                         int flags,
-                         const char* glossary);
+ARG_EXTERN struct arg_rex *arg_rex0(const char *shortopts, const char *longopts,
+                                    const char *pattern, const char *datatype,
+                                    int flags, const char *glossary);
+ARG_EXTERN struct arg_rex *arg_rex1(const char *shortopts, const char *longopts,
+                                    const char *pattern, const char *datatype,
+                                    int flags, const char *glossary);
+ARG_EXTERN struct arg_rex *arg_rexn(const char *shortopts, const char *longopts,
+                                    const char *pattern, const char *datatype,
+                                    int mincount, int maxcount, int flags,
+                                    const char *glossary);
 
-ARG_EXTERN struct arg_file* arg_file0(const char* shortopts, const char* longopts, const char* datatype, const char* glossary);
-ARG_EXTERN struct arg_file* arg_file1(const char* shortopts, const char* longopts, const char* datatype, const char* glossary);
-ARG_EXTERN struct arg_file* arg_filen(const char* shortopts, const char* longopts, const char* datatype, int mincount, int maxcount, const char* glossary);
+ARG_EXTERN struct arg_file *arg_file0(const char *shortopts,
+                                      const char *longopts,
+                                      const char *datatype,
+                                      const char *glossary);
+ARG_EXTERN struct arg_file *arg_file1(const char *shortopts,
+                                      const char *longopts,
+                                      const char *datatype,
+                                      const char *glossary);
+ARG_EXTERN struct arg_file *arg_filen(const char *shortopts,
+                                      const char *longopts,
+                                      const char *datatype, int mincount,
+                                      int maxcount, const char *glossary);
 
-ARG_EXTERN struct arg_date* arg_date0(const char* shortopts, const char* longopts, const char* format, const char* datatype, const char* glossary);
-ARG_EXTERN struct arg_date* arg_date1(const char* shortopts, const char* longopts, const char* format, const char* datatype, const char* glossary);
-ARG_EXTERN struct arg_date* arg_daten(const char* shortopts, const char* longopts, const char* format, const char* datatype, int mincount, int maxcount, const char* glossary);
+ARG_EXTERN struct arg_date *arg_date0(const char *shortopts,
+                                      const char *longopts, const char *format,
+                                      const char *datatype,
+                                      const char *glossary);
+ARG_EXTERN struct arg_date *arg_date1(const char *shortopts,
+                                      const char *longopts, const char *format,
+                                      const char *datatype,
+                                      const char *glossary);
+ARG_EXTERN struct arg_date *arg_daten(const char *shortopts,
+                                      const char *longopts, const char *format,
+                                      const char *datatype, int mincount,
+                                      int maxcount, const char *glossary);
 
-ARG_EXTERN struct arg_end* arg_end(int maxcount);
+ARG_EXTERN struct arg_end *arg_end(int maxcount);
 
-#define ARG_DSTR_STATIC ((arg_dstr_freefn*)0)
-#define ARG_DSTR_VOLATILE ((arg_dstr_freefn*)1)
-#define ARG_DSTR_DYNAMIC ((arg_dstr_freefn*)3)
+#define ARG_DSTR_STATIC ((arg_dstr_freefn *)0)
+#define ARG_DSTR_VOLATILE ((arg_dstr_freefn *)1)
+#define ARG_DSTR_DYNAMIC ((arg_dstr_freefn *)3)
 
 /**** other functions *******************************************/
-ARG_EXTERN int arg_nullcheck(void** argtable);
-ARG_EXTERN int arg_parse(int argc, char** argv, void** argtable);
-ARG_EXTERN void arg_print_option(FILE* fp, const char* shortopts, const char* longopts, const char* datatype, const char* suffix);
-ARG_EXTERN void arg_print_syntax(FILE* fp, void** argtable, const char* suffix);
-ARG_EXTERN void arg_print_syntaxv(FILE* fp, void** argtable, const char* suffix);
-ARG_EXTERN void arg_print_glossary(FILE* fp, void** argtable, const char* format);
-ARG_EXTERN void arg_print_glossary_gnu(FILE* fp, void** argtable);
-ARG_EXTERN void arg_print_errors(FILE* fp, struct arg_end* end, const char* progname);
-ARG_EXTERN void arg_print_option_ds(arg_dstr_t ds, const char* shortopts, const char* longopts, const char* datatype, const char* suffix);
-ARG_EXTERN void arg_print_syntax_ds(arg_dstr_t ds, void** argtable, const char* suffix);
-ARG_EXTERN void arg_print_syntaxv_ds(arg_dstr_t ds, void** argtable, const char* suffix);
-ARG_EXTERN void arg_print_glossary_ds(arg_dstr_t ds, void** argtable, const char* format);
-ARG_EXTERN void arg_print_glossary_gnu_ds(arg_dstr_t ds, void** argtable);
-ARG_EXTERN void arg_print_errors_ds(arg_dstr_t ds, struct arg_end* end, const char* progname);
-ARG_EXTERN void arg_freetable(void** argtable, size_t n);
+ARG_EXTERN int arg_nullcheck(void **argtable);
+ARG_EXTERN int arg_parse(int argc, char **argv, void **argtable);
+ARG_EXTERN void arg_print_option(FILE *fp, const char *shortopts,
+                                 const char *longopts, const char *datatype,
+                                 const char *suffix);
+ARG_EXTERN void arg_print_syntax(FILE *fp, void **argtable, const char *suffix);
+ARG_EXTERN void arg_print_syntaxv(FILE *fp, void **argtable,
+                                  const char *suffix);
+ARG_EXTERN void arg_print_glossary(FILE *fp, void **argtable,
+                                   const char *format);
+ARG_EXTERN void arg_print_glossary_gnu(FILE *fp, void **argtable);
+ARG_EXTERN void arg_print_errors(FILE *fp, struct arg_end *end,
+                                 const char *progname);
+ARG_EXTERN void arg_print_option_ds(arg_dstr_t ds, const char *shortopts,
+                                    const char *longopts, const char *datatype,
+                                    const char *suffix);
+ARG_EXTERN void arg_print_syntax_ds(arg_dstr_t ds, void **argtable,
+                                    const char *suffix);
+ARG_EXTERN void arg_print_syntaxv_ds(arg_dstr_t ds, void **argtable,
+                                     const char *suffix);
+ARG_EXTERN void arg_print_glossary_ds(arg_dstr_t ds, void **argtable,
+                                      const char *format);
+ARG_EXTERN void arg_print_glossary_gnu_ds(arg_dstr_t ds, void **argtable);
+ARG_EXTERN void arg_print_errors_ds(arg_dstr_t ds, struct arg_end *end,
+                                    const char *progname);
+ARG_EXTERN void arg_freetable(void **argtable, size_t n);
 
 ARG_EXTERN arg_dstr_t arg_dstr_create(void);
 ARG_EXTERN void arg_dstr_destroy(arg_dstr_t ds);
 ARG_EXTERN void arg_dstr_reset(arg_dstr_t ds);
 ARG_EXTERN void arg_dstr_free(arg_dstr_t ds);
-ARG_EXTERN void arg_dstr_set(arg_dstr_t ds, char* str, arg_dstr_freefn* free_proc);
-ARG_EXTERN void arg_dstr_cat(arg_dstr_t ds, const char* str);
+ARG_EXTERN void arg_dstr_set(arg_dstr_t ds, char *str,
+                             arg_dstr_freefn *free_proc);
+ARG_EXTERN void arg_dstr_cat(arg_dstr_t ds, const char *str);
 ARG_EXTERN void arg_dstr_catc(arg_dstr_t ds, char c);
-ARG_EXTERN void arg_dstr_catf(arg_dstr_t ds, const char* fmt, ...);
-ARG_EXTERN char* arg_dstr_cstr(arg_dstr_t ds);
+ARG_EXTERN void arg_dstr_catf(arg_dstr_t ds, const char *fmt, ...);
+ARG_EXTERN char *arg_dstr_cstr(arg_dstr_t ds);
 
 ARG_EXTERN void arg_cmd_init(void);
 ARG_EXTERN void arg_cmd_uninit(void);
-ARG_EXTERN void arg_cmd_register(const char* name, arg_cmdfn* proc, const char* description);
-ARG_EXTERN void arg_cmd_unregister(const char* name);
-ARG_EXTERN int arg_cmd_dispatch(const char* name, int argc, char* argv[], arg_dstr_t res);
+ARG_EXTERN void arg_cmd_register(const char *name, arg_cmdfn *proc,
+                                 const char *description);
+ARG_EXTERN void arg_cmd_unregister(const char *name);
+ARG_EXTERN int arg_cmd_dispatch(const char *name, int argc, char *argv[],
+                                arg_dstr_t res);
 ARG_EXTERN unsigned int arg_cmd_count(void);
-ARG_EXTERN arg_cmd_info_t* arg_cmd_info(const char* name);
+ARG_EXTERN arg_cmd_info_t *arg_cmd_info(const char *name);
 ARG_EXTERN arg_cmd_itr_t arg_cmd_itr_create(void);
 ARG_EXTERN void arg_cmd_itr_destroy(arg_cmd_itr_t itr);
 ARG_EXTERN int arg_cmd_itr_advance(arg_cmd_itr_t itr);
-ARG_EXTERN char* arg_cmd_itr_key(arg_cmd_itr_t itr);
-ARG_EXTERN arg_cmd_info_t* arg_cmd_itr_value(arg_cmd_itr_t itr);
-ARG_EXTERN int arg_cmd_itr_search(arg_cmd_itr_t itr, void* k);
-ARG_EXTERN void arg_mgsort(void* data, int size, int esize, int i, int k, arg_comparefn* comparefn);
+ARG_EXTERN char *arg_cmd_itr_key(arg_cmd_itr_t itr);
+ARG_EXTERN arg_cmd_info_t *arg_cmd_itr_value(arg_cmd_itr_t itr);
+ARG_EXTERN int arg_cmd_itr_search(arg_cmd_itr_t itr, void *k);
+ARG_EXTERN void arg_mgsort(void *data, int size, int esize, int i, int k,
+                           arg_comparefn *comparefn);
 ARG_EXTERN void arg_make_get_help_msg(arg_dstr_t res);
-ARG_EXTERN void arg_make_help_msg(arg_dstr_t ds, char* cmd_name, void** argtable);
-ARG_EXTERN void arg_make_syntax_err_msg(arg_dstr_t ds, void** argtable, struct arg_end* end);
-ARG_EXTERN int arg_make_syntax_err_help_msg(arg_dstr_t ds, char* name, int help, int nerrors, void** argtable, struct arg_end* end, int* exitcode);
-ARG_EXTERN void arg_set_module_name(const char* name);
-ARG_EXTERN void arg_set_module_version(int major, int minor, int patch, const char* tag);
+ARG_EXTERN void arg_make_help_msg(arg_dstr_t ds, char *cmd_name,
+                                  void **argtable);
+ARG_EXTERN void arg_make_syntax_err_msg(arg_dstr_t ds, void **argtable,
+                                        struct arg_end *end);
+ARG_EXTERN int arg_make_syntax_err_help_msg(arg_dstr_t ds, char *name, int help,
+                                            int nerrors, void **argtable,
+                                            struct arg_end *end, int *exitcode);
+ARG_EXTERN void arg_set_module_name(const char *name);
+ARG_EXTERN void arg_set_module_version(int major, int minor, int patch,
+                                       const char *tag);
 
 /**** deprecated functions, for back-compatibility only ********/
-ARG_EXTERN void arg_free(void** argtable);
+ARG_EXTERN void arg_free(void **argtable);
 
 #ifdef __cplusplus
 }

--- a/arm64_asm.c
+++ b/arm64_asm.c
@@ -4,794 +4,770 @@
 #define MASKn(v, bits, off) (((v) & ((1ull << (bits)) - 1)) << (off))
 
 // https://math.stackexchange.com/questions/490813/range-twos-complement
-#define ARM_FORCE_ALIGN(v, bits, chop)                  \
-	{                                                   \
-		if ((v) & ((1 << (chop)) - 1))                  \
-			return ARM_ERR_INV_OFF;                     \
-		if ((v) >= 0) {                                 \
-			if (((v) >> chop) > (1l << ((bits)-1)) - 1) \
-				return ARM_ERR_INV_OFF;                 \
-		} else if ((-(v) >> chop) > (1l << ((bits)-1))) \
-			return ARM_ERR_INV_OFF;                     \
-	}
-#define ARM_FORCE_REG(r)            \
-	{                               \
-		if ((r) < 0)                \
-			return ARM_ERR_INV_REG; \
-		if ((r) > 32)               \
-			return ARM_ERR_INV_REG; \
-	}
+#define ARM_FORCE_ALIGN(v, bits, chop)                                         \
+  {                                                                            \
+    if ((v) & ((1 << (chop)) - 1))                                             \
+      return ARM_ERR_INV_OFF;                                                  \
+    if ((v) >= 0) {                                                            \
+      if (((v) >> chop) > (1l << ((bits)-1)) - 1)                              \
+        return ARM_ERR_INV_OFF;                                                \
+    } else if ((-(v) >> chop) > (1l << ((bits)-1)))                            \
+      return ARM_ERR_INV_OFF;                                                  \
+  }
+#define ARM_FORCE_REG(r)                                                       \
+  {                                                                            \
+    if ((r) < 0)                                                               \
+      return ARM_ERR_INV_REG;                                                  \
+    if ((r) > 32)                                                              \
+      return ARM_ERR_INV_REG;                                                  \
+  }
 // https://github.com/fujitsu/xbyak_aarch64
 typedef struct {
-	int64_t n, m;
-	int64_t type;
-	int64_t shift;
-	int64_t init_sh;
+  int64_t n, m;
+  int64_t type;
+  int64_t shift;
+  int64_t init_sh;
 } CARMAdrRegReg;
 typedef struct {
-	int64_t n;
-	int64_t off;
+  int64_t n;
+  int64_t off;
 } CARMAdrRegImm;
 typedef struct {
-	int64_t n;
-	int64_t off;
+  int64_t n;
+  int64_t off;
 } CARMAdrPostImm;
 typedef struct {
-	int64_t n;
-	int64_t off;
+  int64_t n;
+  int64_t off;
 } CARMAdrPreImm;
 typedef struct {
-	int64_t n;
-	int64_t off;
-	int64_t ext;
+  int64_t n;
+  int64_t off;
+  int64_t ext;
 } CARMAdrScImm;
 
-static int64_t LdStRegExt(int64_t sz, int64_t opc, int64_t rt, int64_t n, int64_t m, int64_t mod)
-{
-	int64_t s = 1;
-	int64_t v = 0;
-	return (sz << 30) | (7 << 27) | (v << 26) | (opc << 22) | (1 << 21) | (m << 16) | (mod << 13) | (s << 12) | (2 << 10) | (n << 5) | rt;
+static int64_t LdStRegExt(int64_t sz, int64_t opc, int64_t rt, int64_t n,
+                          int64_t m, int64_t mod) {
+  int64_t s = 1;
+  int64_t v = 0;
+  return (sz << 30) | (7 << 27) | (v << 26) | (opc << 22) | (1 << 21) |
+         (m << 16) | (mod << 13) | (s << 12) | (2 << 10) | (n << 5) | rt;
 }
 
-static int64_t MvWideImmX(uint32_t opc, int64_t d, int64_t imm, int64_t shift)
-{
-	if (imm & ~0xffff)
-		return ARM_ERR_INV_OFF;
-	ARM_FORCE_REG(d);
-	uint32_t hw = (shift >> 4) & 0b11;
-	uint32_t imm16 = imm & 0xffff;
-	return (1 << 31) | (opc << 29) | (0x25 << 23) | (hw << 21) | (imm16 << 5) | d;
+static int64_t MvWideImmX(uint32_t opc, int64_t d, int64_t imm, int64_t shift) {
+  if (imm & ~0xffff)
+    return ARM_ERR_INV_OFF;
+  ARM_FORCE_REG(d);
+  uint32_t hw = (shift >> 4) & 0b11;
+  uint32_t imm16 = imm & 0xffff;
+  return (1 << 31) | (opc << 29) | (0x25 << 23) | (hw << 21) | (imm16 << 5) | d;
 }
 static int64_t DataProc2Src(uint32_t opcode, int64_t rd, int64_t rn,
-	int64_t rm)
-{
-	ARM_FORCE_REG(rn);
-	ARM_FORCE_REG(rm);
-	ARM_FORCE_REG(rd);
-	uint32_t sf = 1;
-	uint32_t S = 0;
-	return (sf << 31) | (S << 29) | (0xd6 << 21) | (rm << 16) | (opcode << 10) | (rn << 5) | rd;
+                            int64_t rm) {
+  ARM_FORCE_REG(rn);
+  ARM_FORCE_REG(rm);
+  ARM_FORCE_REG(rd);
+  uint32_t sf = 1;
+  uint32_t S = 0;
+  return (sf << 31) | (S << 29) | (0xd6 << 21) | (rm << 16) | (opcode << 10) |
+         (rn << 5) | rd;
 }
 
 static int64_t FpComp(uint32_t M, uint32_t S, uint32_t type, uint32_t op,
-	uint32_t opcode2, int64_t vn, int64_t vm)
-{
-	ARM_FORCE_REG(vn);
-	ARM_FORCE_REG(vm);
-	return (M << 31) | (S << 29) | (0xf << 25) | (type << 22) | (1 << 21) | (vm << 16) | (op << 14) | (1 << 13) | (vn << 5) | opcode2;
+                      uint32_t opcode2, int64_t vn, int64_t vm) {
+  ARM_FORCE_REG(vn);
+  ARM_FORCE_REG(vm);
+  return (M << 31) | (S << 29) | (0xf << 25) | (type << 22) | (1 << 21) |
+         (vm << 16) | (op << 14) | (1 << 13) | (vn << 5) | opcode2;
 }
 
 static int64_t FpDataProc1Reg(uint32_t M, uint32_t S, uint32_t type,
-	uint32_t opcode, int64_t vd, int64_t vn)
-{
-	ARM_FORCE_REG(vn);
-	ARM_FORCE_REG(vd);
-	return (M << 31) | (S << 29) | (0xf << 25) | (type << 22) | (1 << 21) | (opcode << 15) | (1 << 14) | (vn << 5) | vd;
+                              uint32_t opcode, int64_t vd, int64_t vn) {
+  ARM_FORCE_REG(vn);
+  ARM_FORCE_REG(vd);
+  return (M << 31) | (S << 29) | (0xf << 25) | (type << 22) | (1 << 21) |
+         (opcode << 15) | (1 << 14) | (vn << 5) | vd;
 }
 
 static int64_t LdStRegPairPostImm(int64_t opc, int64_t l, int64_t r, int64_t r2,
-	CARMAdrPostImm* pre)
-{
-	int64_t imm = pre->off;
-	int64_t times = (opc == 2) ? 2 : 1;
-	ARM_FORCE_ALIGN(imm, 7, times + 1);
-	int64_t imm7 = MASKn(imm >> (times + 1), 7, 15);
-	return (opc << 30) | (0x5 << 27) | (1 << 23) | (l << 22) | imm7 | (r2 << 10) | (pre->n << 5) | r;
+                                  CARMAdrPostImm *pre) {
+  int64_t imm = pre->off;
+  int64_t times = (opc == 2) ? 2 : 1;
+  ARM_FORCE_ALIGN(imm, 7, times + 1);
+  int64_t imm7 = MASKn(imm >> (times + 1), 7, 15);
+  return (opc << 30) | (0x5 << 27) | (1 << 23) | (l << 22) | imm7 | (r2 << 10) |
+         (pre->n << 5) | r;
 }
 
 static int64_t LdStRegPairPre(int64_t opc, int64_t L, int64_t rt1, int64_t rt2,
-	CARMAdrPreImm* adr)
-{
-	int64_t imm = adr->off;
-	int64_t times = (opc == 2) ? 2 : 1;
-	ARM_FORCE_ALIGN(imm, 7, times + 1);
-	uint32_t imm7 = MASKn(imm >> (times + 1), 7, 15);
-	return (opc << 30) | (0x5 << 27) | (3 << 23) | (L << 22) | imm7 | (rt2 << 10) | (adr->n << 5) | rt1;
+                              CARMAdrPreImm *adr) {
+  int64_t imm = adr->off;
+  int64_t times = (opc == 2) ? 2 : 1;
+  ARM_FORCE_ALIGN(imm, 7, times + 1);
+  uint32_t imm7 = MASKn(imm >> (times + 1), 7, 15);
+  return (opc << 30) | (0x5 << 27) | (3 << 23) | (L << 22) | imm7 |
+         (rt2 << 10) | (adr->n << 5) | rt1;
 }
 
 // For 64bit
-static int64_t LdStSimdFpUnImm(int32_t opc, int64_t vt, int64_t n, int64_t imm)
-{
-	uint32_t imm12 = MASKn(imm >> 3, 12, 10);
-	ARM_FORCE_ALIGN(imm, 12, 3);
-	if (imm < 0)
-		return ARM_ERR_INV_OFF;
-	return (3 << 30) | (0x7 << 27) | (1 << 26) | (1 << 24) | (opc << 22) | imm12 | (n << 5) | vt;
+static int64_t LdStSimdFpUnImm(int32_t opc, int64_t vt, int64_t n,
+                               int64_t imm) {
+  uint32_t imm12 = MASKn(imm >> 3, 12, 10);
+  ARM_FORCE_ALIGN(imm, 12, 3);
+  if (imm < 0)
+    return ARM_ERR_INV_OFF;
+  return (3 << 30) | (0x7 << 27) | (1 << 26) | (1 << 24) | (opc << 22) | imm12 |
+         (n << 5) | vt;
 }
 
-static int64_t LdRegSimdFpLiteralEnc(int64_t vt, int64_t imm)
-{
-	uint32_t imm19 = MASKn(imm >> 2, 19, 5);
-	ARM_FORCE_ALIGN(imm, 19, 2);
-	return (1 << 30) | (0x3 << 27) | (1 << 26) | imm19 | vt;
+static int64_t LdRegSimdFpLiteralEnc(int64_t vt, int64_t imm) {
+  uint32_t imm19 = MASKn(imm >> 2, 19, 5);
+  ARM_FORCE_ALIGN(imm, 19, 2);
+  return (1 << 30) | (0x3 << 27) | (1 << 26) | imm19 | vt;
 }
 
 static int64_t LdStRegPre(int64_t sz, int64_t opc, int64_t r,
-	CARMAdrPreImm* adr)
-{
-	ARM_FORCE_ALIGN(adr->off, 9, 0);
-	return (sz << 30) | (0x7 << 27) | (0xf << 27) | (opc << 22) | MASKn(adr->off, 9, 12) | (3 << 10) | (adr->n << 5) | r;
+                          CARMAdrPreImm *adr) {
+  ARM_FORCE_ALIGN(adr->off, 9, 0);
+  return (sz << 30) | (0x7 << 27) | (0xf << 27) | (opc << 22) |
+         MASKn(adr->off, 9, 12) | (3 << 10) | (adr->n << 5) | r;
 }
 
 static int64_t LdStRegPostImm(int64_t sz, int64_t opc, int64_t r,
-	CARMAdrPostImm* adr)
-{
-	ARM_FORCE_ALIGN(adr->off, 9, 0);
-	return (sz << 30) | (0xf << 27) | (0xf << 27) | (opc << 22) | MASKn(adr->off, 9, 12) | (1 << 10) | (adr->n << 5) | r;
+                              CARMAdrPostImm *adr) {
+  ARM_FORCE_ALIGN(adr->off, 9, 0);
+  return (sz << 30) | (0xf << 27) | (0xf << 27) | (opc << 22) |
+         MASKn(adr->off, 9, 12) | (1 << 10) | (adr->n << 5) | r;
 }
 
 static int64_t FpDataProc2Reg(int64_t M, int64_t s, int64_t type,
-	int64_t opcode, int64_t d, int64_t n, int64_t m)
-{
-	return (M << 31) | (s << 29) | (0xf << 25) | (type << 22) | (1 << 21) | (m << 16) | (opcode << 12) | (2 << 10) | (n << 5) | d;
+                              int64_t opcode, int64_t d, int64_t n, int64_t m) {
+  return (M << 31) | (s << 29) | (0xf << 25) | (type << 22) | (1 << 21) |
+         (m << 16) | (opcode << 12) | (2 << 10) | (n << 5) | d;
 }
 
 static int64_t LdRegLiteralEnc(int64_t opc, int64_t v, int64_t r,
-	int64_t label)
-{
-	ARM_FORCE_ALIGN(label, 19, 2);
-	return (opc << 30) | (0x3 << 27) | (v << 26) | MASKn(label >> 2, 19, 5) | r;
+                               int64_t label) {
+  ARM_FORCE_ALIGN(label, 19, 2);
+  return (opc << 30) | (0x3 << 27) | (v << 26) | MASKn(label >> 2, 19, 5) | r;
 }
 static int64_t ConversionFpIntIF(int64_t sf, int64_t s, int64_t type,
-	int64_t rmode, int64_t opcode, int64_t d,
-	int64_t n)
-{
-	return (sf << 31) | (s << 29) | (0xf << 25) | (type << 22) | (1 << 21) | (rmode << 19) | (opcode << 16) | (n << 5) | d;
+                                 int64_t rmode, int64_t opcode, int64_t d,
+                                 int64_t n) {
+  return (sf << 31) | (s << 29) | (0xf << 25) | (type << 22) | (1 << 21) |
+         (rmode << 19) | (opcode << 16) | (n << 5) | d;
 }
 static int64_t ConversionFpIntFI(uint32_t sf, uint32_t S, uint32_t type,
-	uint32_t rmode, uint32_t opcode, int32_t vd,
-	int32_t rn)
-{
-	return (sf << 31) | (S << 29) | (0xf << 25) | (type << 22) | (1 << 21) | (rmode << 19) | (opcode << 16) | (rn << 5) | (vd);
+                                 uint32_t rmode, uint32_t opcode, int32_t vd,
+                                 int32_t rn) {
+  return (sf << 31) | (S << 29) | (0xf << 25) | (type << 22) | (1 << 21) |
+         (rmode << 19) | (opcode << 16) | (rn << 5) | (vd);
 }
 static int64_t LdStRegUnImm(int64_t sz, int64_t opc, int64_t r,
-	CARMAdrRegImm* adr)
-{
-	ARM_FORCE_ALIGN(adr->off, 12, sz);
-	return MASKn(adr->off >> sz, 12, 10) | (sz << 30) | (0x7 << 27) | (1 << 24) | (opc << 22) | (adr->n << 5) | (r);
+                            CARMAdrRegImm *adr) {
+  ARM_FORCE_ALIGN(adr->off, 12, sz);
+  return MASKn(adr->off >> sz, 12, 10) | (sz << 30) | (0x7 << 27) | (1 << 24) |
+         (opc << 22) | (adr->n << 5) | (r);
 }
 
-static int64_t LdStRegReg(int64_t size, int64_t opc, int64_t rt, int64_t m, int64_t n, int64_t shift)
-{
-	//(1<<12) triggers shift
-	int64_t S = shift;
-	return (size << 30) | (0x7 << 27) | (opc << 22) | (1 << 21) | (n << 16) | (3 << 13) | (S << 12) | (2 << 10) | (m << 5) | rt;
+static int64_t LdStRegReg(int64_t size, int64_t opc, int64_t rt, int64_t m,
+                          int64_t n, int64_t shift) {
+  //(1<<12) triggers shift
+  int64_t S = shift;
+  return (size << 30) | (0x7 << 27) | (opc << 22) | (1 << 21) | (n << 16) |
+         (3 << 13) | (S << 12) | (2 << 10) | (m << 5) | rt;
 }
 
-static int64_t CompareBr(int64_t op, int64_t r, int64_t imm)
-{
-	ARM_FORCE_ALIGN(imm, 19, 2);
-	return (0x1a << 25) | (op << 24) | MASKn(imm >> 2, 19, 5) | r;
+static int64_t CompareBr(int64_t op, int64_t r, int64_t imm) {
+  ARM_FORCE_ALIGN(imm, 19, 2);
+  return (0x1a << 25) | (op << 24) | MASKn(imm >> 2, 19, 5) | r;
 }
 
-static int64_t CompareBrX(int64_t op, int64_t r, int64_t imm)
-{
-	ARM_FORCE_ALIGN(imm, 19, 2);
-	return (1 << 31) | (0x1a << 25) | (op << 24) | MASKn(imm >> 2, 19, 5) | r;
+static int64_t CompareBrX(int64_t op, int64_t r, int64_t imm) {
+  ARM_FORCE_ALIGN(imm, 19, 2);
+  return (1 << 31) | (0x1a << 25) | (op << 24) | MASKn(imm >> 2, 19, 5) | r;
 }
 
 static int64_t UncondBrNoReg(int64_t opc, int64_t op2, int64_t op3, int64_t rn,
-	int64_t op4)
-{
-	return (0x6b << 25) | (opc << 21) | (op2 << 16) | (op3 << 10) | (rn << 5) | op4;
+                             int64_t op4) {
+  return (0x6b << 25) | (opc << 21) | (op2 << 16) | (op3 << 10) | (rn << 5) |
+         op4;
 }
 
-static int64_t UncondBrImm(int64_t op, int64_t label)
-{
-	ARM_FORCE_ALIGN(label, 26, 2);
-	return (op << 31) | (5 << 26) | MASKn(label >> 2, 26, 0);
+static int64_t UncondBrImm(int64_t op, int64_t label) {
+  ARM_FORCE_ALIGN(label, 26, 2);
+  return (op << 31) | (5 << 26) | MASKn(label >> 2, 26, 0);
 }
 
 static int64_t UncondBr1Reg(int64_t opc, int64_t op2, int64_t op3, int64_t reg,
-	int64_t op4)
-{
-	return (0x6b << 25) | (opc << 21) | (op2 << 16) | (op3 << 10) | (reg << 5) | op4;
+                            int64_t op4) {
+  return (0x6b << 25) | (opc << 21) | (op2 << 16) | (op3 << 10) | (reg << 5) |
+         op4;
 }
 
-static int64_t CondBrImm(int64_t cond, int64_t imm)
-{
-	ARM_FORCE_ALIGN(imm, 19, 2);
-	return (0x2a << 25) | MASKn(imm >> 2, 19, 5) | cond;
+static int64_t CondBrImm(int64_t cond, int64_t imm) {
+  ARM_FORCE_ALIGN(imm, 19, 2);
+  return (0x2a << 25) | MASKn(imm >> 2, 19, 5) | cond;
 }
 static int64_t AddSubImm(int64_t op, int64_t s, int64_t d, int64_t n,
-	int64_t imm, int64_t sh)
-{
-	ARM_FORCE_ALIGN(imm, 12, 0);
-	int32_t imm12 = MASKn(imm, 12, 10);
-	int32_t shift = MASKn(sh, 1, 22);
-	return imm12 | shift | MASKn(d, 6, 0) | MASKn(n, 6, 5) | (0x11ll << 24) | (s << 29) | (op << 30);
+                         int64_t imm, int64_t sh) {
+  ARM_FORCE_ALIGN(imm, 12, 0);
+  int32_t imm12 = MASKn(imm, 12, 10);
+  int32_t shift = MASKn(sh, 1, 22);
+  return imm12 | shift | MASKn(d, 6, 0) | MASKn(n, 6, 5) | (0x11ll << 24) |
+         (s << 29) | (op << 30);
 }
 
-static int64_t TestBr(int64_t op, int64_t rt, int64_t imm, int64_t off)
-{
-	int64_t d5 = (imm >> 5) & 1;
-	int64_t d40 = MASKn(imm, 5, 0);
-	int64_t imm14 = MASKn(off >> 2, 14, 5);
-	ARM_FORCE_ALIGN(off, 14, 2);
-	return (d5 << 31) | (0x1b << 25) | (op << 24) | (d40 << 19) | imm14 | rt;
+static int64_t TestBr(int64_t op, int64_t rt, int64_t imm, int64_t off) {
+  int64_t d5 = (imm >> 5) & 1;
+  int64_t d40 = MASKn(imm, 5, 0);
+  int64_t imm14 = MASKn(off >> 2, 14, 5);
+  ARM_FORCE_ALIGN(off, 14, 2);
+  return (d5 << 31) | (0x1b << 25) | (op << 24) | (d40 << 19) | imm14 | rt;
 }
 
 static int64_t Bitfield(int64_t op, int64_t d, int64_t n, uint64_t immr,
-	uint64_t imms)
-{
-	return (op << 29) | (0x26 << 23) | (0 << 22) | MASKn(immr, 6, 16) | MASKn(imms, 6, 10) | (n << 5) | d;
+                        uint64_t imms) {
+  return (op << 29) | (0x26 << 23) | (0 << 22) | MASKn(immr, 6, 16) |
+         MASKn(imms, 6, 10) | (n << 5) | d;
 }
 
 static int64_t BitfieldX(int64_t op, int64_t d, int64_t n, uint64_t immr,
-	uint64_t imms)
-{
-	return (1 << 31) | (op << 29) | (0x26 << 23) | (1 << 22) | MASKn(immr, 6, 16) | MASKn(imms, 6, 10) | (n << 5) | d;
+                         uint64_t imms) {
+  return (1 << 31) | (op << 29) | (0x26 << 23) | (1 << 22) |
+         MASKn(immr, 6, 16) | MASKn(imms, 6, 10) | (n << 5) | d;
 }
 
 static int64_t AddSubImmX(int64_t op, int64_t s, int64_t d, int64_t n,
-	int64_t imm, int64_t sh)
-{
-	if (imm < 0)
-		return ARM_ERR_INV_OFF;
-	ARM_FORCE_ALIGN(imm, 12, 0);
-	int32_t imm12 = MASKn(imm, 12, 10);
-	int32_t shift = MASKn(sh, 1, 22);
-	return (1 << 31) | imm12 | shift | MASKn(d, 6, 0) | MASKn(n, 6, 5) | (0x11ll << 24) | (s << 29) | (op << 30);
+                          int64_t imm, int64_t sh) {
+  if (imm < 0)
+    return ARM_ERR_INV_OFF;
+  ARM_FORCE_ALIGN(imm, 12, 0);
+  int32_t imm12 = MASKn(imm, 12, 10);
+  int32_t shift = MASKn(sh, 1, 22);
+  return (1 << 31) | imm12 | shift | MASKn(d, 6, 0) | MASKn(n, 6, 5) |
+         (0x11ll << 24) | (s << 29) | (op << 30);
 }
 
 static int64_t AddSubExtReg(int64_t opc, int64_t s, int64_t d, int64_t n,
-	int64_t m, int64_t emod, int64_t sh)
-{
-	return (opc << 30) | (s << 29) | (0xb << 24) | (1 << 21) | (m << 16) | (emod << 13) | MASKn(sh, 3, 10) | (n << 5) | d;
+                            int64_t m, int64_t emod, int64_t sh) {
+  return (opc << 30) | (s << 29) | (0xb << 24) | (1 << 21) | (m << 16) |
+         (emod << 13) | MASKn(sh, 3, 10) | (n << 5) | d;
 }
 
 static int64_t AddSubExtRegX(int64_t opc, int64_t s, int64_t d, int64_t n,
-	int64_t m, int64_t emod, int64_t sh)
-{
-	uint32_t option = (emod == 12) ? 3 : emod;
-	return (1 << 31) | (opc << 30) | (s << 29) | (0xb << 24) | (1 << 21) | (m << 16) | (option << 13) | MASKn(sh, 3, 10) | (n << 5) | d;
+                             int64_t m, int64_t emod, int64_t sh) {
+  uint32_t option = (emod == 12) ? 3 : emod;
+  return (1 << 31) | (opc << 30) | (s << 29) | (0xb << 24) | (1 << 21) |
+         (m << 16) | (option << 13) | MASKn(sh, 3, 10) | (n << 5) | d;
 }
 
 static int64_t AddSubShiftReg(int64_t opc, int64_t s, int64_t d, int64_t n,
-	int64_t m, int64_t shmod, int64_t sh,
-	int64_t alias)
-{
-	int64_t rd_sp = d == 31;
-	int64_t rn_sp = d == 31;
-	if (((rd_sp + rn_sp) >= 1 + alias) && shmod == LSL) {
-		return AddSubExtReg(opc, s, d, n, m, 12, sh);
-	}
-	return (opc << 30) | (s << 29) | (0xb << 24) | (shmod << 22) | (m << 16) | MASKn(sh, 6, 10) | (n << 5) | d;
+                              int64_t m, int64_t shmod, int64_t sh,
+                              int64_t alias) {
+  int64_t rd_sp = d == 31;
+  int64_t rn_sp = d == 31;
+  if (((rd_sp + rn_sp) >= 1 + alias) && shmod == LSL) {
+    return AddSubExtReg(opc, s, d, n, m, 12, sh);
+  }
+  return (opc << 30) | (s << 29) | (0xb << 24) | (shmod << 22) | (m << 16) |
+         MASKn(sh, 6, 10) | (n << 5) | d;
 }
 
 static int64_t LdStSimdFpRegPostImm(int64_t opc, int64_t d, int64_t p,
-	int64_t off)
-{
-	ARM_FORCE_ALIGN(off, 9, 0);
-	return (3 << 30) | (0x7 << 27) | (1 << 26) | (opc << 22) | MASKn(off, 9, 12) | (1 << 10) | (p << 5) | d;
+                                    int64_t off) {
+  ARM_FORCE_ALIGN(off, 9, 0);
+  return (3 << 30) | (0x7 << 27) | (1 << 26) | (opc << 22) | MASKn(off, 9, 12) |
+         (1 << 10) | (p << 5) | d;
 }
 
 static int64_t LdStSimdFpRegPreImm(int64_t opc, int64_t d, int64_t p,
-	int64_t off)
-{
-	ARM_FORCE_ALIGN(off, 9, 0);
-	return (3 << 30) | (0x7 << 27) | (1 << 26) | (opc << 22) | MASKn(off, 9, 12) | (3 << 10) | (p << 5) | d;
+                                   int64_t off) {
+  ARM_FORCE_ALIGN(off, 9, 0);
+  return (3 << 30) | (0x7 << 27) | (1 << 26) | (opc << 22) | MASKn(off, 9, 12) |
+         (3 << 10) | (p << 5) | d;
 }
 
 static int64_t AddSubShiftRegX(int64_t opc, int64_t s, int64_t d, int64_t n,
-	int64_t m, int64_t shmod, int64_t sh,
-	int64_t alias)
-{
-	int64_t rd_sp = d == 31;
-	int64_t rn_sp = n == 31;
-	if (((rd_sp + rn_sp) >= 1 + alias) && shmod == LSL) {
-		return AddSubExtRegX(opc, s, d, n, m, 12, sh);
-	}
-	return (1 << 31) | (opc << 30) | (s << 29) | (0xb << 24) | (shmod << 22) | (m << 16) | MASKn(sh, 6, 10) | (n << 5) | d;
+                               int64_t m, int64_t shmod, int64_t sh,
+                               int64_t alias) {
+  int64_t rd_sp = d == 31;
+  int64_t rn_sp = n == 31;
+  if (((rd_sp + rn_sp) >= 1 + alias) && shmod == LSL) {
+    return AddSubExtRegX(opc, s, d, n, m, 12, sh);
+  }
+  return (1 << 31) | (opc << 30) | (s << 29) | (0xb << 24) | (shmod << 22) |
+         (m << 16) | MASKn(sh, 6, 10) | (n << 5) | d;
 }
 
 static int64_t DataProc3RegX(int64_t op54, int64_t op31, int64_t o0, int64_t d,
-	int64_t n, int64_t m, int64_t ra)
-{
-	return (1 << 31) | (op54 << 29) | (0x1b << 24) | (op31 << 21) | (m << 16) | (o0 << 15) | (ra << 10) | (n << 5) | (d);
+                             int64_t n, int64_t m, int64_t ra) {
+  return (1 << 31) | (op54 << 29) | (0x1b << 24) | (op31 << 21) | (m << 16) |
+         (o0 << 15) | (ra << 10) | (n << 5) | (d);
 }
 
 static int64_t LogicalShiftReg(int64_t opc, int64_t N, int64_t rd, int64_t rn,
-	int64_t rm, int64_t shmod, uint32_t sh)
-{
-	return (opc << 29) | (0xa << 24) | (shmod << 22) | (N << 21) | (rm << 16) | MASKn(sh, 6, 10) | MASKn(rn, 6, 5) | rd;
+                               int64_t rm, int64_t shmod, uint32_t sh) {
+  return (opc << 29) | (0xa << 24) | (shmod << 22) | (N << 21) | (rm << 16) |
+         MASKn(sh, 6, 10) | MASKn(rn, 6, 5) | rd;
 }
 
 static int64_t LogicalShiftRegX(int64_t opc, int64_t N, int64_t rd, int64_t rn,
-	int64_t rm, int64_t shmod, uint32_t sh)
-{
-	return (1ll << 31) | (opc << 29) | (0xa << 24) | (shmod << 22) | (N << 21) | (rm << 16) | MASKn(sh, 6, 10) | MASKn(rn, 6, 5) | rd;
+                                int64_t rm, int64_t shmod, uint32_t sh) {
+  return (1ll << 31) | (opc << 29) | (0xa << 24) | (shmod << 22) | (N << 21) |
+         (rm << 16) | MASKn(sh, 6, 10) | MASKn(rn, 6, 5) | rd;
 }
 
 static int64_t CondSel(int64_t op, int64_t s, int64_t op2, int64_t d, int64_t n,
-	int64_t m, int64_t cond)
-{
-	return (op << 30) | (s << 29) | (m << 16) | (cond << 12) | (op2 << 10) | (n << 5) | (d);
+                       int64_t m, int64_t cond) {
+  return (op << 30) | (s << 29) | (m << 16) | (cond << 12) | (op2 << 10) |
+         (n << 5) | (d);
 }
 
 static int64_t CondSelX(int64_t op, int64_t s, int64_t op2, int64_t d,
-	int64_t n, int64_t m, int64_t cond)
-{
-	return (1 << 31) | (op << 30) | (s << 29) | (0xd4 << 21) | (m << 16) | (cond << 12) | (op2 << 10) | (n << 5) | (d);
+                        int64_t n, int64_t m, int64_t cond) {
+  return (1 << 31) | (op << 30) | (s << 29) | (0xd4 << 21) | (m << 16) |
+         (cond << 12) | (op2 << 10) | (n << 5) | (d);
 }
 
-static int64_t MvReg(int64_t d, int64_t n)
-{
-	if (d == 31 || n == 31) {
-		return AddSubImm(0, 0, d, n, 0, 0);
-	} else
-		return LogicalShiftReg(1, 0, d, 31, n, LSL, 0);
+static int64_t MvReg(int64_t d, int64_t n) {
+  if (d == 31 || n == 31) {
+    return AddSubImm(0, 0, d, n, 0, 0);
+  } else
+    return LogicalShiftReg(1, 0, d, 31, n, LSL, 0);
 }
 
-static int64_t MvRegX(int64_t d, int64_t n)
-{
-	if (d == 31 || n == 31) {
-		return AddSubImmX(0, 0, d, n, 0, 0);
-	} else
-		return LogicalShiftRegX(1, 0, d, 31, n, LSL, 0);
+static int64_t MvRegX(int64_t d, int64_t n) {
+  if (d == 31 || n == 31) {
+    return AddSubImmX(0, 0, d, n, 0, 0);
+  } else
+    return LogicalShiftRegX(1, 0, d, 31, n, LSL, 0);
 }
 
-int64_t LdStSimdFpRegRegShift(uint32_t opc, int64_t vt, int64_t rn, int64_t rm)
-{
-	uint32_t size = 3;
-	uint32_t option = 3;
-	uint32_t S = 1;
-	uint32_t V = 1;
-	return (size << 30) | (0x7 << 27) | (V << 26) | (opc << 22) | (1 << 21) | (rm << 16) | (option << 13) | (S << 12) | (2 << 10) | (rn << 5) | vt;
+int64_t LdStSimdFpRegRegShift(uint32_t opc, int64_t vt, int64_t rn,
+                              int64_t rm) {
+  uint32_t size = 3;
+  uint32_t option = 3;
+  uint32_t S = 1;
+  uint32_t V = 1;
+  return (size << 30) | (0x7 << 27) | (V << 26) | (opc << 22) | (1 << 21) |
+         (rm << 16) | (option << 13) | (S << 12) | (2 << 10) | (rn << 5) | vt;
 }
 
 // dst+=label
-int64_t ARM_adrX(int64_t d, int64_t pc_off)
-{
-	int32_t inst = 0x10 << 24;
-	ARM_FORCE_ALIGN(pc_off, 21, 0);
-	inst |= MASKn(d, 6, 0);
-	inst |= MASKn(pc_off >> 2, 19, 5);
-	inst |= MASKn(pc_off, 2, 29);
-	return inst;
+int64_t ARM_adrX(int64_t d, int64_t pc_off) {
+  int32_t inst = 0x10 << 24;
+  ARM_FORCE_ALIGN(pc_off, 21, 0);
+  inst |= MASKn(d, 6, 0);
+  inst |= MASKn(pc_off >> 2, 19, 5);
+  inst |= MASKn(pc_off, 2, 29);
+  return inst;
 }
 
-int64_t ARM_addImmX(int64_t d, int64_t n, int64_t imm)
-{
-	return AddSubImmX(0, 0, d, n, imm, 0);
+int64_t ARM_addImmX(int64_t d, int64_t n, int64_t imm) {
+  return AddSubImmX(0, 0, d, n, imm, 0);
 }
 
-int64_t ARM_subImmX(int64_t d, int64_t n, int64_t imm)
-{
-	return AddSubImmX(1, 0, d, n, imm, 0);
+int64_t ARM_subImmX(int64_t d, int64_t n, int64_t imm) {
+  return AddSubImmX(1, 0, d, n, imm, 0);
 }
 
-int64_t ARM_subsImmX(int64_t d, int64_t n, int64_t imm)
-{
-	return AddSubImmX(1, 1, d, n, imm, 0);
+int64_t ARM_subsImmX(int64_t d, int64_t n, int64_t imm) {
+  return AddSubImmX(1, 1, d, n, imm, 0);
 }
 
-int64_t ARM_cmpImmX(int64_t n, int64_t imm)
-{
-	return AddSubImmX(1, 1, 31, n, imm, 0);
+int64_t ARM_cmpImmX(int64_t n, int64_t imm) {
+  return AddSubImmX(1, 1, 31, n, imm, 0);
 }
 
-int64_t ARM_andRegX(int64_t rd, int64_t rn, int64_t rm)
-{
-	return LogicalShiftRegX(0, 0, rd, rn, rm, LSL, 0);
+int64_t ARM_andRegX(int64_t rd, int64_t rn, int64_t rm) {
+  return LogicalShiftRegX(0, 0, rd, rn, rm, LSL, 0);
 }
 
-int64_t ARM_orrRegX(int64_t rd, int64_t rn, int64_t rm)
-{
-	return LogicalShiftRegX(1, 0, rd, rn, rm, LSL, 0);
+int64_t ARM_orrRegX(int64_t rd, int64_t rn, int64_t rm) {
+  return LogicalShiftRegX(1, 0, rd, rn, rm, LSL, 0);
 }
 
 // MVN move negative
-int64_t ARM_mvnShift(int64_t rd, int64_t rm, int64_t shmod, int64_t sh)
-{
-	return LogicalShiftReg(1, 1, rd, 31, rm, shmod, sh);
+int64_t ARM_mvnShift(int64_t rd, int64_t rm, int64_t shmod, int64_t sh) {
+  return LogicalShiftReg(1, 1, rd, 31, rm, shmod, sh);
 }
 
-int64_t ARM_mvnShiftX(int64_t rd, int64_t rm, int64_t shmod, int64_t sh)
-{
-	return LogicalShiftRegX(1, 1, rd, 31, rm, shmod, sh);
+int64_t ARM_mvnShiftX(int64_t rd, int64_t rm, int64_t shmod, int64_t sh) {
+  return LogicalShiftRegX(1, 1, rd, 31, rm, shmod, sh);
 }
 
 // Psuedo inst i invented
-int64_t ARM_mvnReg(int64_t rd, int64_t rm)
-{
-	return LogicalShiftReg(1, 1, rd, 31, rm, LSL, 0);
+int64_t ARM_mvnReg(int64_t rd, int64_t rm) {
+  return LogicalShiftReg(1, 1, rd, 31, rm, LSL, 0);
 }
 
-int64_t ARM_mvnRegX(int64_t rd, int64_t rm)
-{
-	return LogicalShiftRegX(1, 1, rd, 31, rm, LSL, 0);
+int64_t ARM_mvnRegX(int64_t rd, int64_t rm) {
+  return LogicalShiftRegX(1, 1, rd, 31, rm, LSL, 0);
 }
 
 // exclusive xor
 int64_t ARM_eorShiftX(int64_t rd, int64_t rn, int64_t rm, int64_t shmod,
-	int64_t sh)
-{
-	return LogicalShiftRegX(2, 0, rd, rn, rm, shmod, sh);
+                      int64_t sh) {
+  return LogicalShiftRegX(2, 0, rd, rn, rm, shmod, sh);
 }
 
-int64_t ARM_eorRegX(int64_t rd, int64_t rn, int64_t rm)
-{
-	return ARM_eorShiftX(rd, rn, rm, LSL, 0);
+int64_t ARM_eorRegX(int64_t rd, int64_t rn, int64_t rm) {
+  return ARM_eorShiftX(rd, rn, rm, LSL, 0);
 }
 
-int64_t ARM_andsRegX(int64_t rd, int64_t rn, int64_t rm)
-{
-	return LogicalShiftRegX(3, 0, rd, rn, rm, LSL, 0);
+int64_t ARM_andsRegX(int64_t rd, int64_t rn, int64_t rm) {
+  return LogicalShiftRegX(3, 0, rd, rn, rm, LSL, 0);
 }
 
-int64_t ARM_movReg(int64_t d, int64_t n) { return MvReg(d, n); }
-
-int64_t ARM_movRegX(int64_t d, int64_t n) { return MvRegX(d, n); }
-
-int64_t ARM_addRegX(int64_t d, int64_t n, int64_t m)
-{
-	return AddSubShiftRegX(0, 0, d, n, m, LSL, 0, 0);
+int64_t ARM_movReg(int64_t d, int64_t n) {
+  return MvReg(d, n);
 }
 
-int64_t ARM_addsRegX(int64_t d, int64_t n, int64_t m)
-{
-	return AddSubShiftRegX(0, 1, d, n, m, LSL, 0, 0);
+int64_t ARM_movRegX(int64_t d, int64_t n) {
+  return MvRegX(d, n);
 }
 
-int64_t ARM_addsImmX(int64_t rd, int64_t rn, int64_t imm)
-{
-	return AddSubImmX(0, 1, rd, rn, imm, 0);
+int64_t ARM_addRegX(int64_t d, int64_t n, int64_t m) {
+  return AddSubShiftRegX(0, 0, d, n, m, LSL, 0, 0);
 }
 
-int64_t ARM_subRegX(int64_t d, int64_t n, int64_t m)
-{
-	return AddSubShiftRegX(1, 0, d, n, m, LSL, 0, 0);
+int64_t ARM_addsRegX(int64_t d, int64_t n, int64_t m) {
+  return AddSubShiftRegX(0, 1, d, n, m, LSL, 0, 0);
 }
 
-int64_t ARM_subsRegX(int64_t d, int64_t n, int64_t m)
-{
-	return AddSubShiftRegX(1, 1, d, n, m, LSL, 0, 0);
+int64_t ARM_addsImmX(int64_t rd, int64_t rn, int64_t imm) {
+  return AddSubImmX(0, 1, rd, rn, imm, 0);
 }
 
-int64_t ARM_negsRegX(int64_t d, int64_t m)
-{
-	return AddSubShiftRegX(1, 1, d, 31, m, LSL, 0, 1);
+int64_t ARM_subRegX(int64_t d, int64_t n, int64_t m) {
+  return AddSubShiftRegX(1, 0, d, n, m, LSL, 0, 0);
 }
 
-int64_t ARM_cmpRegX(int64_t n, int64_t m)
-{
-	return AddSubShiftRegX(1, 1, 31, n, m, LSL, 0, 1);
+int64_t ARM_subsRegX(int64_t d, int64_t n, int64_t m) {
+  return AddSubShiftRegX(1, 1, d, n, m, LSL, 0, 0);
 }
 
-int64_t ARM_csel(int64_t d, int64_t n, int64_t m, int64_t cond)
-{
-	return CondSel(0, 0, 0, d, n, m, cond);
+int64_t ARM_negsRegX(int64_t d, int64_t m) {
+  return AddSubShiftRegX(1, 1, d, 31, m, LSL, 0, 1);
 }
 
-int64_t ARM_cselX(int64_t d, int64_t n, int64_t m, int64_t cond)
-{
-	return CondSelX(0, 0, 0, d, n, m, cond);
+int64_t ARM_cmpRegX(int64_t n, int64_t m) {
+  return AddSubShiftRegX(1, 1, 31, n, m, LSL, 0, 1);
 }
 
-int64_t ARM_cset(int64_t d, int64_t cond)
-{
-	return CondSel(0, 0, 1, d, 31, 31, cond ^ 1);
+int64_t ARM_csel(int64_t d, int64_t n, int64_t m, int64_t cond) {
+  return CondSel(0, 0, 0, d, n, m, cond);
 }
 
-int64_t ARM_csetX(int64_t d, int64_t cond)
-{
-	return CondSelX(0, 0, 1, d, 31, 31, cond ^ 1);
+int64_t ARM_cselX(int64_t d, int64_t n, int64_t m, int64_t cond) {
+  return CondSelX(0, 0, 0, d, n, m, cond);
 }
 
-int64_t ARM_mulRegX(int64_t d, int64_t n, int64_t m)
-{
-	return DataProc3RegX(0, 0, 0, d, n, m, 31);
+int64_t ARM_cset(int64_t d, int64_t cond) {
+  return CondSel(0, 0, 1, d, 31, 31, cond ^ 1);
 }
 
-int64_t ARM_uxtb(int64_t d, int64_t n) { return Bitfield(2, d, n, 0, 7); }
-
-int64_t ARM_uxtbX(int64_t d, int64_t n) { return BitfieldX(2, d, n, 0, 7); }
-
-int64_t ARM_uxth(int64_t d, int64_t n) { return Bitfield(2, d, n, 0, 15); }
-
-int64_t ARM_uxthX(int64_t d, int64_t n) { return BitfieldX(2, d, n, 0, 15); }
-
-int64_t ARM_uxtwX(int64_t d, int64_t n) { return BitfieldX(2, d, n, 0, 31); }
-
-int64_t ARM_sxtb(int64_t d, int64_t n) { return BitfieldX(0, d, n, 0, 7); }
-
-int64_t ARM_sxtbX(int64_t d, int64_t n) { return BitfieldX(0, d, n, 0, 7); }
-
-int64_t ARM_sxth(int64_t d, int64_t n) { return Bitfield(0, d, n, 0, 15); }
-
-int64_t ARM_sxthX(int64_t d, int64_t n) { return BitfieldX(0, d, n, 0, 15); }
-
-int64_t ARM_sxtw(int64_t d, int64_t n) { return Bitfield(0, d, n, 0, 31); }
-
-int64_t ARM_sxtwX(int64_t d, int64_t n) { return BitfieldX(0, d, n, 0, 31); }
-
-int64_t ARM_asrImm(int64_t d, int64_t n, int64_t imm)
-{
-	return Bitfield(0, d, n, imm, 31);
+int64_t ARM_csetX(int64_t d, int64_t cond) {
+  return CondSelX(0, 0, 1, d, 31, 31, cond ^ 1);
 }
 
-int64_t ARM_asrImmX(int64_t d, int64_t n, int64_t imm)
-{
-	return BitfieldX(0, d, n, imm, 63);
+int64_t ARM_mulRegX(int64_t d, int64_t n, int64_t m) {
+  return DataProc3RegX(0, 0, 0, d, n, m, 31);
 }
 
-int64_t ARM_lslImm(int64_t d, int64_t n, int64_t imm)
-{
-	return Bitfield(2, d, n, MASKn(-imm % 32, 6, 0), 31 - imm);
+int64_t ARM_uxtb(int64_t d, int64_t n) {
+  return Bitfield(2, d, n, 0, 7);
 }
 
-int64_t ARM_lslImmX(int64_t d, int64_t n, int64_t imm)
-{
-	return BitfieldX(2, d, n, MASKn(-imm % 64, 6, 0), 63 - imm);
+int64_t ARM_uxtbX(int64_t d, int64_t n) {
+  return BitfieldX(2, d, n, 0, 7);
 }
 
-int64_t ARM_lsrImm(int64_t d, int64_t n, int64_t imm)
-{
-	return Bitfield(2, d, n, imm, 31);
+int64_t ARM_uxth(int64_t d, int64_t n) {
+  return Bitfield(2, d, n, 0, 15);
 }
 
-int64_t ARM_lsrImmX(int64_t d, int64_t n, int64_t imm)
-{
-	return BitfieldX(2, d, n, imm, 63);
+int64_t ARM_uxthX(int64_t d, int64_t n) {
+  return BitfieldX(2, d, n, 0, 15);
 }
-int64_t ARM_ret() { return UncondBrNoReg(2, 31, 0, 30, 0); }
 
-int64_t ARM_eret() { return UncondBrNoReg(4, 31, 0, 31, 0); }
+int64_t ARM_uxtwX(int64_t d, int64_t n) {
+  return BitfieldX(2, d, n, 0, 31);
+}
 
-int64_t ARM_br(int64_t r) { return UncondBr1Reg(0, 31, 0, r, 0); }
+int64_t ARM_sxtb(int64_t d, int64_t n) {
+  return BitfieldX(0, d, n, 0, 7);
+}
+
+int64_t ARM_sxtbX(int64_t d, int64_t n) {
+  return BitfieldX(0, d, n, 0, 7);
+}
+
+int64_t ARM_sxth(int64_t d, int64_t n) {
+  return Bitfield(0, d, n, 0, 15);
+}
+
+int64_t ARM_sxthX(int64_t d, int64_t n) {
+  return BitfieldX(0, d, n, 0, 15);
+}
+
+int64_t ARM_sxtw(int64_t d, int64_t n) {
+  return Bitfield(0, d, n, 0, 31);
+}
+
+int64_t ARM_sxtwX(int64_t d, int64_t n) {
+  return BitfieldX(0, d, n, 0, 31);
+}
+
+int64_t ARM_asrImm(int64_t d, int64_t n, int64_t imm) {
+  return Bitfield(0, d, n, imm, 31);
+}
+
+int64_t ARM_asrImmX(int64_t d, int64_t n, int64_t imm) {
+  return BitfieldX(0, d, n, imm, 63);
+}
+
+int64_t ARM_lslImm(int64_t d, int64_t n, int64_t imm) {
+  return Bitfield(2, d, n, MASKn(-imm % 32, 6, 0), 31 - imm);
+}
+
+int64_t ARM_lslImmX(int64_t d, int64_t n, int64_t imm) {
+  return BitfieldX(2, d, n, MASKn(-imm % 64, 6, 0), 63 - imm);
+}
+
+int64_t ARM_lsrImm(int64_t d, int64_t n, int64_t imm) {
+  return Bitfield(2, d, n, imm, 31);
+}
+
+int64_t ARM_lsrImmX(int64_t d, int64_t n, int64_t imm) {
+  return BitfieldX(2, d, n, imm, 63);
+}
+int64_t ARM_ret() {
+  return UncondBrNoReg(2, 31, 0, 30, 0);
+}
+
+int64_t ARM_eret() {
+  return UncondBrNoReg(4, 31, 0, 31, 0);
+}
+
+int64_t ARM_br(int64_t r) {
+  return UncondBr1Reg(0, 31, 0, r, 0);
+}
 
 // Func call
-int64_t ARM_blr(int64_t r) { return UncondBr1Reg(1, 31, 0, r, 0); }
+int64_t ARM_blr(int64_t r) {
+  return UncondBr1Reg(1, 31, 0, r, 0);
+}
 
-int64_t ARM_retReg(int64_t r) { return UncondBr1Reg(2, 31, 0, r, 0); }
+int64_t ARM_retReg(int64_t r) {
+  return UncondBr1Reg(2, 31, 0, r, 0);
+}
 
-int64_t ARM_bcc(int64_t cond, int64_t lab) { return CondBrImm(cond, lab); }
+int64_t ARM_bcc(int64_t cond, int64_t lab) {
+  return CondBrImm(cond, lab);
+}
 
-int64_t ARM_b(int64_t lab) { return UncondBrImm(0, lab); }
+int64_t ARM_b(int64_t lab) {
+  return UncondBrImm(0, lab);
+}
 
-int64_t ARM_bl(int64_t lab) { return UncondBrImm(1, lab); }
+int64_t ARM_bl(int64_t lab) {
+  return UncondBrImm(1, lab);
+}
 
 // Condition branch if not zero
-int64_t ARM_cbz(int64_t r, int64_t label) { return CompareBr(0, r, label); }
+int64_t ARM_cbz(int64_t r, int64_t label) {
+  return CompareBr(0, r, label);
+}
 
-int64_t ARM_cbzX(int64_t r, int64_t label) { return CompareBrX(0, r, label); }
+int64_t ARM_cbzX(int64_t r, int64_t label) {
+  return CompareBrX(0, r, label);
+}
 
 // Vice versa
-int64_t ARM_cbnz(int64_t r, int64_t label) { return CompareBr(1, r, label); }
+int64_t ARM_cbnz(int64_t r, int64_t label) {
+  return CompareBr(1, r, label);
+}
 
-int64_t ARM_cbnzX(int64_t r, int64_t label) { return CompareBrX(1, r, label); }
+int64_t ARM_cbnzX(int64_t r, int64_t label) {
+  return CompareBrX(1, r, label);
+}
 
 // This is one of Bungis's favorites,it tests if a bit is set and jumps
-int64_t ARM_tbz(int64_t rt, int64_t bit, int64_t label)
-{
-	return TestBr(0, rt, bit, label);
+int64_t ARM_tbz(int64_t rt, int64_t bit, int64_t label) {
+  return TestBr(0, rt, bit, label);
 }
 
-int64_t ARM_tbnz(int64_t rt, int64_t bit, int64_t label)
-{
-	return TestBr(1, rt, bit, label);
+int64_t ARM_tbnz(int64_t rt, int64_t bit, int64_t label) {
+  return TestBr(1, rt, bit, label);
 }
 
-int64_t ARM_strbRegReg(int64_t r, int64_t a, int64_t b)
-{
-	return LdStRegReg(0, 0, r, a, b, 0);
+int64_t ARM_strbRegReg(int64_t r, int64_t a, int64_t b) {
+  return LdStRegReg(0, 0, r, a, b, 0);
 }
 
-int64_t ARM_strbRegImm(int64_t r, int64_t n, int64_t off)
-{
-	CARMAdrRegImm adr;
-	adr.n = n;
-	adr.off = off;
-	return LdStRegUnImm(0, 0, r, &adr);
+int64_t ARM_strbRegImm(int64_t r, int64_t n, int64_t off) {
+  CARMAdrRegImm adr;
+  adr.n = n;
+  adr.off = off;
+  return LdStRegUnImm(0, 0, r, &adr);
 }
 
-int64_t ARM_ldrbRegImm(int64_t r, int64_t n, int64_t off)
-{
-	CARMAdrRegImm adr;
-	adr.n = n;
-	adr.off = off;
-	return LdStRegUnImm(0, 1, r, &adr);
+int64_t ARM_ldrbRegImm(int64_t r, int64_t n, int64_t off) {
+  CARMAdrRegImm adr;
+  adr.n = n;
+  adr.off = off;
+  return LdStRegUnImm(0, 1, r, &adr);
 }
 
-int64_t ARM_ldrbRegReg(int64_t r, int64_t a, int64_t b)
-{
-	return LdStRegReg(0, 1, r, a, b, 0);
+int64_t ARM_ldrbRegReg(int64_t r, int64_t a, int64_t b) {
+  return LdStRegReg(0, 1, r, a, b, 0);
 }
 
-int64_t ARM_strhRegReg(int64_t r, int64_t a, int64_t b)
-{
-	return LdStRegReg(1, 0, r, a, b, 0);
+int64_t ARM_strhRegReg(int64_t r, int64_t a, int64_t b) {
+  return LdStRegReg(1, 0, r, a, b, 0);
 }
 
-int64_t ARM_strhRegImm(int64_t r, int64_t n, int64_t off)
-{
-	CARMAdrRegImm adr;
-	adr.n = n;
-	adr.off = off;
-	return LdStRegUnImm(1, 0, r, &adr);
+int64_t ARM_strhRegImm(int64_t r, int64_t n, int64_t off) {
+  CARMAdrRegImm adr;
+  adr.n = n;
+  adr.off = off;
+  return LdStRegUnImm(1, 0, r, &adr);
 }
 
-int64_t ARM_ldrhRegReg(int64_t r, int64_t a, int64_t b)
-{
-	return LdStRegReg(1, 1, r, a, b, 0);
+int64_t ARM_ldrhRegReg(int64_t r, int64_t a, int64_t b) {
+  return LdStRegReg(1, 1, r, a, b, 0);
 }
 
-int64_t ARM_ldrhRegImm(int64_t r, int64_t n, int64_t off)
-{
-	CARMAdrRegImm adr;
-	adr.n = n;
-	adr.off = off;
-	return LdStRegUnImm(1, 1, r, &adr);
+int64_t ARM_ldrhRegImm(int64_t r, int64_t n, int64_t off) {
+  CARMAdrRegImm adr;
+  adr.n = n;
+  adr.off = off;
+  return LdStRegUnImm(1, 1, r, &adr);
 }
 
-int64_t ARM_strRegImm(int64_t r, int64_t n, int64_t off)
-{
-	CARMAdrRegImm adr;
-	adr.n = n;
-	adr.off = off;
-	return LdStRegUnImm(2, 0, r, &adr);
+int64_t ARM_strRegImm(int64_t r, int64_t n, int64_t off) {
+  CARMAdrRegImm adr;
+  adr.n = n;
+  adr.off = off;
+  return LdStRegUnImm(2, 0, r, &adr);
 }
 
-int64_t ARM_strRegReg(int64_t r, int64_t a, int64_t b)
-{
-	return LdStRegReg(2, 0, r, a, b, 0);
+int64_t ARM_strRegReg(int64_t r, int64_t a, int64_t b) {
+  return LdStRegReg(2, 0, r, a, b, 0);
 }
 
-int64_t ARM_ldrRegReg(int64_t r, int64_t a, int64_t b)
-{
-	return LdStRegReg(2, 1, r, a, b, 0);
+int64_t ARM_ldrRegReg(int64_t r, int64_t a, int64_t b) {
+  return LdStRegReg(2, 1, r, a, b, 0);
 }
 
-int64_t ARM_ldrRegImm(int64_t r, int64_t n, int64_t off)
-{
-	CARMAdrRegImm adr;
-	adr.n = n;
-	adr.off = off;
-	return LdStRegUnImm(2, 1, r, &adr);
+int64_t ARM_ldrRegImm(int64_t r, int64_t n, int64_t off) {
+  CARMAdrRegImm adr;
+  adr.n = n;
+  adr.off = off;
+  return LdStRegUnImm(2, 1, r, &adr);
 }
 
-int64_t ARM_strRegImmX(int64_t r, int64_t n, int64_t off)
-{
-	CARMAdrRegImm adr;
-	adr.n = n;
-	adr.off = off;
-	return LdStRegUnImm(3, 0, r, &adr);
+int64_t ARM_strRegImmX(int64_t r, int64_t n, int64_t off) {
+  CARMAdrRegImm adr;
+  adr.n = n;
+  adr.off = off;
+  return LdStRegUnImm(3, 0, r, &adr);
 }
 
-int64_t ARM_ldrRegImmX(int64_t r, int64_t n, int64_t off)
-{
-	CARMAdrRegImm adr;
-	adr.n = n;
-	adr.off = off;
-	return LdStRegUnImm(3, 1, r, &adr);
+int64_t ARM_ldrRegImmX(int64_t r, int64_t n, int64_t off) {
+  CARMAdrRegImm adr;
+  adr.n = n;
+  adr.off = off;
+  return LdStRegUnImm(3, 1, r, &adr);
 }
 
-int64_t ARM_strRegRegX(int64_t r, int64_t a, int64_t b)
-{
-	return LdStRegReg(3, 0, r, a, b, 0);
+int64_t ARM_strRegRegX(int64_t r, int64_t a, int64_t b) {
+  return LdStRegReg(3, 0, r, a, b, 0);
 }
-int64_t ARM_ldrRegRegX(int64_t r, int64_t a, int64_t b)
-{
-	return LdStRegReg(3, 1, r, a, b, 0);
+int64_t ARM_ldrRegRegX(int64_t r, int64_t a, int64_t b) {
+  return LdStRegReg(3, 1, r, a, b, 0);
 }
 
-int64_t ARM_fmulReg(int64_t d, int64_t n, int64_t m)
-{
-	return FpDataProc2Reg(0, 0, 1, 0, d, n, m);
+int64_t ARM_fmulReg(int64_t d, int64_t n, int64_t m) {
+  return FpDataProc2Reg(0, 0, 1, 0, d, n, m);
 }
 
-int64_t ARM_fdivReg(int64_t d, int64_t n, int64_t m)
-{
-	return FpDataProc2Reg(0, 0, 1, 1, d, n, m);
+int64_t ARM_fdivReg(int64_t d, int64_t n, int64_t m) {
+  return FpDataProc2Reg(0, 0, 1, 1, d, n, m);
 }
 
-int64_t ARM_faddReg(int64_t d, int64_t n, int64_t m)
-{
-	return FpDataProc2Reg(0, 0, 1, 2, d, n, m);
+int64_t ARM_faddReg(int64_t d, int64_t n, int64_t m) {
+  return FpDataProc2Reg(0, 0, 1, 2, d, n, m);
 }
 
-int64_t ARM_fsubReg(int64_t d, int64_t n, int64_t m)
-{
-	return FpDataProc2Reg(0, 0, 1, 3, d, n, m);
+int64_t ARM_fsubReg(int64_t d, int64_t n, int64_t m) {
+  return FpDataProc2Reg(0, 0, 1, 3, d, n, m);
 }
 
-int64_t ARM_scvtf(int64_t d, int64_t n)
-{
-	return ConversionFpIntFI(1, 0, 1, 0, 2, d, n);
+int64_t ARM_scvtf(int64_t d, int64_t n) {
+  return ConversionFpIntFI(1, 0, 1, 0, 2, d, n);
 }
 
-int64_t ARM_ucvtf(int64_t d, int64_t n)
-{
-	return ConversionFpIntFI(1, 0, 1, 0, 3, d, n);
+int64_t ARM_ucvtf(int64_t d, int64_t n) {
+  return ConversionFpIntFI(1, 0, 1, 0, 3, d, n);
 }
 
-int64_t ARM_fcvtzs(int64_t d, int64_t n)
-{
-	return ConversionFpIntIF(1, 0, 1, 3, 0, d, n);
+int64_t ARM_fcvtzs(int64_t d, int64_t n) {
+  return ConversionFpIntIF(1, 0, 1, 3, 0, d, n);
 }
 
-int64_t ARM_ldrLabel(int64_t d, int64_t label)
-{
-	return LdRegLiteralEnc(0, 0, d, label);
+int64_t ARM_ldrLabel(int64_t d, int64_t label) {
+  return LdRegLiteralEnc(0, 0, d, label);
 }
 
-int64_t ARM_ldrLabelX(int64_t d, int64_t label)
-{
-	return LdRegLiteralEnc(1, 0, d, label);
+int64_t ARM_ldrLabelX(int64_t d, int64_t label) {
+  return LdRegLiteralEnc(1, 0, d, label);
 }
 
-int64_t ARM_ldrLabelF64(int64_t d, int64_t label)
-{
-	return LdRegSimdFpLiteralEnc(d, label);
+int64_t ARM_ldrLabelF64(int64_t d, int64_t label) {
+  return LdRegSimdFpLiteralEnc(d, label);
 }
 
-int64_t ARM_strPostImm(int64_t r, int64_t b, int64_t off)
-{
-	CARMAdrPreImm adr = { b, off };
-	return LdStRegPostImm(2, 0, r, &adr);
+int64_t ARM_strPostImm(int64_t r, int64_t b, int64_t off) {
+  CARMAdrPreImm adr = {b, off};
+  return LdStRegPostImm(2, 0, r, &adr);
 }
 
-int64_t ARM_ldrPostImm(int64_t r, int64_t b, int64_t off)
-{
-	CARMAdrPreImm adr = { b, off };
-	return LdStRegPostImm(2, 1, r, &adr);
+int64_t ARM_ldrPostImm(int64_t r, int64_t b, int64_t off) {
+  CARMAdrPreImm adr = {b, off};
+  return LdStRegPostImm(2, 1, r, &adr);
 }
 
-int64_t ARM_strPreImm(int64_t r, int64_t b, int64_t off)
-{
-	CARMAdrPreImm adr = { b, off };
-	return LdStRegPre(2, 0, r, &adr);
+int64_t ARM_strPreImm(int64_t r, int64_t b, int64_t off) {
+  CARMAdrPreImm adr = {b, off};
+  return LdStRegPre(2, 0, r, &adr);
 }
 
-int64_t ARM_ldrPreImm(int64_t r, int64_t b, int64_t off)
-{
-	CARMAdrPreImm adr = { b, off };
-	return LdStRegPre(2, 1, r, &adr);
+int64_t ARM_ldrPreImm(int64_t r, int64_t b, int64_t off) {
+  CARMAdrPreImm adr = {b, off};
+  return LdStRegPre(2, 1, r, &adr);
 }
 
-int64_t ARM_strPostImmX(int64_t r, int64_t b, int64_t off)
-{
-	CARMAdrPreImm adr = { b, off };
-	return LdStRegPostImm(3, 0, r, &adr);
+int64_t ARM_strPostImmX(int64_t r, int64_t b, int64_t off) {
+  CARMAdrPreImm adr = {b, off};
+  return LdStRegPostImm(3, 0, r, &adr);
 }
 
-int64_t ARM_ldrPostImmX(int64_t r, int64_t b, int64_t off)
-{
-	CARMAdrPreImm adr = { b, off };
-	return LdStRegPostImm(3, 1, r, &adr);
+int64_t ARM_ldrPostImmX(int64_t r, int64_t b, int64_t off) {
+  CARMAdrPreImm adr = {b, off};
+  return LdStRegPostImm(3, 1, r, &adr);
 }
 
-int64_t ARM_strPreImmX(int64_t r, int64_t b, int64_t off)
-{
-	CARMAdrPreImm adr = { b, off };
-	return LdStRegPre(3, 0, r, &adr);
+int64_t ARM_strPreImmX(int64_t r, int64_t b, int64_t off) {
+  CARMAdrPreImm adr = {b, off};
+  return LdStRegPre(3, 0, r, &adr);
 }
 
-int64_t ARM_ldrPreImmX(int64_t r, int64_t b, int64_t off)
-{
-	CARMAdrPreImm adr = { b, off };
-	return LdStRegPre(3, 1, r, &adr);
+int64_t ARM_ldrPreImmX(int64_t r, int64_t b, int64_t off) {
+  CARMAdrPreImm adr = {b, off};
+  return LdStRegPre(3, 1, r, &adr);
 }
 
 //
@@ -799,157 +775,135 @@ int64_t ARM_ldrPreImmX(int64_t r, int64_t b, int64_t off)
 // LDP load a pair of registers
 //
 
-int64_t ARM_stpPreImm(int64_t r, int64_t r2, int64_t b, int64_t off)
-{
-	CARMAdrPreImm adr = { b, off };
-	return LdStRegPairPre(0, 0, r, r2, &adr);
+int64_t ARM_stpPreImm(int64_t r, int64_t r2, int64_t b, int64_t off) {
+  CARMAdrPreImm adr = {b, off};
+  return LdStRegPairPre(0, 0, r, r2, &adr);
 }
 
-int64_t ARM_stpPreImmX(int64_t r, int64_t r2, int64_t b, int64_t off)
-{
-	CARMAdrPreImm adr = { b, off };
-	return LdStRegPairPre(2, 0, r, r2, &adr);
+int64_t ARM_stpPreImmX(int64_t r, int64_t r2, int64_t b, int64_t off) {
+  CARMAdrPreImm adr = {b, off};
+  return LdStRegPairPre(2, 0, r, r2, &adr);
 }
 
-int64_t ARM_ldpPreImm(int64_t r, int64_t r2, int64_t b, int64_t off)
-{
-	CARMAdrPreImm adr = { b, off };
-	return LdStRegPairPre(0, 1, r, r2, &adr);
+int64_t ARM_ldpPreImm(int64_t r, int64_t r2, int64_t b, int64_t off) {
+  CARMAdrPreImm adr = {b, off};
+  return LdStRegPairPre(0, 1, r, r2, &adr);
 }
 
-int64_t ARM_ldpPreImmX(int64_t r, int64_t r2, int64_t b, int64_t off)
-{
-	CARMAdrPreImm adr = { b, off };
-	return LdStRegPairPre(2, 1, r, r2, &adr);
+int64_t ARM_ldpPreImmX(int64_t r, int64_t r2, int64_t b, int64_t off) {
+  CARMAdrPreImm adr = {b, off};
+  return LdStRegPairPre(2, 1, r, r2, &adr);
 }
 
-int64_t ARM_stpPostImm(int64_t r, int64_t r2, int64_t b, int64_t off)
-{
-	CARMAdrPreImm adr = { b, off };
-	return LdStRegPairPostImm(0, 0, r, r2, &adr);
+int64_t ARM_stpPostImm(int64_t r, int64_t r2, int64_t b, int64_t off) {
+  CARMAdrPreImm adr = {b, off};
+  return LdStRegPairPostImm(0, 0, r, r2, &adr);
 }
 
-int64_t ARM_stpPostImmX(int64_t r, int64_t r2, int64_t b, int64_t off)
-{
-	CARMAdrPreImm adr = { b, off };
-	return LdStRegPairPostImm(2, 0, r, r2, &adr);
+int64_t ARM_stpPostImmX(int64_t r, int64_t r2, int64_t b, int64_t off) {
+  CARMAdrPreImm adr = {b, off};
+  return LdStRegPairPostImm(2, 0, r, r2, &adr);
 }
 
-int64_t ARM_ldpPostImm(int64_t r, int64_t r2, int64_t b, int64_t off)
-{
-	CARMAdrPreImm adr = { b, off };
-	return LdStRegPairPostImm(0, 1, r, r2, &adr);
+int64_t ARM_ldpPostImm(int64_t r, int64_t r2, int64_t b, int64_t off) {
+  CARMAdrPreImm adr = {b, off};
+  return LdStRegPairPostImm(0, 1, r, r2, &adr);
 }
 
-int64_t ARM_ldpPostImmX(int64_t r, int64_t r2, int64_t b, int64_t off)
-{
-	CARMAdrPreImm adr = { b, off };
-	return LdStRegPairPostImm(2, 1, r, r2, &adr);
+int64_t ARM_ldpPostImmX(int64_t r, int64_t r2, int64_t b, int64_t off) {
+  CARMAdrPreImm adr = {b, off};
+  return LdStRegPairPostImm(2, 1, r, r2, &adr);
 }
 
-int64_t ARM_ldrRegImmF64(int64_t r, int64_t n, uint64_t off)
-{
-	return LdStSimdFpUnImm(1, r, n, off);
+int64_t ARM_ldrRegImmF64(int64_t r, int64_t n, uint64_t off) {
+  return LdStSimdFpUnImm(1, r, n, off);
 }
 
-int64_t ARM_strRegImmF64(int64_t r, int64_t n, uint64_t off)
-{
-	return LdStSimdFpUnImm(0, r, n, off);
+int64_t ARM_strRegImmF64(int64_t r, int64_t n, uint64_t off) {
+  return LdStSimdFpUnImm(0, r, n, off);
 }
 
-int64_t ARM_fnegReg(int64_t d, int64_t s)
-{
-	return FpDataProc1Reg(0, 0, 1, 2, d, s);
+int64_t ARM_fnegReg(int64_t d, int64_t s) {
+  return FpDataProc1Reg(0, 0, 1, 2, d, s);
 }
 
-int64_t ARM_fmovReg(int64_t d, int64_t s)
-{
-	return FpDataProc1Reg(0, 0, 1, 0, d, s);
+int64_t ARM_fmovReg(int64_t d, int64_t s) {
+  return FpDataProc1Reg(0, 0, 1, 0, d, s);
 }
 
-int64_t ARM_fcmp(int64_t a, int64_t b) { return FpComp(0, 0, 1, 0, 0, a, b); }
-
-int64_t ARM_sdivRegX(int64_t d, int64_t n, int64_t m)
-{
-	return DataProc2Src(3, d, n, m);
+int64_t ARM_fcmp(int64_t a, int64_t b) {
+  return FpComp(0, 0, 1, 0, 0, a, b);
 }
 
-int64_t ARM_lslvRegX(int64_t d, int64_t n, int64_t m)
-{
-	return DataProc2Src(8, d, n, m);
+int64_t ARM_sdivRegX(int64_t d, int64_t n, int64_t m) {
+  return DataProc2Src(3, d, n, m);
 }
 
-int64_t ARM_lsrvRegX(int64_t d, int64_t n, int64_t m)
-{
-	return DataProc2Src(9, d, n, m);
+int64_t ARM_lslvRegX(int64_t d, int64_t n, int64_t m) {
+  return DataProc2Src(8, d, n, m);
 }
 
-int64_t ARM_asrvRegX(int64_t d, int64_t n, int64_t m)
-{
-	return DataProc2Src(10, d, n, m);
+int64_t ARM_lsrvRegX(int64_t d, int64_t n, int64_t m) {
+  return DataProc2Src(9, d, n, m);
 }
 
-int64_t ARM_movzImmX(int64_t d, int64_t i16, int64_t sh)
-{
-	switch (sh) {
-	case 0:
-	case 16:
-	case 32:
-	case 48:
-		break;
-	default:
-		throw(*(uint32_t*)"ASM");
-	}
-	return MvWideImmX(2, d, i16, sh);
-}
-int64_t ARM_movnImmX(int64_t d, int64_t i16, int64_t sh)
-{
-	switch (sh) {
-	case 0:
-	case 16:
-	case 32:
-	case 48:
-		break;
-	default:
-		throw(*(uint32_t*)"ASM");
-	}
-	return MvWideImmX(0, d, i16, sh);
+int64_t ARM_asrvRegX(int64_t d, int64_t n, int64_t m) {
+  return DataProc2Src(10, d, n, m);
 }
 
-int64_t ARM_strPostImmF64(int64_t d, int64_t p, int64_t off)
-{
-	return LdStSimdFpRegPostImm(0, d, p, off);
+int64_t ARM_movzImmX(int64_t d, int64_t i16, int64_t sh) {
+  switch (sh) {
+  case 0:
+  case 16:
+  case 32:
+  case 48:
+    break;
+  default:
+    throw(*(uint32_t *)"ASM");
+  }
+  return MvWideImmX(2, d, i16, sh);
 }
-int64_t ARM_ldrPostImmF64(int64_t d, int64_t p, int64_t off)
-{
-	return LdStSimdFpRegPostImm(1, d, p, off);
-}
-
-int64_t ARM_strPreImmF64(int64_t d, int64_t p, int64_t off)
-{
-	return LdStSimdFpRegPreImm(0, d, p, off);
-}
-int64_t ARM_ldrPreImmF64(int64_t d, int64_t p, int64_t off)
-{
-	return LdStSimdFpRegPreImm(1, d, p, off);
-}
-static int64_t LdStSimdFpReg(int64_t opc, int64_t d, int64_t n, int64_t m)
-{
-	uint32_t size = 3;
-	uint32_t option = 3;
-	uint32_t S = 0;
-	uint32_t V = 1;
-	return (size << 30) | (0x7 << 27) | (V << 26) | (opc << 22) | (1 << 21) | (m << 16) | (option << 13) | (S << 12) | (2 << 10) | (n << 5) | d;
-}
-
-int64_t ARM_strRegRegF64(int64_t d, int64_t n, int64_t m)
-{
-	return LdStSimdFpReg(0, d, n, m);
+int64_t ARM_movnImmX(int64_t d, int64_t i16, int64_t sh) {
+  switch (sh) {
+  case 0:
+  case 16:
+  case 32:
+  case 48:
+    break;
+  default:
+    throw(*(uint32_t *)"ASM");
+  }
+  return MvWideImmX(0, d, i16, sh);
 }
 
-int64_t ARM_ldrRegRegF64(int64_t d, int64_t n, int64_t m)
-{
-	return LdStSimdFpReg(1, d, n, m);
+int64_t ARM_strPostImmF64(int64_t d, int64_t p, int64_t off) {
+  return LdStSimdFpRegPostImm(0, d, p, off);
+}
+int64_t ARM_ldrPostImmF64(int64_t d, int64_t p, int64_t off) {
+  return LdStSimdFpRegPostImm(1, d, p, off);
+}
+
+int64_t ARM_strPreImmF64(int64_t d, int64_t p, int64_t off) {
+  return LdStSimdFpRegPreImm(0, d, p, off);
+}
+int64_t ARM_ldrPreImmF64(int64_t d, int64_t p, int64_t off) {
+  return LdStSimdFpRegPreImm(1, d, p, off);
+}
+static int64_t LdStSimdFpReg(int64_t opc, int64_t d, int64_t n, int64_t m) {
+  uint32_t size = 3;
+  uint32_t option = 3;
+  uint32_t S = 0;
+  uint32_t V = 1;
+  return (size << 30) | (0x7 << 27) | (V << 26) | (opc << 22) | (1 << 21) |
+         (m << 16) | (option << 13) | (S << 12) | (2 << 10) | (n << 5) | d;
+}
+
+int64_t ARM_strRegRegF64(int64_t d, int64_t n, int64_t m) {
+  return LdStSimdFpReg(0, d, n, m);
+}
+
+int64_t ARM_ldrRegRegF64(int64_t d, int64_t n, int64_t m) {
+  return LdStSimdFpReg(1, d, n, m);
 }
 
 //
@@ -957,63 +911,51 @@ int64_t ARM_ldrRegRegF64(int64_t d, int64_t n, int64_t m)
 // a prayer for the ARM developers. In HolyC,typecasts are "bit-for-bit"
 // and ARM allows us to do "bit-for-bit" transfers easily with fmov and freinds
 //
-int64_t ARM_fmovI64F64(int64_t d, int64_t s)
-{
-	return ConversionFpIntIF(1, 0, 1, 0, 6, d, s);
+int64_t ARM_fmovI64F64(int64_t d, int64_t s) {
+  return ConversionFpIntIF(1, 0, 1, 0, 6, d, s);
 }
-int64_t ARM_fmovF64I64(int64_t d, int64_t s)
-{
-	return ConversionFpIntFI(1, 0, 1, 0, 7, d, s);
+int64_t ARM_fmovF64I64(int64_t d, int64_t s) {
+  return ConversionFpIntFI(1, 0, 1, 0, 7, d, s);
 }
 
-int64_t ARM_strbRegRegShift(int64_t a, int64_t n, int64_t m)
-{
-	return LdStRegReg(0, 0, a, n, m, 1);
+int64_t ARM_strbRegRegShift(int64_t a, int64_t n, int64_t m) {
+  return LdStRegReg(0, 0, a, n, m, 1);
 }
 
-int64_t ARM_ldrbRegRegShift(int64_t a, int64_t n, int64_t m)
-{
-	return LdStRegReg(0, 1, a, n, m, 1);
+int64_t ARM_ldrbRegRegShift(int64_t a, int64_t n, int64_t m) {
+  return LdStRegReg(0, 1, a, n, m, 1);
 }
 
-int64_t ARM_strhRegRegShift(int64_t a, int64_t n, int64_t m)
-{
-	return LdStRegReg(1, 0, a, n, m, 1);
+int64_t ARM_strhRegRegShift(int64_t a, int64_t n, int64_t m) {
+  return LdStRegReg(1, 0, a, n, m, 1);
 }
 
-int64_t ARM_ldrhRegRegShift(int64_t a, int64_t n, int64_t m)
-{
-	return LdStRegReg(1, 1, a, n, m, 1);
+int64_t ARM_ldrhRegRegShift(int64_t a, int64_t n, int64_t m) {
+  return LdStRegReg(1, 1, a, n, m, 1);
 }
 
-int64_t ARM_strRegRegShift(int64_t a, int64_t n, int64_t m)
-{
-	return LdStRegReg(2, 0, a, n, m, 1);
+int64_t ARM_strRegRegShift(int64_t a, int64_t n, int64_t m) {
+  return LdStRegReg(2, 0, a, n, m, 1);
 }
 
-int64_t ARM_ldrRegRegShift(int64_t a, int64_t n, int64_t m)
-{
-	return LdStRegReg(2, 1, a, n, m, 1);
+int64_t ARM_ldrRegRegShift(int64_t a, int64_t n, int64_t m) {
+  return LdStRegReg(2, 1, a, n, m, 1);
 }
 
-int64_t ARM_strRegRegShiftX(int64_t a, int64_t n, int64_t m)
-{
-	return LdStRegReg(3, 0, a, n, m, 1);
+int64_t ARM_strRegRegShiftX(int64_t a, int64_t n, int64_t m) {
+  return LdStRegReg(3, 0, a, n, m, 1);
 }
 
-int64_t ARM_ldrRegRegShiftX(int64_t a, int64_t n, int64_t m)
-{
-	return LdStRegReg(3, 1, a, n, m, 1);
+int64_t ARM_ldrRegRegShiftX(int64_t a, int64_t n, int64_t m) {
+  return LdStRegReg(3, 1, a, n, m, 1);
 }
 
-int64_t ARM_ldrRegRegShiftF64(int64_t a, int64_t n, int64_t m)
-{
-	return LdStSimdFpRegRegShift(1, a, n, m);
+int64_t ARM_ldrRegRegShiftF64(int64_t a, int64_t n, int64_t m) {
+  return LdStSimdFpRegRegShift(1, a, n, m);
 }
 
-int64_t ARM_strRegRegShiftF64(int64_t a, int64_t n, int64_t m)
-{
-	return LdStSimdFpRegRegShift(0, a, n, m);
+int64_t ARM_strRegRegShiftF64(int64_t a, int64_t n, int64_t m) {
+  return LdStSimdFpRegRegShift(0, a, n, m);
 }
 
 //
@@ -1023,153 +965,155 @@ int64_t ARM_strRegRegShiftF64(int64_t a, int64_t n, int64_t m)
 //
 
 // Return's -1 on poo poo unencodable
-static int64_t GenNImmSImmR(int64_t imm)
-{
-	// TODO write this stuff in assemblt
-	if (imm == 0 || ~imm == 0)
-		return ARM_ERR_INV_OFF;
-	int64_t consec = 0, idx, zero_gap = 0, first_zeros, width, x;
-	uint64_t pattern;
+static int64_t GenNImmSImmR(int64_t imm) {
+  // TODO write this stuff in assemblt
+  if (imm == 0 || ~imm == 0)
+    return ARM_ERR_INV_OFF;
+  int64_t consec = 0, idx, zero_gap = 0, first_zeros, width, x;
+  uint64_t pattern;
 #define ROT(x, n) ((x) >> n) | ((x) << (64 - n))
-	// Find first 1
-	zero_gap = __builtin_ctzl(imm);
-	// Count consecitive bits for the pattern
-	consec = __builtin_ctzl((~imm) >> zero_gap);
-	// If leading is zero,check the number of ones at the end
-	if (zero_gap == 0) {
-		// Zeros may be present at the other side of  the ones
-		//"[10000111]"
-		//    ^^^^
-		if ((imm >> consec) == 0)
-			zero_gap = 64 - consec;
-		else
-			zero_gap = __builtin_ctzl(imm >> consec) - consec;
-		consec += __builtin_clzl(~imm);
-	} else if (zero_gap != 0) {
-		// add leading 0s to the gap amount
-		zero_gap += __builtin_clzl(imm);
-	}
-	// Our pattern size is zero_gap+consec
-	width = zero_gap + consec;
-	switch (width) {
-#define MAKE_PATT                           \
-	x = consec - 1;                         \
-	pattern = 0;                            \
-	for (idx = 0; idx != 64 / width; idx++) \
-		if (!idx)                           \
-			pattern |= (1l << consec) - 1l; \
-		else                                \
-			pattern |= ((1l << consec) - 1l) << (width * idx);
+  // Find first 1
+  zero_gap = __builtin_ctzl(imm);
+  // Count consecitive bits for the pattern
+  consec = __builtin_ctzl((~imm) >> zero_gap);
+  // If leading is zero,check the number of ones at the end
+  if (zero_gap == 0) {
+    // Zeros may be present at the other side of  the ones
+    //"[10000111]"
+    //    ^^^^
+    if ((imm >> consec) == 0)
+      zero_gap = 64 - consec;
+    else
+      zero_gap = __builtin_ctzl(imm >> consec) - consec;
+    consec += __builtin_clzl(~imm);
+  } else if (zero_gap != 0) {
+    // add leading 0s to the gap amount
+    zero_gap += __builtin_clzl(imm);
+  }
+  // Our pattern size is zero_gap+consec
+  width = zero_gap + consec;
+  switch (width) {
+#define MAKE_PATT                                                              \
+  x = consec - 1;                                                              \
+  pattern = 0;                                                                 \
+  for (idx = 0; idx != 64 / width; idx++)                                      \
+    if (!idx)                                                                  \
+      pattern |= (1l << consec) - 1l;                                          \
+    else                                                                       \
+      pattern |= ((1l << consec) - 1l) << (width * idx);
 
-#define CHECK_PATT(n)                          \
-	for (idx = 0; idx != width; idx++)         \
-		if (pattern == imm)                    \
-			return (n << 12) | (idx << 6) | x; \
-		else                                   \
-			pattern = ROT(pattern, 1);
-		break;
-	case 2:
-		MAKE_PATT;
-		CHECK_PATT(0);
-		break;
-	case 4:
-		MAKE_PATT;
-		CHECK_PATT(0);
-		break;
-	case 8:
-		MAKE_PATT;
-		CHECK_PATT(0);
-		break;
-	case 16:
-		MAKE_PATT;
-		CHECK_PATT(0);
-		break;
-	case 32:
-		MAKE_PATT;
-		CHECK_PATT(0);
-		break;
-	case 64:
-		MAKE_PATT;
-		CHECK_PATT(1);
-		break;
-	default:;
-	}
-	return ARM_ERR_INV_OFF;
-}
-
-static int64_t LogicalImm(int64_t opc, int64_t d, int64_t s, int64_t i)
-{
-	int64_t poodle = GenNImmSImmR(i);
-	if (i == ARM_ERR_INV_OFF)
-		return i;
-	return MASKn(opc, 8, 29) | MASKn(0x24, 8, 23) | MASKn(s, 14, 10) | MASKn(s, 6, 5) | MASKn(d, 6, 0);
+#define CHECK_PATT(n)                                                          \
+  for (idx = 0; idx != width; idx++)                                           \
+    if (pattern == imm)                                                        \
+      return (n << 12) | (idx << 6) | x;                                       \
+    else                                                                       \
+      pattern = ROT(pattern, 1);
+    break;
+  case 2:
+    MAKE_PATT;
+    CHECK_PATT(0);
+    break;
+  case 4:
+    MAKE_PATT;
+    CHECK_PATT(0);
+    break;
+  case 8:
+    MAKE_PATT;
+    CHECK_PATT(0);
+    break;
+  case 16:
+    MAKE_PATT;
+    CHECK_PATT(0);
+    break;
+  case 32:
+    MAKE_PATT;
+    CHECK_PATT(0);
+    break;
+  case 64:
+    MAKE_PATT;
+    CHECK_PATT(1);
+    break;
+  default:;
+  }
+  return ARM_ERR_INV_OFF;
 }
 
-static int64_t LogicalImmX(int64_t opc, int64_t d, int64_t s, int64_t i)
-{
-	int64_t poodle = GenNImmSImmR(i);
-	if (poodle == ARM_ERR_INV_OFF)
-		return poodle;
-	return (1 << 31) | MASKn(opc, 8, 29) | MASKn(0x24, 8, 23) | MASKn(poodle, 14, 10) | MASKn(s, 6, 5) | MASKn(d, 6, 0);
+static int64_t LogicalImm(int64_t opc, int64_t d, int64_t s, int64_t i) {
+  int64_t poodle = GenNImmSImmR(i);
+  if (i == ARM_ERR_INV_OFF)
+    return i;
+  return MASKn(opc, 8, 29) | MASKn(0x24, 8, 23) | MASKn(s, 14, 10) |
+         MASKn(s, 6, 5) | MASKn(d, 6, 0);
 }
 
-int64_t ARM_andImmX(int64_t d, int64_t s, int64_t i)
-{
-	return LogicalImmX(0, d, s, i);
+static int64_t LogicalImmX(int64_t opc, int64_t d, int64_t s, int64_t i) {
+  int64_t poodle = GenNImmSImmR(i);
+  if (poodle == ARM_ERR_INV_OFF)
+    return poodle;
+  return (1 << 31) | MASKn(opc, 8, 29) | MASKn(0x24, 8, 23) |
+         MASKn(poodle, 14, 10) | MASKn(s, 6, 5) | MASKn(d, 6, 0);
 }
 
-int64_t ARM_orrImmX(int64_t d, int64_t s, int64_t i)
-{
-	return LogicalImmX(1, d, s, i);
+int64_t ARM_andImmX(int64_t d, int64_t s, int64_t i) {
+  return LogicalImmX(0, d, s, i);
 }
 
-int64_t ARM_eorImmX(int64_t d, int64_t s, int64_t i)
-{
-	return LogicalImmX(2, d, s, i);
+int64_t ARM_orrImmX(int64_t d, int64_t s, int64_t i) {
+  return LogicalImmX(1, d, s, i);
 }
 
-static int64_t LdStRegPairImm(int64_t opc, int64_t L, int64_t r1, int64_t r2, int64_t ra, int64_t off)
-{
-	int64_t times = 2;
-	if (off % times)
-		return ARM_ERR_INV_OFF;
-	if (off > times * 256)
-		return ARM_ERR_INV_OFF;
-	if (off < times * -256)
-		return ARM_ERR_INV_OFF;
-	return MASKn(opc, 32, 30) | MASKn(0x5, 32, 27) | MASKn(2, 32, 23) | MASKn(L, 32, 22) | MASKn(off / 8, 7, 15) | MASKn(r2, 5, 10) | MASKn(ra, 5, 5) | MASKn(r1, 5, 0);
+int64_t ARM_eorImmX(int64_t d, int64_t s, int64_t i) {
+  return LogicalImmX(2, d, s, i);
 }
 
-int64_t ARM_stpImmX(int64_t r1, int64_t r2, int64_t ra, int64_t off)
-{
-	return LdStRegPairImm(2, 0, r1, r2, ra, off);
-}
-int64_t ARM_ldpImmX(int64_t r1, int64_t r2, int64_t ra, int64_t off)
-{
-	return LdStRegPairImm(2, 1, r1, r2, ra, off);
-}
-
-static int64_t LdStSimdFpPairImm(int64_t opc, int64_t L, int64_t r1, int64_t r2, int64_t ra, int64_t off)
-{
-	int64_t times = 2;
-	if (off % times)
-		return ARM_ERR_INV_OFF;
-	if (off > times * 256)
-		return ARM_ERR_INV_OFF;
-	if (off < times * -256)
-		return ARM_ERR_INV_OFF;
-	return MASKn(opc, 32, 30) | MASKn(0x5, 32, 27) | (1 << 26) | MASKn(2, 32, 23) | MASKn(L, 32, 22) | MASKn(off / 8, 7, 15) | MASKn(r2, 5, 10) | MASKn(ra, 5, 5) | MASKn(r1, 5, 0);
+static int64_t LdStRegPairImm(int64_t opc, int64_t L, int64_t r1, int64_t r2,
+                              int64_t ra, int64_t off) {
+  int64_t times = 2;
+  if (off % times)
+    return ARM_ERR_INV_OFF;
+  if (off > times * 256)
+    return ARM_ERR_INV_OFF;
+  if (off < times * -256)
+    return ARM_ERR_INV_OFF;
+  return MASKn(opc, 32, 30) | MASKn(0x5, 32, 27) | MASKn(2, 32, 23) |
+         MASKn(L, 32, 22) | MASKn(off / 8, 7, 15) | MASKn(r2, 5, 10) |
+         MASKn(ra, 5, 5) | MASKn(r1, 5, 0);
 }
 
-int64_t ARM_stpImmF64(int64_t r1, int64_t r2, int64_t ra, int64_t off)
-{
-	return LdStSimdFpPairImm(1, 0, r1, r2, ra, off);
+int64_t ARM_stpImmX(int64_t r1, int64_t r2, int64_t ra, int64_t off) {
+  return LdStRegPairImm(2, 0, r1, r2, ra, off);
 }
-int64_t ARM_ldpImmF64(int64_t r1, int64_t r2, int64_t ra, int64_t off)
-{
-	return LdStSimdFpPairImm(1, 1, r1, r2, ra, off);
+int64_t ARM_ldpImmX(int64_t r1, int64_t r2, int64_t ra, int64_t off) {
+  return LdStRegPairImm(2, 1, r1, r2, ra, off);
 }
-int64_t ARM_andsImmX(int64_t d, int64_t n, int64_t imm) { return LogicalImmX(3, d, n, imm); }
 
-int64_t ARM_udivX(int64_t d, int64_t n, int64_t m) { return DataProc2Src(2, d, n, m); }
-int64_t ARM_umullX(int64_t d, int64_t n, int64_t m) { return DataProc3RegX(0, 5, 0, d, n, m, 31); }
+static int64_t LdStSimdFpPairImm(int64_t opc, int64_t L, int64_t r1, int64_t r2,
+                                 int64_t ra, int64_t off) {
+  int64_t times = 2;
+  if (off % times)
+    return ARM_ERR_INV_OFF;
+  if (off > times * 256)
+    return ARM_ERR_INV_OFF;
+  if (off < times * -256)
+    return ARM_ERR_INV_OFF;
+  return MASKn(opc, 32, 30) | MASKn(0x5, 32, 27) | (1 << 26) |
+         MASKn(2, 32, 23) | MASKn(L, 32, 22) | MASKn(off / 8, 7, 15) |
+         MASKn(r2, 5, 10) | MASKn(ra, 5, 5) | MASKn(r1, 5, 0);
+}
+
+int64_t ARM_stpImmF64(int64_t r1, int64_t r2, int64_t ra, int64_t off) {
+  return LdStSimdFpPairImm(1, 0, r1, r2, ra, off);
+}
+int64_t ARM_ldpImmF64(int64_t r1, int64_t r2, int64_t ra, int64_t off) {
+  return LdStSimdFpPairImm(1, 1, r1, r2, ra, off);
+}
+int64_t ARM_andsImmX(int64_t d, int64_t n, int64_t imm) {
+  return LogicalImmX(3, d, n, imm);
+}
+
+int64_t ARM_udivX(int64_t d, int64_t n, int64_t m) {
+  return DataProc2Src(2, d, n, m);
+}
+int64_t ARM_umullX(int64_t d, int64_t n, int64_t m) {
+  return DataProc3RegX(0, 5, 0, d, n, m, 31);
+}

--- a/arm_backend.c
+++ b/arm_backend.c
@@ -1,8 +1,8 @@
 #pragma once
 #include "aiwn.h"
-static int64_t SpillsTmpRegs(CRPN* rpn);
-static int64_t ICMov(CCmpCtrl* cctrl, CICArg* dst, CICArg* src, char* bin,
-	int64_t code_off);
+static int64_t SpillsTmpRegs(CRPN *rpn);
+static int64_t ICMov(CCmpCtrl *cctrl, CICArg *dst, CICArg *src, char *bin,
+                     int64_t code_off);
 //
 // ASSci art
 // POOPING README
@@ -41,379 +41,371 @@ static int64_t ICMov(CCmpCtrl* cctrl, CICArg* dst, CICArg* src, char* bin,
 // Decemeber 16,2022 Im stuck at home because of a snow storm
 // Decemeber 23,2022,i got 3 monster energy drinks
 //
-static int64_t IsBranchableInst(CRPN* rpn)
-{
-	switch (rpn->type) {
-	case IC_OR_OR:
-	case IC_AND_AND:
-	case IC_LT:
-	case IC_GT:
-	case IC_GE:
-	case IC_LE:
-	case IC_EQ_EQ:
-	case IC_NE:
-	case IC_LNOT:
-	case IC_BT:
-	case IC_BTS:
-	case IC_BTR:
-	case IC_BTC:
-	case IC_LBTS:
-	case IC_LBTR:
-	case IC_LBTC:
-		return 1;
-	}
-	return 0;
+static int64_t IsBranchableInst(CRPN *rpn) {
+  switch (rpn->type) {
+  case IC_OR_OR:
+  case IC_AND_AND:
+  case IC_LT:
+  case IC_GT:
+  case IC_GE:
+  case IC_LE:
+  case IC_EQ_EQ:
+  case IC_NE:
+  case IC_LNOT:
+  case IC_BT:
+  case IC_BTS:
+  case IC_BTR:
+  case IC_BTC:
+  case IC_LBTS:
+  case IC_LBTR:
+  case IC_LBTC:
+    return 1;
+  }
+  return 0;
 }
 
-static int64_t IsTerminalInst(CRPN* r)
-{
-	switch (r->type) {
-		break;
-	case IC_RET:
-	case IC_GOTO:
-		return 1;
-	}
-	return 0;
+static int64_t IsTerminalInst(CRPN *r) {
+  switch (r->type) {
+    break;
+  case IC_RET:
+  case IC_GOTO:
+    return 1;
+  }
+  return 0;
 }
 
-static int64_t IsConst(CRPN* rpn)
-{
-	switch (rpn->type) {
-	case IC_CHR:
-	case IC_F64:
-	case IC_I64:
-		return 1;
-	}
-	return 0;
+static int64_t IsConst(CRPN *rpn) {
+  switch (rpn->type) {
+  case IC_CHR:
+  case IC_F64:
+  case IC_I64:
+    return 1;
+  }
+  return 0;
 }
 
-static int64_t ConstVal(CRPN* rpn)
-{
-	switch (rpn->type) {
-	case IC_CHR:
-	case IC_I64:
-		return rpn->integer;
-	case IC_F64:
-		return rpn->flt;
-	}
-	return 0;
+static int64_t ConstVal(CRPN *rpn) {
+  switch (rpn->type) {
+  case IC_CHR:
+  case IC_I64:
+    return rpn->integer;
+  case IC_F64:
+    return rpn->flt;
+  }
+  return 0;
 }
 
 enum {
-	// Meet the arguments
-	ARM_REG_X0 = 0, // I am also a return value
-	ARM_REG_X1,
-	ARM_REG_X2,
-	ARM_REG_X3,
-	ARM_REG_X4,
-	ARM_REG_X5,
-	ARM_REG_X6,
-	ARM_REG_X7,
-	// Meet the silly willies(scratch)
-	ARM_REG_X8,
-	ARM_REG_X9,
-	ARM_REG_X10,
-	ARM_REG_X11,
-	ARM_REG_X12,
-	ARM_REG_X13,
-	ARM_REG_X14,
-	ARM_REG_X15,
-	ARM_REG_X16,
-	ARM_REG_X17,
-	// Meet the platform register(does something?)
-	ARM_REG_X18,
-	// Meet the bodacious bunch(saved accross calls)
-	ARM_REG_X19,
-	ARM_REG_X20,
-	ARM_REG_X21,
-	ARM_REG_X22,
-	ARM_REG_X23,
-	ARM_REG_X24,
-	ARM_REG_X25,
-	ARM_REG_X26,
-	ARM_REG_X27,
-	ARM_REG_X28,
-	// Meet the frame pointer
-	ARM_REG_X29,
+  // Meet the arguments
+  ARM_REG_X0 = 0, // I am also a return value
+  ARM_REG_X1,
+  ARM_REG_X2,
+  ARM_REG_X3,
+  ARM_REG_X4,
+  ARM_REG_X5,
+  ARM_REG_X6,
+  ARM_REG_X7,
+  // Meet the silly willies(scratch)
+  ARM_REG_X8,
+  ARM_REG_X9,
+  ARM_REG_X10,
+  ARM_REG_X11,
+  ARM_REG_X12,
+  ARM_REG_X13,
+  ARM_REG_X14,
+  ARM_REG_X15,
+  ARM_REG_X16,
+  ARM_REG_X17,
+  // Meet the platform register(does something?)
+  ARM_REG_X18,
+  // Meet the bodacious bunch(saved accross calls)
+  ARM_REG_X19,
+  ARM_REG_X20,
+  ARM_REG_X21,
+  ARM_REG_X22,
+  ARM_REG_X23,
+  ARM_REG_X24,
+  ARM_REG_X25,
+  ARM_REG_X26,
+  ARM_REG_X27,
+  ARM_REG_X28,
+  // Meet the frame pointer
+  ARM_REG_X29,
 #define ARM_REG_FP ARM_REG_X29
-	// Meet the return address
-	ARM_REG_X30,
+  // Meet the return address
+  ARM_REG_X30,
 #define ARM_REG_LR ARM_REG_X30
-	// Meet the (secret) stack pointer
-	ARM_REG_SP,
+  // Meet the (secret) stack pointer
+  ARM_REG_SP,
 };
 enum {
-	// Meet the floating point arguments
-	ARM_REG_V0 = 0, // Also return register
-	ARM_REG_V1,
-	ARM_REG_V2,
-	ARM_REG_V3,
-	ARM_REG_V4,
-	ARM_REG_V5,
-	ARM_REG_V6,
-	ARM_REG_V7,
-	// Meet the saved registers
-	ARM_REG_V8,
-	ARM_REG_V9,
-	ARM_REG_V10,
-	ARM_REG_V11,
-	ARM_REG_V12,
-	ARM_REG_V13,
-	ARM_REG_V14,
-	ARM_REG_V15,
-	// Meet the poo poo registers(not saved)
-	ARM_REG_V16,
-	ARM_REG_V17,
-	ARM_REG_V18,
-	ARM_REG_V19,
-	ARM_REG_V20,
-	ARM_REG_V21,
-	ARM_REG_V22,
-	ARM_REG_V23,
-	ARM_REG_V24,
-	ARM_REG_V25,
-	ARM_REG_V26,
-	ARM_REG_V27,
-	ARM_REG_V28,
-	ARM_REG_V29,
-	ARM_REG_V30,
-	ARM_REG_V31,
+  // Meet the floating point arguments
+  ARM_REG_V0 = 0, // Also return register
+  ARM_REG_V1,
+  ARM_REG_V2,
+  ARM_REG_V3,
+  ARM_REG_V4,
+  ARM_REG_V5,
+  ARM_REG_V6,
+  ARM_REG_V7,
+  // Meet the saved registers
+  ARM_REG_V8,
+  ARM_REG_V9,
+  ARM_REG_V10,
+  ARM_REG_V11,
+  ARM_REG_V12,
+  ARM_REG_V13,
+  ARM_REG_V14,
+  ARM_REG_V15,
+  // Meet the poo poo registers(not saved)
+  ARM_REG_V16,
+  ARM_REG_V17,
+  ARM_REG_V18,
+  ARM_REG_V19,
+  ARM_REG_V20,
+  ARM_REG_V21,
+  ARM_REG_V22,
+  ARM_REG_V23,
+  ARM_REG_V24,
+  ARM_REG_V25,
+  ARM_REG_V26,
+  ARM_REG_V27,
+  ARM_REG_V28,
+  ARM_REG_V29,
+  ARM_REG_V30,
+  ARM_REG_V31,
 };
 
-static int64_t PutICArgIntoReg(CCmpCtrl* cctrl, CICArg* arg, int64_t raw_type,
-	int64_t fallback, char* bin, int64_t code_off);
-#define AIWNIOS_ADD_CODE(val)                   \
-	{                                           \
-		if (bin) {                              \
-			int64_t v2 = (val);                 \
-			if (v2 == ARM_ERR_INV_REG)          \
-				throw(*(uint32_t*)"ASM");       \
-			if (v2 == ARM_ERR_INV_OFF)          \
-				throw(*(uint32_t*)"ASM");       \
-			((int32_t*)bin)[code_off / 4] = v2; \
-		}                                       \
-		code_off += 4;                          \
-	}
+static int64_t PutICArgIntoReg(CCmpCtrl *cctrl, CICArg *arg, int64_t raw_type,
+                               int64_t fallback, char *bin, int64_t code_off);
+#define AIWNIOS_ADD_CODE(val)                                                  \
+  {                                                                            \
+    if (bin) {                                                                 \
+      int64_t v2 = (val);                                                      \
+      if (v2 == ARM_ERR_INV_REG)                                               \
+        throw(*(uint32_t *)"ASM");                                             \
+      if (v2 == ARM_ERR_INV_OFF)                                               \
+        throw(*(uint32_t *)"ASM");                                             \
+      ((int32_t *)bin)[code_off / 4] = v2;                                     \
+    }                                                                          \
+    code_off += 4;                                                             \
+  }
 
-static int64_t PushToStack(CCmpCtrl* cctrl, CICArg* arg, char* bin,
-	int64_t code_off)
-{
-	CICArg tmp = *arg;
-	PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, 0, bin, code_off);
-	if (tmp.raw_type != RT_F64) {
-		AIWNIOS_ADD_CODE(ARM_strPreImmX(tmp.reg, ARM_REG_SP, -16));
-	} else {
-		AIWNIOS_ADD_CODE(ARM_strPreImmF64(tmp.reg, ARM_REG_SP, -16));
-	}
-	return code_off;
+static int64_t PushToStack(CCmpCtrl *cctrl, CICArg *arg, char *bin,
+                           int64_t code_off) {
+  CICArg tmp = *arg;
+  PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, 0, bin, code_off);
+  if (tmp.raw_type != RT_F64) {
+    AIWNIOS_ADD_CODE(ARM_strPreImmX(tmp.reg, ARM_REG_SP, -16));
+  } else {
+    AIWNIOS_ADD_CODE(ARM_strPreImmF64(tmp.reg, ARM_REG_SP, -16));
+  }
+  return code_off;
 }
-static int64_t PopFromStack(CCmpCtrl* cctrl, CICArg* arg, char* bin,
-	int64_t code_off)
-{
-	CICArg tmp = *arg;
-	if (arg->mode == MD_REG) {
-		// All is good
-	} else {
-		tmp.mode = MD_REG;
-		tmp.reg = 0;
-	}
-	if (tmp.raw_type != RT_F64) {
-		AIWNIOS_ADD_CODE(ARM_ldrPostImmX(tmp.reg, ARM_REG_SP, 16));
-	} else {
-		AIWNIOS_ADD_CODE(ARM_ldrPostImmF64(tmp.reg, ARM_REG_SP, 16));
-	}
-	if (arg->mode != MD_REG)
-		code_off = ICMov(cctrl, arg, &tmp, bin, code_off);
-	return code_off;
+static int64_t PopFromStack(CCmpCtrl *cctrl, CICArg *arg, char *bin,
+                            int64_t code_off) {
+  CICArg tmp = *arg;
+  if (arg->mode == MD_REG) {
+    // All is good
+  } else {
+    tmp.mode = MD_REG;
+    tmp.reg = 0;
+  }
+  if (tmp.raw_type != RT_F64) {
+    AIWNIOS_ADD_CODE(ARM_ldrPostImmX(tmp.reg, ARM_REG_SP, 16));
+  } else {
+    AIWNIOS_ADD_CODE(ARM_ldrPostImmF64(tmp.reg, ARM_REG_SP, 16));
+  }
+  if (arg->mode != MD_REG)
+    code_off = ICMov(cctrl, arg, &tmp, bin, code_off);
+  return code_off;
 }
 //
 // Will overwrite the arg's value,but it's ok as we are about to use it's
 // value(and discard it)
 //
-static int64_t PutICArgIntoReg(CCmpCtrl* cctrl, CICArg* arg, int64_t raw_type,
-	int64_t fallback, char* bin, int64_t code_off)
-{
-	CICArg tmp = { 0 };
-	if (arg->mode == MD_REG) {
-		if ((raw_type == RT_F64) ^ (arg->raw_type == RT_F64)) {
-			// They differ so continue as usaul
-		} else // They are the same
-			return code_off;
-	}
-	tmp.raw_type = raw_type;
-	tmp.reg = fallback;
-	tmp.mode = MD_REG;
-	code_off = ICMov(cctrl, &tmp, arg, bin, code_off);
-	memcpy(arg, &tmp, sizeof(CICArg));
-	return code_off;
+static int64_t PutICArgIntoReg(CCmpCtrl *cctrl, CICArg *arg, int64_t raw_type,
+                               int64_t fallback, char *bin, int64_t code_off) {
+  CICArg tmp = {0};
+  if (arg->mode == MD_REG) {
+    if ((raw_type == RT_F64) ^ (arg->raw_type == RT_F64)) {
+      // They differ so continue as usaul
+    } else // They are the same
+      return code_off;
+  }
+  tmp.raw_type = raw_type;
+  tmp.reg = fallback;
+  tmp.mode = MD_REG;
+  code_off = ICMov(cctrl, &tmp, arg, bin, code_off);
+  memcpy(arg, &tmp, sizeof(CICArg));
+  return code_off;
 }
 
-static int64_t __OptPassFinal(CCmpCtrl* cctrl, CRPN* rpn, char* bin,
-	int64_t code_off);
-static int64_t __ICMoveI64(CCmpCtrl* cctrl, int64_t reg, uint64_t imm, char* bin,
-	int64_t code_off)
-{
-	int64_t code;
+static int64_t __OptPassFinal(CCmpCtrl *cctrl, CRPN *rpn, char *bin,
+                              int64_t code_off);
+static int64_t __ICMoveI64(CCmpCtrl *cctrl, int64_t reg, uint64_t imm,
+                           char *bin, int64_t code_off) {
+  int64_t code;
   CCodeMiscRef *ref;
-	if (bin && !(cctrl->flags & CCF_AOT_COMPILE)) { // TODO make sure not AOT
-		if (ARM_ERR_INV_OFF != (code = ARM_adrX(reg, imm - (int64_t)(bin + code_off)))) {
-			AIWNIOS_ADD_CODE(code);
-			return code_off;
-		}
-	}
-	// Here's the deal,you can store a 16bit literal into a register,but you
-	// can shift it to get bigger range,and you can make it negative
-	if ((imm & 0xffffll) == imm) {
-		AIWNIOS_ADD_CODE(ARM_movzImmX(reg, imm, 0));
-		return code_off;
-	}
-	if ((imm & 0xffff0000ll) == imm) {
-		AIWNIOS_ADD_CODE(ARM_movzImmX(reg, imm >> 16, 16));
-		return code_off;
-	}
-	if ((imm & 0xffff00000000ll) == imm) {
-		AIWNIOS_ADD_CODE(ARM_movzImmX(reg, imm >> 32, 32));
-		return code_off;
-	}
-	if ((imm & 0xffff000000000000ll) == imm) {
-		AIWNIOS_ADD_CODE(ARM_movzImmX(reg, imm >> 48, 48));
-		return code_off;
-	}
-	/*
-	imm = ~imm;
-	if ((imm & 0xffff) == imm) {
-		AIWNIOS_ADD_CODE(ARM_movnImmX(reg, imm, 0));
-		return code_off;
-	}
-	if ((imm & 0xffff0000) == imm) {
-		AIWNIOS_ADD_CODE(ARM_movnImmX(reg, imm >> 16, 16));
-		return code_off;
-	}
-	if ((imm & 0xffff00000000ll) == imm) {
-		AIWNIOS_ADD_CODE(ARM_movnImmX(reg, imm >> 32, 32));
-		return code_off;
-	}
-	if ((imm & 0xffff000000000000ll) == imm) {
-		AIWNIOS_ADD_CODE(ARM_movnImmX(reg, imm >> 48, 48));
-		return code_off;
-	}
-	imm = ~imm;
+  if (bin && !(cctrl->flags & CCF_AOT_COMPILE)) { // TODO make sure not AOT
+    if (ARM_ERR_INV_OFF !=
+        (code = ARM_adrX(reg, imm - (int64_t)(bin + code_off)))) {
+      AIWNIOS_ADD_CODE(code);
+      return code_off;
+    }
+  }
+  // Here's the deal,you can store a 16bit literal into a register,but you
+  // can shift it to get bigger range,and you can make it negative
+  if ((imm & 0xffffll) == imm) {
+    AIWNIOS_ADD_CODE(ARM_movzImmX(reg, imm, 0));
+    return code_off;
+  }
+  if ((imm & 0xffff0000ll) == imm) {
+    AIWNIOS_ADD_CODE(ARM_movzImmX(reg, imm >> 16, 16));
+    return code_off;
+  }
+  if ((imm & 0xffff00000000ll) == imm) {
+    AIWNIOS_ADD_CODE(ARM_movzImmX(reg, imm >> 32, 32));
+    return code_off;
+  }
+  if ((imm & 0xffff000000000000ll) == imm) {
+    AIWNIOS_ADD_CODE(ARM_movzImmX(reg, imm >> 48, 48));
+    return code_off;
+  }
+  /*
+  imm = ~imm;
+  if ((imm & 0xffff) == imm) {
+    AIWNIOS_ADD_CODE(ARM_movnImmX(reg, imm, 0));
+    return code_off;
+  }
+  if ((imm & 0xffff0000) == imm) {
+    AIWNIOS_ADD_CODE(ARM_movnImmX(reg, imm >> 16, 16));
+    return code_off;
+  }
+  if ((imm & 0xffff00000000ll) == imm) {
+    AIWNIOS_ADD_CODE(ARM_movnImmX(reg, imm >> 32, 32));
+    return code_off;
+  }
+  if ((imm & 0xffff000000000000ll) == imm) {
+    AIWNIOS_ADD_CODE(ARM_movnImmX(reg, imm >> 48, 48));
+    return code_off;
+  }
+  imm = ~imm;
   */
-	CCodeMisc* misc = cctrl->code_ctrl->code_misc->next;
-	char* dptr;
-	for (misc; misc != cctrl->code_ctrl->code_misc; misc = misc->base.next) {
-		if (misc->type == CMT_INT_CONST && misc->integer == imm) {
-			goto found;
-		}
-	}
-	misc = A_CALLOC(sizeof(CCodeMisc), cctrl->hc);
-	misc->type = CMT_INT_CONST;
-	misc->integer = imm;
-	QueIns(misc, cctrl->code_ctrl->code_misc->last);
+  CCodeMisc *misc = cctrl->code_ctrl->code_misc->next;
+  char *dptr;
+  for (misc; misc != cctrl->code_ctrl->code_misc; misc = misc->base.next) {
+    if (misc->type == CMT_INT_CONST && misc->integer == imm) {
+      goto found;
+    }
+  }
+  misc = A_CALLOC(sizeof(CCodeMisc), cctrl->hc);
+  misc->type = CMT_INT_CONST;
+  misc->integer = imm;
+  QueIns(misc, cctrl->code_ctrl->code_misc->last);
 found:
-	if (bin && misc->addr && cctrl->code_ctrl->final_pass) {
-		AIWNIOS_ADD_CODE(ARM_ldrLabelX(reg, 0));
-		ref=CodeMiscAddRef(misc, bin + code_off - 4);
-    ref->patch_cond_br=ARM_ldrLabelX;
-    ref->user_data1=reg;
-    
-	} else
-		AIWNIOS_ADD_CODE(0); // See above AIWNIOS_ADD_CODE
-	return code_off;
+  if (bin && misc->addr && cctrl->code_ctrl->final_pass) {
+    AIWNIOS_ADD_CODE(ARM_ldrLabelX(reg, 0));
+    ref = CodeMiscAddRef(misc, bin + code_off - 4);
+    ref->patch_cond_br = ARM_ldrLabelX;
+    ref->user_data1 = reg;
+
+  } else
+    AIWNIOS_ADD_CODE(0); // See above AIWNIOS_ADD_CODE
+  return code_off;
 }
 
-static int64_t __ICMoveF64(CCmpCtrl* cctrl, int64_t reg, double imm, char* bin,
-	int64_t code_off)
-{
-	//(For now),I ain't messing around with binary literals in ARM
-	CCodeMisc* misc = cctrl->code_ctrl->code_misc->next;
+static int64_t __ICMoveF64(CCmpCtrl *cctrl, int64_t reg, double imm, char *bin,
+                           int64_t code_off) {
+  //(For now),I ain't messing around with binary literals in ARM
+  CCodeMisc *misc = cctrl->code_ctrl->code_misc->next;
   CCodeMiscRef *ref;
-	char* dptr;
-	for (misc; misc != cctrl->code_ctrl->code_misc; misc = misc->base.next) {
-		if (misc->type == CMT_FLOAT_CONST)
-			if (misc->integer == *(int64_t*)&imm) {
-				goto found;
-			}
-	}
-	misc = A_CALLOC(sizeof(CCodeMisc), cctrl->hc);
-	misc->type = CMT_FLOAT_CONST;
-	misc->integer = *(int64_t*)&imm;
-	QueIns(misc, cctrl->code_ctrl->code_misc->last);
+  char *dptr;
+  for (misc; misc != cctrl->code_ctrl->code_misc; misc = misc->base.next) {
+    if (misc->type == CMT_FLOAT_CONST)
+      if (misc->integer == *(int64_t *)&imm) {
+        goto found;
+      }
+  }
+  misc = A_CALLOC(sizeof(CCodeMisc), cctrl->hc);
+  misc->type = CMT_FLOAT_CONST;
+  misc->integer = *(int64_t *)&imm;
+  QueIns(misc, cctrl->code_ctrl->code_misc->last);
 found:
-	if (bin && misc->addr && cctrl->code_ctrl->final_pass) {
-		AIWNIOS_ADD_CODE(ARM_ldrLabelF64(reg, 0));
-		ref=CodeMiscAddRef(misc, bin + code_off - 4);
-    ref->patch_cond_br=ARM_ldrLabelF64;
-    ref->user_data1=reg;
-	} else
-		AIWNIOS_ADD_CODE(0); // See above AIWNIOS_ADD_CODE
-	return code_off;
+  if (bin && misc->addr && cctrl->code_ctrl->final_pass) {
+    AIWNIOS_ADD_CODE(ARM_ldrLabelF64(reg, 0));
+    ref = CodeMiscAddRef(misc, bin + code_off - 4);
+    ref->patch_cond_br = ARM_ldrLabelF64;
+    ref->user_data1 = reg;
+  } else
+    AIWNIOS_ADD_CODE(0); // See above AIWNIOS_ADD_CODE
+  return code_off;
 }
 
 #define ARM_LABEL_DIST (((1 << 19) - 1) << 2)
-static int64_t PtrDist(int64_t a, int64_t b)
-{
-	if (a > b)
-		return a - b;
-	return b - a;
+static int64_t PtrDist(int64_t a, int64_t b) {
+  if (a > b)
+    return a - b;
+  return b - a;
 }
 
-static void PushSpilledTmp(CCmpCtrl* cctrl, CRPN* rpn)
-{
-	int64_t raw_type = rpn->raw_type;
-	CICArg* res = &rpn->res;
-	// These have no need to be put into a temporay
-	switch (rpn->type) {
-		break;
-	case IC_IREG:
-	case IC_FREG:
-		res->mode = MD_REG;
-		res->raw_type = raw_type;
-		res->reg = rpn->integer;
-		return;
-		break;
-	case IC_BASE_PTR:
-		res->mode = MD_FRAME;
-		res->raw_type = raw_type;
-		res->off = rpn->integer;
-		return;
-	case IC_STATIC:
-		res->mode = MD_PTR;
-		res->raw_type = raw_type;
-		res->off = rpn->integer;
-		return;
-	case __IC_STATIC_REF:
-		res->mode = MD_STATIC;
-		res->raw_type = raw_type;
-		res->off = rpn->integer;
-		return;
-	}
-	rpn->flags |= ICF_SPILLED;
-	if (raw_type != RT_F64) {
-		res->mode = MD_FRAME;
-		res->raw_type = raw_type;
-		if (cctrl->backend_user_data0 < (res->off = cctrl->backend_user_data1 += 8)) { // Will set ref->off before the top
-			cctrl->backend_user_data0 = res->off;
-		}
-	} else {
-		res->mode = MD_FRAME;
-		res->raw_type = raw_type;
-		if (cctrl->backend_user_data0 < (res->off = cctrl->backend_user_data1 += 8)) { // Will set ref->off before the top
-			cctrl->backend_user_data0 = res->off;
-		}
-	}
-	// See two above notes
-	res->off -= 8;
-	// In functions,wiggle room comes after the function locals.
-	if (cctrl->cur_fun && res->mode == MD_FRAME)
-		res->off += cctrl->cur_fun->base.sz + 16; //+16 for LR/FP
-	else if (res->mode == MD_FRAME) {
-		if (cctrl->backend_user_data4) {
-			res->off += cctrl->backend_user_data4; // wiggle room start(if set)
-		} else
-			// Anonymus potatoes like to assume LR/FP pair too.
-			res->off += 16;
-	}
+static void PushSpilledTmp(CCmpCtrl *cctrl, CRPN *rpn) {
+  int64_t raw_type = rpn->raw_type;
+  CICArg *res = &rpn->res;
+  // These have no need to be put into a temporay
+  switch (rpn->type) {
+    break;
+  case IC_IREG:
+  case IC_FREG:
+    res->mode = MD_REG;
+    res->raw_type = raw_type;
+    res->reg = rpn->integer;
+    return;
+    break;
+  case IC_BASE_PTR:
+    res->mode = MD_FRAME;
+    res->raw_type = raw_type;
+    res->off = rpn->integer;
+    return;
+  case IC_STATIC:
+    res->mode = MD_PTR;
+    res->raw_type = raw_type;
+    res->off = rpn->integer;
+    return;
+  case __IC_STATIC_REF:
+    res->mode = MD_STATIC;
+    res->raw_type = raw_type;
+    res->off = rpn->integer;
+    return;
+  }
+  rpn->flags |= ICF_SPILLED;
+  if (raw_type != RT_F64) {
+    res->mode = MD_FRAME;
+    res->raw_type = raw_type;
+    if (cctrl->backend_user_data0 < (res->off = cctrl->backend_user_data1 +=
+                                     8)) { // Will set ref->off before the top
+      cctrl->backend_user_data0 = res->off;
+    }
+  } else {
+    res->mode = MD_FRAME;
+    res->raw_type = raw_type;
+    if (cctrl->backend_user_data0 < (res->off = cctrl->backend_user_data1 +=
+                                     8)) { // Will set ref->off before the top
+      cctrl->backend_user_data0 = res->off;
+    }
+  }
+  // See two above notes
+  res->off -= 8;
+  // In functions,wiggle room comes after the function locals.
+  if (cctrl->cur_fun && res->mode == MD_FRAME)
+    res->off += cctrl->cur_fun->base.sz + 16; //+16 for LR/FP
+  else if (res->mode == MD_FRAME) {
+    if (cctrl->backend_user_data4) {
+      res->off += cctrl->backend_user_data4; // wiggle room start(if set)
+    } else
+      // Anonymus potatoes like to assume LR/FP pair too.
+      res->off += 16;
+  }
 }
 //
 // Takes an argument called inher. We can use the parent's destination
@@ -429,1134 +421,1163 @@ static void PushSpilledTmp(CCmpCtrl* cctrl, CRPN* rpn)
 //  ~ dst=1
 //   ! dst=2
 
-static void PushTmp(CCmpCtrl* cctrl, CRPN* rpn, CICArg* inher_from)
-{
-	int64_t raw_type = rpn->raw_type;
-	CICArg* res = &rpn->res;
-	// These have no need to be put into a temporay
-	switch (rpn->type) {
-		break;
-	case __IC_STATIC_REF:
-		res->mode = MD_STATIC;
-		res->raw_type = raw_type;
-		res->off = rpn->integer;
-		return;
-	case IC_STATIC:
-		res->mode = MD_PTR;
-		res->raw_type = raw_type;
-		res->off = rpn->integer;
-		return;
-	case IC_GLOBAL:
-		res->mode = MD_PTR;
-		res->raw_type = raw_type;
-		res->off = rpn->global_var->data_addr;
-		return;
-		// These dudes will compile down to a MD_I64/MD_F64
-	case IC_I64:
-		res->mode = MD_I64;
-		res->integer = rpn->integer;
-		res->raw_type = RT_I64i;
-		return;
-		break;
-	case IC_F64:
-		res->mode = MD_F64;
-		res->flt = rpn->flt;
-		res->raw_type = RT_F64;
-		return;
-	case IC_IREG:
-	case IC_FREG:
-		res->mode = MD_REG;
-		res->raw_type = raw_type;
-		res->reg = rpn->integer;
-		return;
-		break;
-	case IC_BASE_PTR:
-		res->mode = MD_FRAME;
-		res->raw_type = raw_type;
-		res->off = rpn->integer;
-		return;
-	}
-	if (inher_from) {
-		if (rpn->raw_type == RT_F64 && inher_from->raw_type == RT_F64 && inher_from->mode != MD_NULL) {
-			rpn->res = *inher_from;
-			rpn->flags |= ICF_TMP_NO_UNDO;
-			return;
-		} else if (rpn->raw_type != RT_F64 && inher_from->raw_type != RT_F64 && inher_from->mode != MD_NULL) {
-			rpn->res = *inher_from;
-			rpn->flags |= ICF_TMP_NO_UNDO;
-			return;
-		}
-	}
-	if (raw_type != RT_F64) {
-		if (cctrl->backend_user_data2 < AIWNIOS_TMP_IREG_CNT) {
-			res->mode = MD_REG;
-			res->raw_type = raw_type;
-			res->off = 0;
-			res->reg = AIWNIOS_TMP_IREG_START + cctrl->backend_user_data2++;
-		} else {
-			PushSpilledTmp(cctrl, rpn);
-		}
-	} else {
-		if (cctrl->backend_user_data3 < AIWNIOS_TMP_FREG_CNT) {
-			res->mode = MD_REG;
-			res->raw_type = raw_type;
-			res->off = 0;
-			res->reg = AIWNIOS_TMP_FREG_START + cctrl->backend_user_data3++;
-		} else {
-			PushSpilledTmp(cctrl, rpn);
-		}
-	}
+static void PushTmp(CCmpCtrl *cctrl, CRPN *rpn, CICArg *inher_from) {
+  int64_t raw_type = rpn->raw_type;
+  CICArg *res = &rpn->res;
+  // These have no need to be put into a temporay
+  switch (rpn->type) {
+    break;
+  case __IC_STATIC_REF:
+    res->mode = MD_STATIC;
+    res->raw_type = raw_type;
+    res->off = rpn->integer;
+    return;
+  case IC_STATIC:
+    res->mode = MD_PTR;
+    res->raw_type = raw_type;
+    res->off = rpn->integer;
+    return;
+  case IC_GLOBAL:
+    res->mode = MD_PTR;
+    res->raw_type = raw_type;
+    res->off = rpn->global_var->data_addr;
+    return;
+    // These dudes will compile down to a MD_I64/MD_F64
+  case IC_I64:
+    res->mode = MD_I64;
+    res->integer = rpn->integer;
+    res->raw_type = RT_I64i;
+    return;
+    break;
+  case IC_F64:
+    res->mode = MD_F64;
+    res->flt = rpn->flt;
+    res->raw_type = RT_F64;
+    return;
+  case IC_IREG:
+  case IC_FREG:
+    res->mode = MD_REG;
+    res->raw_type = raw_type;
+    res->reg = rpn->integer;
+    return;
+    break;
+  case IC_BASE_PTR:
+    res->mode = MD_FRAME;
+    res->raw_type = raw_type;
+    res->off = rpn->integer;
+    return;
+  }
+  if (inher_from) {
+    if (rpn->raw_type == RT_F64 && inher_from->raw_type == RT_F64 &&
+        inher_from->mode != MD_NULL) {
+      rpn->res = *inher_from;
+      rpn->flags |= ICF_TMP_NO_UNDO;
+      return;
+    } else if (rpn->raw_type != RT_F64 && inher_from->raw_type != RT_F64 &&
+               inher_from->mode != MD_NULL) {
+      rpn->res = *inher_from;
+      rpn->flags |= ICF_TMP_NO_UNDO;
+      return;
+    }
+  }
+  if (raw_type != RT_F64) {
+    if (cctrl->backend_user_data2 < AIWNIOS_TMP_IREG_CNT) {
+      res->mode = MD_REG;
+      res->raw_type = raw_type;
+      res->off = 0;
+      res->reg = AIWNIOS_TMP_IREG_START + cctrl->backend_user_data2++;
+    } else {
+      PushSpilledTmp(cctrl, rpn);
+    }
+  } else {
+    if (cctrl->backend_user_data3 < AIWNIOS_TMP_FREG_CNT) {
+      res->mode = MD_REG;
+      res->raw_type = raw_type;
+      res->off = 0;
+      res->reg = AIWNIOS_TMP_FREG_START + cctrl->backend_user_data3++;
+    } else {
+      PushSpilledTmp(cctrl, rpn);
+    }
+  }
 }
 
-static void PopTmp(CCmpCtrl* cctrl, CRPN* rpn)
-{
-	int64_t raw_type = rpn->raw_type;
-	if (rpn->flags & ICF_TMP_NO_UNDO)
-		return;
-	// These have no need to be put into a temporay
-	switch (rpn->type) {
-		break;
-	case IC_I64:
-	case IC_F64:
-	case IC_IREG:
-	case IC_FREG:
-	case IC_BASE_PTR:
-	case IC_GLOBAL:
-	case IC_STATIC:
-	case __IC_STATIC_REF:
-		return;
-	}
-	if (rpn->flags & ICF_SPILLED) {
-		cctrl->backend_user_data1 -= 8;
-	} else {
-		if (raw_type != RT_F64) {
-			assert(--cctrl->backend_user_data2 >= 0);
-		} else {
-			assert(--cctrl->backend_user_data3 >= 0);
-		}
-	}
-	assert(cctrl->backend_user_data1 >= 0);
+static void PopTmp(CCmpCtrl *cctrl, CRPN *rpn) {
+  int64_t raw_type = rpn->raw_type;
+  if (rpn->flags & ICF_TMP_NO_UNDO)
+    return;
+  // These have no need to be put into a temporay
+  switch (rpn->type) {
+    break;
+  case IC_I64:
+  case IC_F64:
+  case IC_IREG:
+  case IC_FREG:
+  case IC_BASE_PTR:
+  case IC_GLOBAL:
+  case IC_STATIC:
+  case __IC_STATIC_REF:
+    return;
+  }
+  if (rpn->flags & ICF_SPILLED) {
+    cctrl->backend_user_data1 -= 8;
+  } else {
+    if (raw_type != RT_F64) {
+      assert(--cctrl->backend_user_data2 >= 0);
+    } else {
+      assert(--cctrl->backend_user_data3 >= 0);
+    }
+  }
+  assert(cctrl->backend_user_data1 >= 0);
 }
 //
 // Here's the deal,we can replace an *(reg+123) with MD_INDIR_REG with
 // off==123
 //
-static int64_t DerefToICArg(CCmpCtrl* cctrl, CICArg* res, CRPN* rpn,
-	int64_t base_reg_fallback, char* bin,
-	int64_t code_off)
-{
-	if (rpn->type != IC_DEREF) {
-		PushTmp(cctrl, rpn, NULL);
-		code_off = __OptPassFinal(cctrl, rpn, bin, code_off);
-		*res = rpn->res;
-		PopTmp(cctrl, rpn);
-		return code_off;
-	}
-	int64_t r = rpn->raw_type, rsz, off, mul;
-	rpn = rpn->base.next;
-	CRPN *next = rpn->base.next, *next2, *next3, *next4, *tmp;
-	switch (r) {
-		break;
-	case RT_I8i:
-		rsz = 1;
-		break;
-	case RT_U8i:
-		rsz = 1;
-		break;
-	case RT_I16i:
-		rsz = 2;
-		break;
-	case RT_U16i:
-		rsz = 2;
-		break;
-	case RT_I32i:
-		rsz = 4;
-		break;
-	case RT_U32i:
-		rsz = 4;
-		break;
-	default:
-		rsz = 8;
-	}
-	if (rpn->type == IC_ADD) {
-		next2 = ICFwd(rpn->base.next);
-		if (next->type == IC_I64) {
-			PushTmp(cctrl, next2, NULL);
-			code_off = __OptPassFinal(cctrl, next2, bin, code_off);
-			PopTmp(cctrl, next2);
-			code_off = PutICArgIntoReg(cctrl, &next2->res, RT_PTR, base_reg_fallback,
-				bin, code_off);
-			res->mode = MD_INDIR_REG;
-			res->off = next->integer;
-			res->raw_type = r;
-			res->reg = next2->res.reg;
-			return code_off;
-		} else if (next2->type == IC_I64) {
-			PushTmp(cctrl, next, NULL);
-			code_off = __OptPassFinal(cctrl, next, bin, code_off);
-			PopTmp(cctrl, next);
-			code_off = PutICArgIntoReg(cctrl, &next->res, RT_PTR, base_reg_fallback,
-				bin, code_off);
-			res->mode = MD_INDIR_REG;
-			res->off = next2->integer;
-			res->raw_type = r;
-			res->reg = next->res.reg;
-			return code_off;
-		} else if (next->type == IC_MUL) {
-		index_chk:
-			off = 0;
-			next3 = ICArgN(next, 0);
-			next4 = ICArgN(next, 1);
-			if (next3->type == IC_IREG)
-				off++;
-			if (next4->type == IC_IREG)
-				off++;
-			if (cctrl->backend_user_data2 + 2 - off <= AIWNIOS_TMP_IREG_CNT) {
-				if (next3->type == IC_I64) {
-					mul = next3->integer;
-				idx:
-					if (rsz == mul && next4->raw_type != RT_F64) {
-						// IC_ADD==rpn
-						//   IC_MUL==next
-						//      IC_I64==next3
-						//      mul==next4
-						//   off==next2
-						//
+static int64_t DerefToICArg(CCmpCtrl *cctrl, CICArg *res, CRPN *rpn,
+                            int64_t base_reg_fallback, char *bin,
+                            int64_t code_off) {
+  if (rpn->type != IC_DEREF) {
+    PushTmp(cctrl, rpn, NULL);
+    code_off = __OptPassFinal(cctrl, rpn, bin, code_off);
+    *res = rpn->res;
+    PopTmp(cctrl, rpn);
+    return code_off;
+  }
+  int64_t r = rpn->raw_type, rsz, off, mul;
+  rpn = rpn->base.next;
+  CRPN *next = rpn->base.next, *next2, *next3, *next4, *tmp;
+  switch (r) {
+    break;
+  case RT_I8i:
+    rsz = 1;
+    break;
+  case RT_U8i:
+    rsz = 1;
+    break;
+  case RT_I16i:
+    rsz = 2;
+    break;
+  case RT_U16i:
+    rsz = 2;
+    break;
+  case RT_I32i:
+    rsz = 4;
+    break;
+  case RT_U32i:
+    rsz = 4;
+    break;
+  default:
+    rsz = 8;
+  }
+  if (rpn->type == IC_ADD) {
+    next2 = ICFwd(rpn->base.next);
+    if (next->type == IC_I64) {
+      PushTmp(cctrl, next2, NULL);
+      code_off = __OptPassFinal(cctrl, next2, bin, code_off);
+      PopTmp(cctrl, next2);
+      code_off = PutICArgIntoReg(cctrl, &next2->res, RT_PTR, base_reg_fallback,
+                                 bin, code_off);
+      res->mode = MD_INDIR_REG;
+      res->off = next->integer;
+      res->raw_type = r;
+      res->reg = next2->res.reg;
+      return code_off;
+    } else if (next2->type == IC_I64) {
+      PushTmp(cctrl, next, NULL);
+      code_off = __OptPassFinal(cctrl, next, bin, code_off);
+      PopTmp(cctrl, next);
+      code_off = PutICArgIntoReg(cctrl, &next->res, RT_PTR, base_reg_fallback,
+                                 bin, code_off);
+      res->mode = MD_INDIR_REG;
+      res->off = next2->integer;
+      res->raw_type = r;
+      res->reg = next->res.reg;
+      return code_off;
+    } else if (next->type == IC_MUL) {
+    index_chk:
+      off = 0;
+      next3 = ICArgN(next, 0);
+      next4 = ICArgN(next, 1);
+      if (next3->type == IC_IREG)
+        off++;
+      if (next4->type == IC_IREG)
+        off++;
+      if (cctrl->backend_user_data2 + 2 - off <= AIWNIOS_TMP_IREG_CNT) {
+        if (next3->type == IC_I64) {
+          mul = next3->integer;
+        idx:
+          if (rsz == mul && next4->raw_type != RT_F64) {
+            // IC_ADD==rpn
+            //   IC_MUL==next
+            //      IC_I64==next3
+            //      mul==next4
+            //   off==next2
+            //
 
-						// Store
-						off = cctrl->backend_user_data2;
-						if (SpillsTmpRegs(next4))
-							PushSpilledTmp(cctrl, next2);
-						else
-							PushTmp(cctrl, next2, NULL);
-						PushTmp(cctrl, next4, NULL);
-						code_off = __OptPassFinal(cctrl, next2, bin, code_off);
-						code_off = __OptPassFinal(cctrl, next4, bin, code_off);
-						if (next4->res.mode != MD_REG) {
-							code_off = PutICArgIntoReg(cctrl, &next4->res, RT_I64i, cctrl->backend_user_data2++, bin, code_off);
-						}
-						if (next2->res.mode != MD_REG) {
-							code_off = PutICArgIntoReg(cctrl, &next2->res, RT_I64i, cctrl->backend_user_data2++, bin, code_off);
-						}
-						PopTmp(cctrl, next2);
-						PopTmp(cctrl, next4);
-						res->mode = __MD_ARM_SHIFT;
-						res->reg = next2->res.reg;
-						res->reg2 = next4->res.reg;
-						res->raw_type = r;
-						// Restore
-						cctrl->backend_user_data2 = off;
-						return code_off;
-					}
-				} else if (next4->type == IC_I64) {
-					tmp = next3;
-					next3 = next4;
-					next4 = tmp;
-					mul = next3->integer;
-					goto idx;
-				} else {
-					// See above note
-					//  IC_ADD==rpn==next
-					//    mul==next4
-					//    off==next2
-					//
-					next2 = next3;
-					mul = 1;
-					goto idx;
-				}
-			} else if (next2->type == IC_MUL) {
-				tmp = next;
-				next = next2;
-				next2 = tmp;
-				goto index_chk;
-			}
-		} else {
-			mul = 1;
-			next = rpn;
-			goto index_chk;
-		}
-	}
-	PushTmp(cctrl, rpn, NULL);
-	code_off = __OptPassFinal(cctrl, rpn, bin, code_off);
-	code_off = PutICArgIntoReg(cctrl, &rpn->res, RT_PTR, base_reg_fallback, bin,
-		code_off);
-	PopTmp(cctrl, rpn);
-	res->mode = MD_INDIR_REG;
-	res->off = 0;
-	res->raw_type = r;
-	res->reg = rpn->res.reg;
-	return code_off;
-}
-static int64_t __ICFCallTOS(CCmpCtrl* cctrl, CRPN* rpn, char* bin,
-	int64_t code_off)
-{
-	int64_t i,first_is_vargs=0,base; //This is reverse polish notation
-	CICArg tmp={0},tmp2={0};
-	CRPN* rpn2,*varg;
-	int64_t to_pop = rpn->length * 8,vargs_len=0;
-	void* fptr;
-	for (i = 0; i < rpn->length; i++) {
-		rpn2 = ICArgN(rpn, i);
-		if (rpn2->type == __IC_VARGS) {
-			to_pop += (vargs_len=rpn2->length * 8);
-      first_is_vargs=1;
-    }
-  }
-  //Arm mandates 16 byte align
-  if(to_pop%16)
-    to_pop+=8;
-  if(to_pop) {
-    if(ARM_ERR_INV_OFF!=ARM_subImmX(ARM_REG_SP,ARM_REG_SP,to_pop)) {
-      AIWNIOS_ADD_CODE(ARM_subImmX(ARM_REG_SP,ARM_REG_SP,to_pop));
+            // Store
+            off = cctrl->backend_user_data2;
+            if (SpillsTmpRegs(next4))
+              PushSpilledTmp(cctrl, next2);
+            else
+              PushTmp(cctrl, next2, NULL);
+            PushTmp(cctrl, next4, NULL);
+            code_off = __OptPassFinal(cctrl, next2, bin, code_off);
+            code_off = __OptPassFinal(cctrl, next4, bin, code_off);
+            if (next4->res.mode != MD_REG) {
+              code_off =
+                  PutICArgIntoReg(cctrl, &next4->res, RT_I64i,
+                                  cctrl->backend_user_data2++, bin, code_off);
+            }
+            if (next2->res.mode != MD_REG) {
+              code_off =
+                  PutICArgIntoReg(cctrl, &next2->res, RT_I64i,
+                                  cctrl->backend_user_data2++, bin, code_off);
+            }
+            PopTmp(cctrl, next2);
+            PopTmp(cctrl, next4);
+            res->mode = __MD_ARM_SHIFT;
+            res->reg = next2->res.reg;
+            res->reg2 = next4->res.reg;
+            res->raw_type = r;
+            // Restore
+            cctrl->backend_user_data2 = off;
+            return code_off;
+          }
+        } else if (next4->type == IC_I64) {
+          tmp = next3;
+          next3 = next4;
+          next4 = tmp;
+          mul = next3->integer;
+          goto idx;
+        } else {
+          // See above note
+          //  IC_ADD==rpn==next
+          //    mul==next4
+          //    off==next2
+          //
+          next2 = next3;
+          mul = 1;
+          goto idx;
+        }
+      } else if (next2->type == IC_MUL) {
+        tmp = next;
+        next = next2;
+        next2 = tmp;
+        goto index_chk;
+      }
     } else {
-      code_off=__ICMoveI64(cctrl,0,to_pop,bin,code_off);
-      AIWNIOS_ADD_CODE(ARM_subRegX(ARM_REG_SP,ARM_REG_SP,0));
+      mul = 1;
+      next = rpn;
+      goto index_chk;
     }
   }
-  if(first_is_vargs) {
-    base=to_pop-vargs_len;
-    rpn2=ICArgN(rpn,0);
-    for(vargs_len-=8;vargs_len/8>=0;vargs_len-=8) {
-      varg=ICArgN(rpn2,rpn2->length-vargs_len/8-1);
-      varg->res.mode=MD_INDIR_REG;
-      varg->res.off=vargs_len+base;
-      varg->res.reg=ARM_REG_SP;
-      varg->res.raw_type=(varg->raw_type==RT_F64)?RT_F64:RT_I64i;		
+  PushTmp(cctrl, rpn, NULL);
+  code_off = __OptPassFinal(cctrl, rpn, bin, code_off);
+  code_off = PutICArgIntoReg(cctrl, &rpn->res, RT_PTR, base_reg_fallback, bin,
+                             code_off);
+  PopTmp(cctrl, rpn);
+  res->mode = MD_INDIR_REG;
+  res->off = 0;
+  res->raw_type = r;
+  res->reg = rpn->res.reg;
+  return code_off;
+}
+static int64_t __ICFCallTOS(CCmpCtrl *cctrl, CRPN *rpn, char *bin,
+                            int64_t code_off) {
+  int64_t i, first_is_vargs = 0, base; // This is reverse polish notation
+  CICArg tmp = {0}, tmp2 = {0};
+  CRPN *rpn2, *varg;
+  int64_t to_pop = rpn->length * 8, vargs_len = 0;
+  void *fptr;
+  for (i = 0; i < rpn->length; i++) {
+    rpn2 = ICArgN(rpn, i);
+    if (rpn2->type == __IC_VARGS) {
+      to_pop += (vargs_len = rpn2->length * 8);
+      first_is_vargs = 1;
+    }
+  }
+  // Arm mandates 16 byte align
+  if (to_pop % 16)
+    to_pop += 8;
+  if (to_pop) {
+    if (ARM_ERR_INV_OFF != ARM_subImmX(ARM_REG_SP, ARM_REG_SP, to_pop)) {
+      AIWNIOS_ADD_CODE(ARM_subImmX(ARM_REG_SP, ARM_REG_SP, to_pop));
+    } else {
+      code_off = __ICMoveI64(cctrl, 0, to_pop, bin, code_off);
+      AIWNIOS_ADD_CODE(ARM_subRegX(ARM_REG_SP, ARM_REG_SP, 0));
+    }
+  }
+  if (first_is_vargs) {
+    base = to_pop - vargs_len;
+    rpn2 = ICArgN(rpn, 0);
+    for (vargs_len -= 8; vargs_len / 8 >= 0; vargs_len -= 8) {
+      varg = ICArgN(rpn2, rpn2->length - vargs_len / 8 - 1);
+      varg->res.mode = MD_INDIR_REG;
+      varg->res.off = vargs_len + base;
+      varg->res.reg = ARM_REG_SP;
+      varg->res.raw_type = (varg->raw_type == RT_F64) ? RT_F64 : RT_I64i;
       code_off = __OptPassFinal(cctrl, varg, bin, code_off);
     }
-    //Put argv at top of argument "stack"(exluding vargs)
-    // args and argv are 2 different "stacks" on top of eachother(argv is a pointer)
-    // argv==[argv stack]
-    // [argv]
-    // [argc]
-    if(ARM_ERR_INV_OFF!=ARM_addImmX(0,ARM_REG_SP,base)) {
-      AIWNIOS_ADD_CODE(ARM_addImmX(0,ARM_REG_SP,base));
+    // Put argv at top of argument "stack"(exluding vargs)
+    //  args and argv are 2 different "stacks" on top of eachother(argv is a
+    //  pointer) argv==[argv stack] [argv] [argc]
+    if (ARM_ERR_INV_OFF != ARM_addImmX(0, ARM_REG_SP, base)) {
+      AIWNIOS_ADD_CODE(ARM_addImmX(0, ARM_REG_SP, base));
     } else {
-      code_off=__ICMoveI64(cctrl,0,base,bin,code_off);
-      AIWNIOS_ADD_CODE(ARM_subRegX(0,ARM_REG_SP,0));
+      code_off = __ICMoveI64(cctrl, 0, base, bin, code_off);
+      AIWNIOS_ADD_CODE(ARM_subRegX(0, ARM_REG_SP, 0));
     }
-    tmp2.mode=MD_REG;
-    tmp2.reg=0;
-    tmp2.raw_type=RT_I64i;
-    tmp.mode=MD_INDIR_REG;
-    tmp.reg=ARM_REG_SP;
-    tmp.off=8*(rpn->length-1);
-    tmp.raw_type=RT_I64i;
-    code_off=ICMov(cctrl,&tmp,&tmp2,bin,code_off);
+    tmp2.mode = MD_REG;
+    tmp2.reg = 0;
+    tmp2.raw_type = RT_I64i;
+    tmp.mode = MD_INDIR_REG;
+    tmp.reg = ARM_REG_SP;
+    tmp.off = 8 * (rpn->length - 1);
+    tmp.raw_type = RT_I64i;
+    code_off = ICMov(cctrl, &tmp, &tmp2, bin, code_off);
   }
-  for (i = first_is_vargs; i<rpn->length ; i++) {
-		rpn2 = ICArgN(rpn, i);
-    rpn2->res.mode=MD_INDIR_REG;
-    rpn2->res.off=(rpn->length-i-1)*8;
-    rpn2->res.reg=ARM_REG_SP;
-		rpn2->res.raw_type=rpn2->raw_type==RT_F64?RT_F64:RT_I64i;
-		code_off = __OptPassFinal(cctrl, rpn2, bin, code_off);
-	}
-	rpn2 = ICArgN(rpn, rpn->length);
-	if (rpn2->type == IC_SHORT_ADDR) {
-		rpn2->code_misc->addr = code_off + bin;
-		AIWNIOS_ADD_CODE(ARM_bl(0));
-		goto after_call;
-	}
-	if (rpn2->type == IC_GLOBAL) {
-		if (rpn2->global_var->base.type & HTT_FUN) {
-			fptr = ((CHashFun*)rpn2->global_var)->fun_ptr;
-			if (cctrl->code_ctrl->final_pass) {
-				if (ARM_ERR_INV_OFF != ARM_bl((char*)fptr - (bin + code_off)))
-					AIWNIOS_ADD_CODE(ARM_bl((char*)fptr - (bin + code_off)))
-				else
-					goto defacto;
-			} else
-				goto defacto;
-		} else
-			goto defacto;
-	} else {
-	defacto:
-    if(!(rpn2->res.mode==MD_REG&&rpn2->res.raw_type!=RT_F64)) {
-      rpn2->raw_type=RT_PTR;
-      rpn2->res.mode=MD_REG;
-      rpn2->res.raw_type=RT_PTR;
-      rpn2->res.reg=8;
+  for (i = first_is_vargs; i < rpn->length; i++) {
+    rpn2 = ICArgN(rpn, i);
+    rpn2->res.mode = MD_INDIR_REG;
+    rpn2->res.off = (rpn->length - i - 1) * 8;
+    rpn2->res.reg = ARM_REG_SP;
+    rpn2->res.raw_type = rpn2->raw_type == RT_F64 ? RT_F64 : RT_I64i;
+    code_off = __OptPassFinal(cctrl, rpn2, bin, code_off);
+  }
+  rpn2 = ICArgN(rpn, rpn->length);
+  if (rpn2->type == IC_SHORT_ADDR) {
+    rpn2->code_misc->addr = code_off + bin;
+    AIWNIOS_ADD_CODE(ARM_bl(0));
+    goto after_call;
+  }
+  if (rpn2->type == IC_GLOBAL) {
+    if (rpn2->global_var->base.type & HTT_FUN) {
+      fptr = ((CHashFun *)rpn2->global_var)->fun_ptr;
+      if (cctrl->code_ctrl->final_pass) {
+        if (ARM_ERR_INV_OFF != ARM_bl((char *)fptr - (bin + code_off)))
+          AIWNIOS_ADD_CODE(ARM_bl((char *)fptr - (bin + code_off)))
+        else
+          goto defacto;
+      } else
+        goto defacto;
+    } else
+      goto defacto;
+  } else {
+  defacto:
+    if (!(rpn2->res.mode == MD_REG && rpn2->res.raw_type != RT_F64)) {
+      rpn2->raw_type = RT_PTR;
+      rpn2->res.mode = MD_REG;
+      rpn2->res.raw_type = RT_PTR;
+      rpn2->res.reg = 8;
     }
     code_off = __OptPassFinal(cctrl, rpn2, bin, code_off);
-    code_off=PutICArgIntoReg(cctrl,&rpn2->res,RT_PTR,8,bin,code_off);
+    code_off = PutICArgIntoReg(cctrl, &rpn2->res, RT_PTR, 8, bin, code_off);
     AIWNIOS_ADD_CODE(ARM_blr(rpn2->res.reg));
-	}
+  }
 after_call:
-	if(to_pop) {
-    if(ARM_ERR_INV_OFF!=ARM_addImmX(ARM_REG_SP,ARM_REG_SP,to_pop)) {
-      AIWNIOS_ADD_CODE(ARM_addImmX(ARM_REG_SP,ARM_REG_SP,to_pop));
+  if (to_pop) {
+    if (ARM_ERR_INV_OFF != ARM_addImmX(ARM_REG_SP, ARM_REG_SP, to_pop)) {
+      AIWNIOS_ADD_CODE(ARM_addImmX(ARM_REG_SP, ARM_REG_SP, to_pop));
     } else {
-      code_off=__ICMoveI64(cctrl,0,to_pop,bin,code_off);
-      AIWNIOS_ADD_CODE(ARM_addRegX(ARM_REG_SP,ARM_REG_SP,0));
+      code_off = __ICMoveI64(cctrl, 0, to_pop, bin, code_off);
+      AIWNIOS_ADD_CODE(ARM_addRegX(ARM_REG_SP, ARM_REG_SP, 0));
     }
   }
-  
-	if (rpn->raw_type != RT_U0) {
-		tmp.reg = 0;
-		tmp.mode = MD_REG;
-		tmp.raw_type = rpn->raw_type;
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-	}
-	return code_off;
+
+  if (rpn->raw_type != RT_U0) {
+    tmp.reg = 0;
+    tmp.mode = MD_REG;
+    tmp.raw_type = rpn->raw_type;
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+  }
+  return code_off;
 }
 /*Im using TempleOS-like ABI now
 // See __IC_CALL
 static int64_t __ICFCall(CCmpCtrl* cctrl, CRPN* rpn, char* bin,
-	int64_t code_off)
+  int64_t code_off)
 {
-	CRPN *rpn2 = rpn->base.next, *rpn3;
-	CICArg *arg_dsts = NULL, tmp = { 0 };
-	CCodeMisc* reloc;
-	char* fptr;
+  CRPN *rpn2 = rpn->base.next, *rpn3;
+  CICArg *arg_dsts = NULL, tmp = { 0 };
+  CCodeMisc* reloc;
+  char* fptr;
 
-	//
-	// argv_stki is the stack location of the first varg
-	//
-	int64_t i2, i = rpn->length, to, ii = 0, fi = 0, stki = 0, vargs_sz = 0;
-	while (--i >= 0)
-		rpn2 = ICFwd(rpn2);
-	AssignRawTypeToNode(cctrl, rpn2);
-	to = rpn->length;
-	arg_dsts = A_MALLOC(to * sizeof(CICArg),
-		cctrl->hc);
-	rpn2 = ICArgN(rpn, rpn->length);
-	PushTmp(cctrl, rpn2, NULL);
-	rpn2 = rpn->base.next;
-	for (i = 0; i != to;) {
-		rpn2 = ICArgN(rpn, rpn->length - i - 1);
-		if (rpn2->type == __IC_VARGS) { // Will pop off the vargs for you
-			vargs_sz = 8 * rpn2->length;
-			if (rpn2->length & 1) // Align to 16
-				vargs_sz += 8;
-		}
-		arg_dsts[i].raw_type = rpn2->raw_type;
-		if (rpn2->raw_type == RT_F64) {
-			if (fi < 8 && i < to) {
-				arg_dsts[i].mode = MD_REG;
-				arg_dsts[i].reg = fi++;
-			} else {
-				arg_dsts[i].mode = MD_INDIR_REG;
-				arg_dsts[i].reg = ARM_REG_SP;
-				arg_dsts[i].off = stki++ * 8;
-			}
-		} else {
-			if (ii < 8 && i < to) {
-				arg_dsts[i].raw_type = RT_I64i;
-				arg_dsts[i].mode = MD_REG;
-				arg_dsts[i].reg = ii++;
-			} else {
-				arg_dsts[i].raw_type = RT_I64i;
-				arg_dsts[i].mode = MD_INDIR_REG;
-				arg_dsts[i].reg = ARM_REG_SP;
-				arg_dsts[i].off = stki++ * 8;
-			}
-		}
-		// Check for function calls in future arguments
-		rpn3 = rpn2;
-		for (i2 = i + 1; i2 < rpn->length; i2++) {
-			rpn3 = ICArgN(rpn, rpn->length - i2 - 1);
-			if (SpillsTmpRegs(rpn3)) {
-				PushSpilledTmp(cctrl, rpn2);
-				goto pass;
-			}
-		}
-		PushTmp(cctrl, rpn2, NULL);
-	pass:
-		code_off = __OptPassFinal(cctrl, rpn2, bin, code_off);
-		rpn2 = ICFwd(rpn2);
-		i++;
-	}
-	// Keep stack aligned to 16 bytes(8 bytes per item)
-	if (stki % 2)
-		stki++;
-	if (stki)
-		AIWNIOS_ADD_CODE(ARM_subImmX(ARM_REG_SP, ARM_REG_SP, stki * 8));
-	i = rpn->length - 1;
+  //
+  // argv_stki is the stack location of the first varg
+  //
+  int64_t i2, i = rpn->length, to, ii = 0, fi = 0, stki = 0, vargs_sz = 0;
+  while (--i >= 0)
+    rpn2 = ICFwd(rpn2);
+  AssignRawTypeToNode(cctrl, rpn2);
+  to = rpn->length;
+  arg_dsts = A_MALLOC(to * sizeof(CICArg),
+    cctrl->hc);
+  rpn2 = ICArgN(rpn, rpn->length);
+  PushTmp(cctrl, rpn2, NULL);
+  rpn2 = rpn->base.next;
+  for (i = 0; i != to;) {
+    rpn2 = ICArgN(rpn, rpn->length - i - 1);
+    if (rpn2->type == __IC_VARGS) { // Will pop off the vargs for you
+      vargs_sz = 8 * rpn2->length;
+      if (rpn2->length & 1) // Align to 16
+        vargs_sz += 8;
+    }
+    arg_dsts[i].raw_type = rpn2->raw_type;
+    if (rpn2->raw_type == RT_F64) {
+      if (fi < 8 && i < to) {
+        arg_dsts[i].mode = MD_REG;
+        arg_dsts[i].reg = fi++;
+      } else {
+        arg_dsts[i].mode = MD_INDIR_REG;
+        arg_dsts[i].reg = ARM_REG_SP;
+        arg_dsts[i].off = stki++ * 8;
+      }
+    } else {
+      if (ii < 8 && i < to) {
+        arg_dsts[i].raw_type = RT_I64i;
+        arg_dsts[i].mode = MD_REG;
+        arg_dsts[i].reg = ii++;
+      } else {
+        arg_dsts[i].raw_type = RT_I64i;
+        arg_dsts[i].mode = MD_INDIR_REG;
+        arg_dsts[i].reg = ARM_REG_SP;
+        arg_dsts[i].off = stki++ * 8;
+      }
+    }
+    // Check for function calls in future arguments
+    rpn3 = rpn2;
+    for (i2 = i + 1; i2 < rpn->length; i2++) {
+      rpn3 = ICArgN(rpn, rpn->length - i2 - 1);
+      if (SpillsTmpRegs(rpn3)) {
+        PushSpilledTmp(cctrl, rpn2);
+        goto pass;
+      }
+    }
+    PushTmp(cctrl, rpn2, NULL);
+  pass:
+    code_off = __OptPassFinal(cctrl, rpn2, bin, code_off);
+    rpn2 = ICFwd(rpn2);
+    i++;
+  }
+  // Keep stack aligned to 16 bytes(8 bytes per item)
+  if (stki % 2)
+    stki++;
+  if (stki)
+    AIWNIOS_ADD_CODE(ARM_subImmX(ARM_REG_SP, ARM_REG_SP, stki * 8));
+  i = rpn->length - 1;
 aloop:
-	while (i >= 0) {
-		i2 = i;
-		// IC_CALL
-		// ARGn <===rpn->length -1
-		// FUN
-		rpn2 = ICArgN(rpn, rpn->length - i - 1);
-		PopTmp(cctrl, rpn2);
-		code_off = ICMov(cctrl, &arg_dsts[i2], &rpn2->res, bin, code_off);
-		i--;
-	next:;
-	}
-	rpn2 = ICArgN(rpn, rpn->length);
-	if (rpn2->type == IC_SHORT_ADDR) {
-		rpn2->code_misc->addr = code_off + bin;
-		AIWNIOS_ADD_CODE(ARM_bl(0));
-		goto after_call;
-	}
-	if (rpn2->type == IC_GLOBAL) {
-		if (rpn2->global_var->base.type & HTT_FUN) {
-			fptr = ((CHashFun*)rpn2->global_var)->fun_ptr;
-			if (cctrl->code_ctrl->final_pass) {
-				if (ARM_ERR_INV_OFF != ARM_bl((char*)fptr - (bin + code_off)))
-					AIWNIOS_ADD_CODE(ARM_bl((char*)fptr - (bin + code_off)))
-				else
-					goto defacto;
-			} else
-				goto defacto;
-		} else
-			goto defacto;
-	} else {
-	defacto:
-		if (rpn2->res.mode == MD_PTR) {
-			rpn2->res.raw_type = RT_PTR;
-			rpn2->res.mode = MD_REG;
-			rpn2->res.reg = 8;
-		}
-		code_off = __OptPassFinal(cctrl, rpn2, bin, code_off);
-		code_off = PutICArgIntoReg(cctrl, &rpn2->res, RT_PTR, 8, bin, code_off);
-		AIWNIOS_ADD_CODE(ARM_blr(rpn2->res.reg));
-	}
+  while (i >= 0) {
+    i2 = i;
+    // IC_CALL
+    // ARGn <===rpn->length -1
+    // FUN
+    rpn2 = ICArgN(rpn, rpn->length - i - 1);
+    PopTmp(cctrl, rpn2);
+    code_off = ICMov(cctrl, &arg_dsts[i2], &rpn2->res, bin, code_off);
+    i--;
+  next:;
+  }
+  rpn2 = ICArgN(rpn, rpn->length);
+  if (rpn2->type == IC_SHORT_ADDR) {
+    rpn2->code_misc->addr = code_off + bin;
+    AIWNIOS_ADD_CODE(ARM_bl(0));
+    goto after_call;
+  }
+  if (rpn2->type == IC_GLOBAL) {
+    if (rpn2->global_var->base.type & HTT_FUN) {
+      fptr = ((CHashFun*)rpn2->global_var)->fun_ptr;
+      if (cctrl->code_ctrl->final_pass) {
+        if (ARM_ERR_INV_OFF != ARM_bl((char*)fptr - (bin + code_off)))
+          AIWNIOS_ADD_CODE(ARM_bl((char*)fptr - (bin + code_off)))
+        else
+          goto defacto;
+      } else
+        goto defacto;
+    } else
+      goto defacto;
+  } else {
+  defacto:
+    if (rpn2->res.mode == MD_PTR) {
+      rpn2->res.raw_type = RT_PTR;
+      rpn2->res.mode = MD_REG;
+      rpn2->res.reg = 8;
+    }
+    code_off = __OptPassFinal(cctrl, rpn2, bin, code_off);
+    code_off = PutICArgIntoReg(cctrl, &rpn2->res, RT_PTR, 8, bin, code_off);
+    AIWNIOS_ADD_CODE(ARM_blr(rpn2->res.reg));
+  }
 after_call:
-	if (stki || vargs_sz)
-		AIWNIOS_ADD_CODE(ARM_addImmX(ARM_REG_SP, ARM_REG_SP, stki * 8 + vargs_sz));
-	if (rpn->raw_type != RT_U0) {
-		tmp.reg = 0;
-		tmp.mode = MD_REG;
-		tmp.raw_type = rpn->raw_type;
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-	}
-	A_FREE(arg_dsts);
-	rpn2 = ICArgN(rpn, rpn->length);
-	PopTmp(cctrl, rpn2);
-	return code_off;
+  if (stki || vargs_sz)
+    AIWNIOS_ADD_CODE(ARM_addImmX(ARM_REG_SP, ARM_REG_SP, stki * 8 + vargs_sz));
+  if (rpn->raw_type != RT_U0) {
+    tmp.reg = 0;
+    tmp.mode = MD_REG;
+    tmp.raw_type = rpn->raw_type;
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+  }
+  A_FREE(arg_dsts);
+  rpn2 = ICArgN(rpn, rpn->length);
+  PopTmp(cctrl, rpn2);
+  return code_off;
 }
 */
 
-static int64_t ICMov(CCmpCtrl* cctrl, CICArg* dst, CICArg* src, char* bin,
-	int64_t code_off)
-{
-	int64_t use_reg, use_reg2, restore_from_tmp = 0, indir_off = 0,
-							   indir_off2 = 0, opc;
-	assert(src->mode!=-1&&src->mode);
-	CICArg tmp = { 0 };
-	CCodeMiscRef* ref;
-	if (dst->mode == MD_NULL)
-		return code_off;
-	if ((dst->raw_type == RT_F64) == (src->raw_type == RT_F64))
-		if (dst->mode == src->mode) {
-			switch (dst->mode) {
-				break;
-			case __MD_ARM_SHIFT:
-				if (dst->reg == src->reg)
-					if (dst->reg2 == src->reg2)
-						return code_off;
-				break;
-			case MD_STATIC:
-				if (dst->off == src->off)
-					return code_off;
-				break;
-			case MD_PTR:
-				if (dst->off == src->off)
-					return code_off;
-				break;
-			case MD_REG:
-				if (dst->reg == src->reg)
-					return code_off;
-				break;
-			case MD_FRAME:
-				if (dst->off == src->off)
-					return code_off;
-				break;
-			case MD_INDIR_REG:
-				if (dst->off == src->off && dst->reg == src->reg)
-					return code_off;
-			}
-		}
-	switch (dst->mode) {
-	case __MD_ARM_SHIFT:
-		if (src->mode == MD_REG && ((src->raw_type == RT_F64) == (dst->raw_type == RT_F64))) {
-			switch (dst->raw_type) {
-			case RT_U0:
-				break;
-			case RT_U8i:
-			case RT_I8i:
-				AIWNIOS_ADD_CODE(ARM_strbRegRegShift(src->reg, dst->reg, dst->reg2));
-				break;
-			case RT_U16i:
-			case RT_I16i:
-				AIWNIOS_ADD_CODE(ARM_strhRegRegShift(src->reg, dst->reg, dst->reg2));
-				break;
-			case RT_U32i:
-			case RT_I32i:
-				AIWNIOS_ADD_CODE(ARM_strRegRegShift(src->reg, dst->reg, dst->reg2));
-				break;
-			case RT_U64i:
-			case RT_I64i:
-			case RT_PTR:
-			case RT_FUNC:
-				AIWNIOS_ADD_CODE(ARM_strRegRegShiftX(src->reg, dst->reg, dst->reg2));
-				break;
-			case RT_F64:
-				AIWNIOS_ADD_CODE(ARM_strRegRegShiftF64(src->reg, dst->reg, dst->reg2));
-			}
-			return code_off;
-		}
-		goto dft;
-		break;
-	case MD_STATIC:
-		use_reg2 = AIWNIOS_TMP_IREG_POOP;
-		indir_off = 0;
-		if (cctrl->code_ctrl->final_pass) {
-			AIWNIOS_ADD_CODE(ARM_adrX(use_reg2, 0));
-			ref = CodeMiscAddRef(cctrl->statics_label, bin + code_off - 4);
-      ref->patch_cond_br=ARM_adrX;
-      ref->user_data1=use_reg2;
-			ref->offset = dst->off;
-		} else
-			AIWNIOS_ADD_CODE(0);
-		goto indir_r2;
-		break;
-	case MD_INDIR_REG:
-		use_reg2 = dst->reg;
-		indir_off = dst->off;
-	indir_r2:
-		if (src->raw_type == dst->raw_type && src->raw_type == RT_F64 && src->mode == MD_REG) {
-			use_reg = src->reg;
-		} else if ((src->raw_type == RT_F64) ^ (RT_F64 == dst->raw_type)) { // Do they differ
-			goto dft;
-		} else if (src->mode == MD_FRAME || src->mode == MD_PTR || src->mode == MD_INDIR_REG) {
-			goto dft;
-		} else if (src->mode == MD_REG) {
-			use_reg = src->reg;
-      //Cant assign SP into mem directly in arm
-      if(use_reg==ARM_REG_SP)
+static int64_t ICMov(CCmpCtrl *cctrl, CICArg *dst, CICArg *src, char *bin,
+                     int64_t code_off) {
+  int64_t use_reg, use_reg2, restore_from_tmp = 0, indir_off = 0,
+                             indir_off2 = 0, opc;
+  assert(src->mode != -1 && src->mode);
+  CICArg tmp = {0};
+  CCodeMiscRef *ref;
+  if (dst->mode == MD_NULL)
+    return code_off;
+  if ((dst->raw_type == RT_F64) == (src->raw_type == RT_F64))
+    if (dst->mode == src->mode) {
+      switch (dst->mode) {
+        break;
+      case __MD_ARM_SHIFT:
+        if (dst->reg == src->reg)
+          if (dst->reg2 == src->reg2)
+            return code_off;
+        break;
+      case MD_STATIC:
+        if (dst->off == src->off)
+          return code_off;
+        break;
+      case MD_PTR:
+        if (dst->off == src->off)
+          return code_off;
+        break;
+      case MD_REG:
+        if (dst->reg == src->reg)
+          return code_off;
+        break;
+      case MD_FRAME:
+        if (dst->off == src->off)
+          return code_off;
+        break;
+      case MD_INDIR_REG:
+        if (dst->off == src->off && dst->reg == src->reg)
+          return code_off;
+      }
+    }
+  switch (dst->mode) {
+  case __MD_ARM_SHIFT:
+    if (src->mode == MD_REG &&
+        ((src->raw_type == RT_F64) == (dst->raw_type == RT_F64))) {
+      switch (dst->raw_type) {
+      case RT_U0:
+        break;
+      case RT_U8i:
+      case RT_I8i:
+        AIWNIOS_ADD_CODE(ARM_strbRegRegShift(src->reg, dst->reg, dst->reg2));
+        break;
+      case RT_U16i:
+      case RT_I16i:
+        AIWNIOS_ADD_CODE(ARM_strhRegRegShift(src->reg, dst->reg, dst->reg2));
+        break;
+      case RT_U32i:
+      case RT_I32i:
+        AIWNIOS_ADD_CODE(ARM_strRegRegShift(src->reg, dst->reg, dst->reg2));
+        break;
+      case RT_U64i:
+      case RT_I64i:
+      case RT_PTR:
+      case RT_FUNC:
+        AIWNIOS_ADD_CODE(ARM_strRegRegShiftX(src->reg, dst->reg, dst->reg2));
+        break;
+      case RT_F64:
+        AIWNIOS_ADD_CODE(ARM_strRegRegShiftF64(src->reg, dst->reg, dst->reg2));
+      }
+      return code_off;
+    }
+    goto dft;
+    break;
+  case MD_STATIC:
+    use_reg2 = AIWNIOS_TMP_IREG_POOP;
+    indir_off = 0;
+    if (cctrl->code_ctrl->final_pass) {
+      AIWNIOS_ADD_CODE(ARM_adrX(use_reg2, 0));
+      ref = CodeMiscAddRef(cctrl->statics_label, bin + code_off - 4);
+      ref->patch_cond_br = ARM_adrX;
+      ref->user_data1 = use_reg2;
+      ref->offset = dst->off;
+    } else
+      AIWNIOS_ADD_CODE(0);
+    goto indir_r2;
+    break;
+  case MD_INDIR_REG:
+    use_reg2 = dst->reg;
+    indir_off = dst->off;
+  indir_r2:
+    if (src->raw_type == dst->raw_type && src->raw_type == RT_F64 &&
+        src->mode == MD_REG) {
+      use_reg = src->reg;
+    } else if ((src->raw_type == RT_F64) ^
+               (RT_F64 == dst->raw_type)) { // Do they differ
+      goto dft;
+    } else if (src->mode == MD_FRAME || src->mode == MD_PTR ||
+               src->mode == MD_INDIR_REG) {
+      goto dft;
+    } else if (src->mode == MD_REG) {
+      use_reg = src->reg;
+      // Cant assign SP into mem directly in arm
+      if (use_reg == ARM_REG_SP)
         goto dft;
     } else {
-		dft:
-			tmp.raw_type = src->raw_type;
-			if (dst->raw_type != RT_F64)
-				use_reg = tmp.reg = AIWNIOS_TMP_IREG_POOP2;
-			else
-				use_reg = tmp.reg = 0;
-			tmp.mode = MD_REG;
-			code_off = ICMov(cctrl, &tmp, src, bin, code_off);
-			if (dst->raw_type == RT_F64 && src->raw_type != dst->raw_type) {
-				AIWNIOS_ADD_CODE(ARM_scvtf(use_reg, use_reg));
-				tmp.raw_type = RT_F64;
-			} else if (src->raw_type == RT_F64 && src->raw_type != dst->raw_type) {
-				AIWNIOS_ADD_CODE(ARM_fcvtzs(use_reg, use_reg));
-				tmp.raw_type = RT_I64i;
-			}
-			code_off = ICMov(cctrl, dst, &tmp, bin, code_off);
-			return code_off;
-		}
-		goto store_r2;
-		break;
-	case MD_PTR:
-		use_reg2 = AIWNIOS_TMP_IREG_POOP;
-		code_off = __ICMoveI64(cctrl, use_reg2, dst->off, bin, code_off);
-		indir_off = 0;
-		goto indir_r2;
-	store_r2:
-		if (indir_off < 0) {
-			indir_off2 = indir_off;
-			indir_off = 0;
-			AIWNIOS_ADD_CODE(ARM_subImmX(use_reg2, use_reg2, -indir_off2));
-		}
-		switch (dst->raw_type) {
-		case RT_U0:
-			break;
-		case RT_F64:
-			opc = ARM_strRegImmF64(use_reg, use_reg2, indir_off);
-			if (opc != ARM_ERR_INV_OFF) {
-				AIWNIOS_ADD_CODE(opc);
-			} else {
-				// 5 is one of our poop registers
-				code_off = __ICMoveI64(cctrl, AIWNIOS_TMP_IREG_POOP, indir_off, bin, code_off);
-				AIWNIOS_ADD_CODE(ARM_strRegRegF64(use_reg, use_reg2, AIWNIOS_TMP_IREG_POOP));
-			}
-			break;
-		case RT_U8i:
-		case RT_I8i:
-			opc = ARM_strbRegImm(use_reg, use_reg2, indir_off);
-			if (opc != ARM_ERR_INV_OFF) {
-				AIWNIOS_ADD_CODE(opc);
-			} else {
-				code_off = __ICMoveI64(cctrl, AIWNIOS_TMP_IREG_POOP, indir_off, bin, code_off);
-				AIWNIOS_ADD_CODE(ARM_strbRegReg(use_reg, use_reg2, AIWNIOS_TMP_IREG_POOP));
-			}
-			break;
-		case RT_U16i:
-		case RT_I16i:
-			opc = ARM_strhRegImm(use_reg, use_reg2, indir_off);
-			if (opc != ARM_ERR_INV_OFF) {
-				AIWNIOS_ADD_CODE(opc);
-			} else {
-				code_off = __ICMoveI64(cctrl, AIWNIOS_TMP_IREG_POOP, indir_off, bin, code_off);
-				AIWNIOS_ADD_CODE(ARM_strhRegReg(use_reg, use_reg2, AIWNIOS_TMP_IREG_POOP));
-			}
-			break;
-		case RT_U32i:
-		case RT_I32i:
-			opc = ARM_strRegImm(use_reg, use_reg2, indir_off);
-			if (opc != ARM_ERR_INV_OFF) {
-				AIWNIOS_ADD_CODE(opc);
-			} else {
-				// 5 is one of our poop registers
-				code_off = __ICMoveI64(cctrl, AIWNIOS_TMP_IREG_POOP, indir_off, bin, code_off);
-				AIWNIOS_ADD_CODE(ARM_strRegReg(use_reg, use_reg2, AIWNIOS_TMP_IREG_POOP));
-			}
-			break;
-		case RT_U64i:
-		case RT_I64i:
-		case RT_FUNC: // func ptr
-		case RT_PTR:
-			opc = ARM_strRegImmX(use_reg, use_reg2, indir_off);
-			if (opc != ARM_ERR_INV_OFF) {
-				AIWNIOS_ADD_CODE(opc);
-			} else {
-				// 5 is one of our poop registers
-				code_off = __ICMoveI64(cctrl, AIWNIOS_TMP_IREG_POOP, indir_off, bin, code_off);
-				AIWNIOS_ADD_CODE(ARM_strRegRegX(use_reg, use_reg2, AIWNIOS_TMP_IREG_POOP));
-			}
-			break;
-		default:
-			abort();
-		}
-		if (indir_off2 < 0) {
-			AIWNIOS_ADD_CODE(ARM_addImmX(use_reg2, use_reg2, -indir_off2));
-		} else if (indir_off2 > 0) {
-			AIWNIOS_ADD_CODE(ARM_subImmX(use_reg2, use_reg2, indir_off2));
-		}
-		break;
-	case MD_FRAME:
-		use_reg2 = ARM_REG_FP;
-		indir_off = dst->off;
-		goto indir_r2;
-		break;
-	case MD_REG:
-		use_reg = dst->reg;
-		if (src->mode == MD_FRAME) {
-			if (src->raw_type == RT_F64 && src->raw_type == dst->raw_type) {
-				use_reg2 = ARM_REG_FP;
-				indir_off = src->off;
-				goto load_r2;
-			} else if ((src->raw_type == RT_F64) ^ (RT_F64 == dst->raw_type)) {
-				goto dft;
-			}
-			use_reg2 = ARM_REG_FP;
-			indir_off = src->off;
-			goto load_r2;
-		} else if (src->mode == __MD_ARM_SHIFT) {
-			if ((src->raw_type == RT_F64) != (dst->raw_type == RT_F64))
-				goto dft;
-			switch (src->raw_type) {
-			case RT_U0:
-				break;
-			case RT_U8i:
-				AIWNIOS_ADD_CODE(ARM_ldrbRegRegShift(dst->reg, src->reg, src->reg2));
-				AIWNIOS_ADD_CODE(ARM_uxtbX(dst->reg, dst->reg));
-				break;
-			case RT_I8i:
-				AIWNIOS_ADD_CODE(ARM_ldrbRegRegShift(dst->reg, src->reg, src->reg2));
-				AIWNIOS_ADD_CODE(ARM_sxtbX(dst->reg, dst->reg));
-				break;
-			case RT_U16i:
-				AIWNIOS_ADD_CODE(ARM_ldrhRegRegShift(dst->reg, src->reg, src->reg2));
-				AIWNIOS_ADD_CODE(ARM_uxthX(dst->reg, dst->reg));
-				break;
-			case RT_I16i:
-				AIWNIOS_ADD_CODE(ARM_ldrhRegRegShift(dst->reg, src->reg, src->reg2));
-				AIWNIOS_ADD_CODE(ARM_sxthX(dst->reg, dst->reg));
-				break;
-			case RT_U32i:
-				AIWNIOS_ADD_CODE(ARM_ldrRegRegShift(dst->reg, src->reg, src->reg2));
-				AIWNIOS_ADD_CODE(ARM_uxtwX(dst->reg, dst->reg));
-				break;
-			case RT_I32i:
-				AIWNIOS_ADD_CODE(ARM_ldrRegRegShift(dst->reg, src->reg, src->reg2));
-				AIWNIOS_ADD_CODE(ARM_sxtwX(dst->reg, dst->reg));
-				break;
-			case RT_U64i:
-			case RT_PTR:
-			case RT_FUNC:
-			case RT_I64i:
-				AIWNIOS_ADD_CODE(ARM_ldrRegRegShiftX(dst->reg, src->reg, src->reg2));
-				break;
-			case RT_F64:
-				AIWNIOS_ADD_CODE(ARM_ldrRegRegShiftF64(dst->reg, src->reg, src->reg2));
-			}
-			return code_off;
-		} else if (src->mode == MD_REG) {
-			if (src->raw_type == RT_F64 && src->raw_type == dst->raw_type) {
-				AIWNIOS_ADD_CODE(ARM_fmovReg(dst->reg, src->reg));
-			} else if (src->raw_type != RT_F64 && dst->raw_type != RT_F64) {
-				AIWNIOS_ADD_CODE(ARM_movRegX(dst->reg, src->reg));
-			} else if (src->raw_type == RT_F64 && dst->raw_type != RT_F64) {
-				AIWNIOS_ADD_CODE(ARM_fcvtzs(dst->reg, src->reg));
-			} else if (src->raw_type != RT_F64 && dst->raw_type == RT_F64) {
-				switch (src->raw_type) {
-				case RT_U8i:
-				case RT_U16i:
-				case RT_U32i:
-				case RT_U64i:
-					AIWNIOS_ADD_CODE(ARM_ucvtf(dst->reg, src->reg));
-					break;
-				default:
-					AIWNIOS_ADD_CODE(ARM_scvtf(dst->reg, src->reg));
-				}
-				return code_off;
-			}
-		} else if (src->mode == MD_PTR) {
-			if (src->raw_type == RT_F64 && src->raw_type == dst->raw_type) {
-				use_reg2 = 0;
-				code_off = __ICMoveI64(cctrl, use_reg2, src->off, bin, code_off);
-				goto load_r2;
-			} else if ((src->raw_type == RT_F64) ^ (RT_F64 == dst->raw_type)) {
-				goto dft;
-			}
-			// We can use ARM_ldrLabel/ARM_ldrLabelX for 64/32bit shenangins if it is in range
-			if (cctrl->code_ctrl->final_pass)
-				switch (src->raw_type) {
-					break;
-				case RT_I32i:
-					opc = ARM_ldrLabel(use_reg, (char*)src->off - (code_off + bin));
-					if (opc != ARM_ERR_INV_OFF) {
-						AIWNIOS_ADD_CODE(opc);
-						AIWNIOS_ADD_CODE(ARM_sxtwX(use_reg, use_reg));
-						return code_off;
-					}
-					break;
-				case RT_U32i:
-					opc = ARM_ldrLabel(use_reg, (char*)src->off - (code_off + bin));
-					if (opc != ARM_ERR_INV_OFF) {
-						AIWNIOS_ADD_CODE(opc);
-						AIWNIOS_ADD_CODE(ARM_uxtwX(use_reg, use_reg));
-						return code_off;
-					}
-					break;
-				case RT_I64i:
-				case RT_U64i:
-					opc = ARM_ldrLabelX(use_reg, (char*)src->off - (code_off + bin));
-					if (opc != ARM_ERR_INV_OFF) {
-						AIWNIOS_ADD_CODE(opc);
-						return code_off;
-					}
-					break;
-				case RT_F64:
-					opc = ARM_ldrLabelF64(use_reg, (char*)src->off - (code_off + bin));
-					if (opc != ARM_ERR_INV_OFF) {
-						AIWNIOS_ADD_CODE(opc);
-						return code_off;
-					}
-				}
+    dft:
+      tmp.raw_type = src->raw_type;
+      if (dst->raw_type != RT_F64)
+        use_reg = tmp.reg = AIWNIOS_TMP_IREG_POOP2;
+      else
+        use_reg = tmp.reg = 0;
+      tmp.mode = MD_REG;
+      code_off = ICMov(cctrl, &tmp, src, bin, code_off);
+      if (dst->raw_type == RT_F64 && src->raw_type != dst->raw_type) {
+        AIWNIOS_ADD_CODE(ARM_scvtf(use_reg, use_reg));
+        tmp.raw_type = RT_F64;
+      } else if (src->raw_type == RT_F64 && src->raw_type != dst->raw_type) {
+        AIWNIOS_ADD_CODE(ARM_fcvtzs(use_reg, use_reg));
+        tmp.raw_type = RT_I64i;
+      }
+      code_off = ICMov(cctrl, dst, &tmp, bin, code_off);
+      return code_off;
+    }
+    goto store_r2;
+    break;
+  case MD_PTR:
+    use_reg2 = AIWNIOS_TMP_IREG_POOP;
+    code_off = __ICMoveI64(cctrl, use_reg2, dst->off, bin, code_off);
+    indir_off = 0;
+    goto indir_r2;
+  store_r2:
+    if (indir_off < 0) {
+      indir_off2 = indir_off;
+      indir_off = 0;
+      AIWNIOS_ADD_CODE(ARM_subImmX(use_reg2, use_reg2, -indir_off2));
+    }
+    switch (dst->raw_type) {
+    case RT_U0:
+      break;
+    case RT_F64:
+      opc = ARM_strRegImmF64(use_reg, use_reg2, indir_off);
+      if (opc != ARM_ERR_INV_OFF) {
+        AIWNIOS_ADD_CODE(opc);
+      } else {
+        // 5 is one of our poop registers
+        code_off =
+            __ICMoveI64(cctrl, AIWNIOS_TMP_IREG_POOP, indir_off, bin, code_off);
+        AIWNIOS_ADD_CODE(
+            ARM_strRegRegF64(use_reg, use_reg2, AIWNIOS_TMP_IREG_POOP));
+      }
+      break;
+    case RT_U8i:
+    case RT_I8i:
+      opc = ARM_strbRegImm(use_reg, use_reg2, indir_off);
+      if (opc != ARM_ERR_INV_OFF) {
+        AIWNIOS_ADD_CODE(opc);
+      } else {
+        code_off =
+            __ICMoveI64(cctrl, AIWNIOS_TMP_IREG_POOP, indir_off, bin, code_off);
+        AIWNIOS_ADD_CODE(
+            ARM_strbRegReg(use_reg, use_reg2, AIWNIOS_TMP_IREG_POOP));
+      }
+      break;
+    case RT_U16i:
+    case RT_I16i:
+      opc = ARM_strhRegImm(use_reg, use_reg2, indir_off);
+      if (opc != ARM_ERR_INV_OFF) {
+        AIWNIOS_ADD_CODE(opc);
+      } else {
+        code_off =
+            __ICMoveI64(cctrl, AIWNIOS_TMP_IREG_POOP, indir_off, bin, code_off);
+        AIWNIOS_ADD_CODE(
+            ARM_strhRegReg(use_reg, use_reg2, AIWNIOS_TMP_IREG_POOP));
+      }
+      break;
+    case RT_U32i:
+    case RT_I32i:
+      opc = ARM_strRegImm(use_reg, use_reg2, indir_off);
+      if (opc != ARM_ERR_INV_OFF) {
+        AIWNIOS_ADD_CODE(opc);
+      } else {
+        // 5 is one of our poop registers
+        code_off =
+            __ICMoveI64(cctrl, AIWNIOS_TMP_IREG_POOP, indir_off, bin, code_off);
+        AIWNIOS_ADD_CODE(
+            ARM_strRegReg(use_reg, use_reg2, AIWNIOS_TMP_IREG_POOP));
+      }
+      break;
+    case RT_U64i:
+    case RT_I64i:
+    case RT_FUNC: // func ptr
+    case RT_PTR:
+      opc = ARM_strRegImmX(use_reg, use_reg2, indir_off);
+      if (opc != ARM_ERR_INV_OFF) {
+        AIWNIOS_ADD_CODE(opc);
+      } else {
+        // 5 is one of our poop registers
+        code_off =
+            __ICMoveI64(cctrl, AIWNIOS_TMP_IREG_POOP, indir_off, bin, code_off);
+        AIWNIOS_ADD_CODE(
+            ARM_strRegRegX(use_reg, use_reg2, AIWNIOS_TMP_IREG_POOP));
+      }
+      break;
+    default:
+      abort();
+    }
+    if (indir_off2 < 0) {
+      AIWNIOS_ADD_CODE(ARM_addImmX(use_reg2, use_reg2, -indir_off2));
+    } else if (indir_off2 > 0) {
+      AIWNIOS_ADD_CODE(ARM_subImmX(use_reg2, use_reg2, indir_off2));
+    }
+    break;
+  case MD_FRAME:
+    use_reg2 = ARM_REG_FP;
+    indir_off = dst->off;
+    goto indir_r2;
+    break;
+  case MD_REG:
+    use_reg = dst->reg;
+    if (src->mode == MD_FRAME) {
+      if (src->raw_type == RT_F64 && src->raw_type == dst->raw_type) {
+        use_reg2 = ARM_REG_FP;
+        indir_off = src->off;
+        goto load_r2;
+      } else if ((src->raw_type == RT_F64) ^ (RT_F64 == dst->raw_type)) {
+        goto dft;
+      }
+      use_reg2 = ARM_REG_FP;
+      indir_off = src->off;
+      goto load_r2;
+    } else if (src->mode == __MD_ARM_SHIFT) {
+      if ((src->raw_type == RT_F64) != (dst->raw_type == RT_F64))
+        goto dft;
+      switch (src->raw_type) {
+      case RT_U0:
+        break;
+      case RT_U8i:
+        AIWNIOS_ADD_CODE(ARM_ldrbRegRegShift(dst->reg, src->reg, src->reg2));
+        AIWNIOS_ADD_CODE(ARM_uxtbX(dst->reg, dst->reg));
+        break;
+      case RT_I8i:
+        AIWNIOS_ADD_CODE(ARM_ldrbRegRegShift(dst->reg, src->reg, src->reg2));
+        AIWNIOS_ADD_CODE(ARM_sxtbX(dst->reg, dst->reg));
+        break;
+      case RT_U16i:
+        AIWNIOS_ADD_CODE(ARM_ldrhRegRegShift(dst->reg, src->reg, src->reg2));
+        AIWNIOS_ADD_CODE(ARM_uxthX(dst->reg, dst->reg));
+        break;
+      case RT_I16i:
+        AIWNIOS_ADD_CODE(ARM_ldrhRegRegShift(dst->reg, src->reg, src->reg2));
+        AIWNIOS_ADD_CODE(ARM_sxthX(dst->reg, dst->reg));
+        break;
+      case RT_U32i:
+        AIWNIOS_ADD_CODE(ARM_ldrRegRegShift(dst->reg, src->reg, src->reg2));
+        AIWNIOS_ADD_CODE(ARM_uxtwX(dst->reg, dst->reg));
+        break;
+      case RT_I32i:
+        AIWNIOS_ADD_CODE(ARM_ldrRegRegShift(dst->reg, src->reg, src->reg2));
+        AIWNIOS_ADD_CODE(ARM_sxtwX(dst->reg, dst->reg));
+        break;
+      case RT_U64i:
+      case RT_PTR:
+      case RT_FUNC:
+      case RT_I64i:
+        AIWNIOS_ADD_CODE(ARM_ldrRegRegShiftX(dst->reg, src->reg, src->reg2));
+        break;
+      case RT_F64:
+        AIWNIOS_ADD_CODE(ARM_ldrRegRegShiftF64(dst->reg, src->reg, src->reg2));
+      }
+      return code_off;
+    } else if (src->mode == MD_REG) {
+      if (src->raw_type == RT_F64 && src->raw_type == dst->raw_type) {
+        AIWNIOS_ADD_CODE(ARM_fmovReg(dst->reg, src->reg));
+      } else if (src->raw_type != RT_F64 && dst->raw_type != RT_F64) {
+        AIWNIOS_ADD_CODE(ARM_movRegX(dst->reg, src->reg));
+      } else if (src->raw_type == RT_F64 && dst->raw_type != RT_F64) {
+        AIWNIOS_ADD_CODE(ARM_fcvtzs(dst->reg, src->reg));
+      } else if (src->raw_type != RT_F64 && dst->raw_type == RT_F64) {
+        switch (src->raw_type) {
+        case RT_U8i:
+        case RT_U16i:
+        case RT_U32i:
+        case RT_U64i:
+          AIWNIOS_ADD_CODE(ARM_ucvtf(dst->reg, src->reg));
+          break;
+        default:
+          AIWNIOS_ADD_CODE(ARM_scvtf(dst->reg, src->reg));
+        }
+        return code_off;
+      }
+    } else if (src->mode == MD_PTR) {
+      if (src->raw_type == RT_F64 && src->raw_type == dst->raw_type) {
+        use_reg2 = 0;
+        code_off = __ICMoveI64(cctrl, use_reg2, src->off, bin, code_off);
+        goto load_r2;
+      } else if ((src->raw_type == RT_F64) ^ (RT_F64 == dst->raw_type)) {
+        goto dft;
+      }
+      // We can use ARM_ldrLabel/ARM_ldrLabelX for 64/32bit shenangins if it is
+      // in range
+      if (cctrl->code_ctrl->final_pass)
+        switch (src->raw_type) {
+          break;
+        case RT_I32i:
+          opc = ARM_ldrLabel(use_reg, (char *)src->off - (code_off + bin));
+          if (opc != ARM_ERR_INV_OFF) {
+            AIWNIOS_ADD_CODE(opc);
+            AIWNIOS_ADD_CODE(ARM_sxtwX(use_reg, use_reg));
+            return code_off;
+          }
+          break;
+        case RT_U32i:
+          opc = ARM_ldrLabel(use_reg, (char *)src->off - (code_off + bin));
+          if (opc != ARM_ERR_INV_OFF) {
+            AIWNIOS_ADD_CODE(opc);
+            AIWNIOS_ADD_CODE(ARM_uxtwX(use_reg, use_reg));
+            return code_off;
+          }
+          break;
+        case RT_I64i:
+        case RT_U64i:
+          opc = ARM_ldrLabelX(use_reg, (char *)src->off - (code_off + bin));
+          if (opc != ARM_ERR_INV_OFF) {
+            AIWNIOS_ADD_CODE(opc);
+            return code_off;
+          }
+          break;
+        case RT_F64:
+          opc = ARM_ldrLabelF64(use_reg, (char *)src->off - (code_off + bin));
+          if (opc != ARM_ERR_INV_OFF) {
+            AIWNIOS_ADD_CODE(opc);
+            return code_off;
+          }
+        }
 
-			use_reg2 = AIWNIOS_TMP_IREG_POOP;
-			code_off = __ICMoveI64(cctrl, use_reg2, src->off, bin, code_off);
-			indir_off = 0;
-		load_r2:
-			if (indir_off < 0) {
-				indir_off2 = indir_off;
-				indir_off = 0;
-				AIWNIOS_ADD_CODE(ARM_subImmX(use_reg2, use_reg2, -indir_off2));
-			}
-			switch (src->raw_type) {
-			case RT_U0:
-				break;
-			case RT_F64:
-				opc = ARM_ldrRegImmF64(use_reg, use_reg2, indir_off);
-				if (opc != ARM_ERR_INV_OFF) {
-					AIWNIOS_ADD_CODE(opc);
-				} else {
-					// 5 is one of our poop registers
-					code_off = __ICMoveI64(cctrl, AIWNIOS_TMP_IREG_POOP, indir_off, bin, code_off);
-					AIWNIOS_ADD_CODE(ARM_ldrRegRegF64(use_reg, use_reg2, AIWNIOS_TMP_IREG_POOP));
-				}
-				break;
-			case RT_U8i:
-				opc = ARM_ldrbRegImm(use_reg, use_reg2, indir_off);
-				if (opc != ARM_ERR_INV_OFF) {
-					AIWNIOS_ADD_CODE(opc);
-				} else {
-					// 5 is one of our poop registers
-					code_off = __ICMoveI64(cctrl, AIWNIOS_TMP_IREG_POOP, indir_off, bin, code_off);
-					AIWNIOS_ADD_CODE(ARM_ldrbRegReg(use_reg, use_reg2, AIWNIOS_TMP_IREG_POOP));
-				}
-				AIWNIOS_ADD_CODE(ARM_uxtbX(use_reg, use_reg));
-				break;
-			case RT_I8i:
-				opc = ARM_ldrbRegImm(use_reg, use_reg2, indir_off);
-				if (opc != ARM_ERR_INV_OFF) {
-					AIWNIOS_ADD_CODE(opc);
-				} else {
-					// 5 is one of our poop registers
-					code_off = __ICMoveI64(cctrl, AIWNIOS_TMP_IREG_POOP, indir_off, bin, code_off);
-					AIWNIOS_ADD_CODE(ARM_ldrbRegReg(use_reg, use_reg2, AIWNIOS_TMP_IREG_POOP));
-				}
-				AIWNIOS_ADD_CODE(ARM_sxtbX(use_reg, use_reg));
-				break;
-			case RT_U16i:
-				opc = ARM_ldrhRegImm(use_reg, use_reg2, indir_off);
-				if (opc != ARM_ERR_INV_OFF) {
-					AIWNIOS_ADD_CODE(opc);
-				} else {
-					// 5 is one of our poop registers
-					code_off = __ICMoveI64(cctrl, AIWNIOS_TMP_IREG_POOP, indir_off, bin, code_off);
-					AIWNIOS_ADD_CODE(ARM_ldrhRegReg(use_reg, use_reg2, AIWNIOS_TMP_IREG_POOP));
-				}
-				AIWNIOS_ADD_CODE(ARM_uxthX(use_reg, use_reg));
-				break;
-			case RT_I16i:
-				opc = ARM_ldrhRegImm(use_reg, use_reg2, indir_off);
-				if (opc != ARM_ERR_INV_OFF) {
-					AIWNIOS_ADD_CODE(opc);
-				} else {
-					// 5 is one of our poop registers
-					code_off = __ICMoveI64(cctrl, AIWNIOS_TMP_IREG_POOP, indir_off, bin, code_off);
-					AIWNIOS_ADD_CODE(ARM_ldrhRegReg(use_reg, use_reg2, AIWNIOS_TMP_IREG_POOP));
-				}
-				AIWNIOS_ADD_CODE(ARM_sxthX(use_reg, use_reg));
-				break;
-			case RT_U32i:
-				opc = ARM_ldrRegImm(use_reg, use_reg2, indir_off);
-				if (opc != ARM_ERR_INV_OFF) {
-					AIWNIOS_ADD_CODE(opc);
-				} else {
-					// 5 is one of our poop registers
-					code_off = __ICMoveI64(cctrl, AIWNIOS_TMP_IREG_POOP, indir_off, bin, code_off);
-					AIWNIOS_ADD_CODE(ARM_ldrRegReg(use_reg, use_reg2, AIWNIOS_TMP_IREG_POOP));
-				}
-				AIWNIOS_ADD_CODE(ARM_uxtwX(use_reg, use_reg));
-				break;
-			case RT_I32i:
-				opc = ARM_ldrRegImm(use_reg, use_reg2, indir_off);
-				if (opc != ARM_ERR_INV_OFF) {
-					AIWNIOS_ADD_CODE(opc);
-				} else {
-					// 5 is one of our poop registers
-					code_off = __ICMoveI64(cctrl, AIWNIOS_TMP_IREG_POOP, indir_off, bin, code_off);
-					AIWNIOS_ADD_CODE(ARM_ldrRegReg(use_reg, use_reg2, AIWNIOS_TMP_IREG_POOP));
-				}
-				AIWNIOS_ADD_CODE(ARM_sxtwX(use_reg, use_reg));
-				break;
-			case RT_U64i:
-			case RT_I64i:
-			case RT_FUNC: // func ptr
-			case RT_PTR:
-				opc = ARM_ldrRegImmX(use_reg, use_reg2, indir_off);
-				if (opc != ARM_ERR_INV_OFF) {
-					AIWNIOS_ADD_CODE(opc);
-				} else {
-					// 5 is one of our poop registers
-					code_off = __ICMoveI64(cctrl, AIWNIOS_TMP_IREG_POOP, indir_off, bin, code_off);
-					AIWNIOS_ADD_CODE(ARM_ldrRegRegX(use_reg, use_reg2, AIWNIOS_TMP_IREG_POOP));
-				}
+      use_reg2 = AIWNIOS_TMP_IREG_POOP;
+      code_off = __ICMoveI64(cctrl, use_reg2, src->off, bin, code_off);
+      indir_off = 0;
+    load_r2:
+      if (indir_off < 0) {
+        indir_off2 = indir_off;
+        indir_off = 0;
+        AIWNIOS_ADD_CODE(ARM_subImmX(use_reg2, use_reg2, -indir_off2));
+      }
+      switch (src->raw_type) {
+      case RT_U0:
+        break;
+      case RT_F64:
+        opc = ARM_ldrRegImmF64(use_reg, use_reg2, indir_off);
+        if (opc != ARM_ERR_INV_OFF) {
+          AIWNIOS_ADD_CODE(opc);
+        } else {
+          // 5 is one of our poop registers
+          code_off = __ICMoveI64(cctrl, AIWNIOS_TMP_IREG_POOP, indir_off, bin,
+                                 code_off);
+          AIWNIOS_ADD_CODE(
+              ARM_ldrRegRegF64(use_reg, use_reg2, AIWNIOS_TMP_IREG_POOP));
+        }
+        break;
+      case RT_U8i:
+        opc = ARM_ldrbRegImm(use_reg, use_reg2, indir_off);
+        if (opc != ARM_ERR_INV_OFF) {
+          AIWNIOS_ADD_CODE(opc);
+        } else {
+          // 5 is one of our poop registers
+          code_off = __ICMoveI64(cctrl, AIWNIOS_TMP_IREG_POOP, indir_off, bin,
+                                 code_off);
+          AIWNIOS_ADD_CODE(
+              ARM_ldrbRegReg(use_reg, use_reg2, AIWNIOS_TMP_IREG_POOP));
+        }
+        AIWNIOS_ADD_CODE(ARM_uxtbX(use_reg, use_reg));
+        break;
+      case RT_I8i:
+        opc = ARM_ldrbRegImm(use_reg, use_reg2, indir_off);
+        if (opc != ARM_ERR_INV_OFF) {
+          AIWNIOS_ADD_CODE(opc);
+        } else {
+          // 5 is one of our poop registers
+          code_off = __ICMoveI64(cctrl, AIWNIOS_TMP_IREG_POOP, indir_off, bin,
+                                 code_off);
+          AIWNIOS_ADD_CODE(
+              ARM_ldrbRegReg(use_reg, use_reg2, AIWNIOS_TMP_IREG_POOP));
+        }
+        AIWNIOS_ADD_CODE(ARM_sxtbX(use_reg, use_reg));
+        break;
+      case RT_U16i:
+        opc = ARM_ldrhRegImm(use_reg, use_reg2, indir_off);
+        if (opc != ARM_ERR_INV_OFF) {
+          AIWNIOS_ADD_CODE(opc);
+        } else {
+          // 5 is one of our poop registers
+          code_off = __ICMoveI64(cctrl, AIWNIOS_TMP_IREG_POOP, indir_off, bin,
+                                 code_off);
+          AIWNIOS_ADD_CODE(
+              ARM_ldrhRegReg(use_reg, use_reg2, AIWNIOS_TMP_IREG_POOP));
+        }
+        AIWNIOS_ADD_CODE(ARM_uxthX(use_reg, use_reg));
+        break;
+      case RT_I16i:
+        opc = ARM_ldrhRegImm(use_reg, use_reg2, indir_off);
+        if (opc != ARM_ERR_INV_OFF) {
+          AIWNIOS_ADD_CODE(opc);
+        } else {
+          // 5 is one of our poop registers
+          code_off = __ICMoveI64(cctrl, AIWNIOS_TMP_IREG_POOP, indir_off, bin,
+                                 code_off);
+          AIWNIOS_ADD_CODE(
+              ARM_ldrhRegReg(use_reg, use_reg2, AIWNIOS_TMP_IREG_POOP));
+        }
+        AIWNIOS_ADD_CODE(ARM_sxthX(use_reg, use_reg));
+        break;
+      case RT_U32i:
+        opc = ARM_ldrRegImm(use_reg, use_reg2, indir_off);
+        if (opc != ARM_ERR_INV_OFF) {
+          AIWNIOS_ADD_CODE(opc);
+        } else {
+          // 5 is one of our poop registers
+          code_off = __ICMoveI64(cctrl, AIWNIOS_TMP_IREG_POOP, indir_off, bin,
+                                 code_off);
+          AIWNIOS_ADD_CODE(
+              ARM_ldrRegReg(use_reg, use_reg2, AIWNIOS_TMP_IREG_POOP));
+        }
+        AIWNIOS_ADD_CODE(ARM_uxtwX(use_reg, use_reg));
+        break;
+      case RT_I32i:
+        opc = ARM_ldrRegImm(use_reg, use_reg2, indir_off);
+        if (opc != ARM_ERR_INV_OFF) {
+          AIWNIOS_ADD_CODE(opc);
+        } else {
+          // 5 is one of our poop registers
+          code_off = __ICMoveI64(cctrl, AIWNIOS_TMP_IREG_POOP, indir_off, bin,
+                                 code_off);
+          AIWNIOS_ADD_CODE(
+              ARM_ldrRegReg(use_reg, use_reg2, AIWNIOS_TMP_IREG_POOP));
+        }
+        AIWNIOS_ADD_CODE(ARM_sxtwX(use_reg, use_reg));
+        break;
+      case RT_U64i:
+      case RT_I64i:
+      case RT_FUNC: // func ptr
+      case RT_PTR:
+        opc = ARM_ldrRegImmX(use_reg, use_reg2, indir_off);
+        if (opc != ARM_ERR_INV_OFF) {
+          AIWNIOS_ADD_CODE(opc);
+        } else {
+          // 5 is one of our poop registers
+          code_off = __ICMoveI64(cctrl, AIWNIOS_TMP_IREG_POOP, indir_off, bin,
+                                 code_off);
+          AIWNIOS_ADD_CODE(
+              ARM_ldrRegRegX(use_reg, use_reg2, AIWNIOS_TMP_IREG_POOP));
+        }
 
-				break;
-			default:
-				abort();
-			}
-			if (indir_off2 < 0) {
-				AIWNIOS_ADD_CODE(ARM_addImmX(use_reg2, use_reg2, -indir_off2));
-			} else if (indir_off2 > 0) {
-				AIWNIOS_ADD_CODE(ARM_subImmX(use_reg2, use_reg2, indir_off2));
-			}
-		} else if (src->mode == MD_INDIR_REG) {
-			use_reg2 = src->reg;
-			indir_off = src->off;
-			if (src->raw_type == RT_F64 && src->raw_type == dst->raw_type) {
-				use_reg2 = src->reg;
-			} else if ((src->raw_type == RT_F64) ^ (RT_F64 == dst->raw_type)) {
-				goto dft;
-			}
-			goto load_r2;
-		} else if (src->mode == MD_I64 && dst->raw_type != RT_F64) {
-			code_off = __ICMoveI64(cctrl, dst->reg, src->integer, bin, code_off);
-		} else if (src->mode == MD_F64 && dst->raw_type == RT_F64) {
-			code_off = __ICMoveF64(cctrl, dst->reg, src->flt, bin, code_off);
-		} else if (src->mode == MD_I64 && dst->raw_type == RT_F64) {
-			code_off = __ICMoveF64(cctrl, dst->reg, src->integer, bin, code_off);
-		} else if (src->mode == MD_F64 && dst->raw_type != RT_F64) {
-			code_off = __ICMoveI64(cctrl, dst->reg, src->flt, bin, code_off);
-		} else if (src->mode == MD_STATIC) {
-			use_reg2 = AIWNIOS_TMP_IREG_POOP;
-			indir_off = 0;
-			if (cctrl->code_ctrl->final_pass) {
-				AIWNIOS_ADD_CODE(ARM_adrX(use_reg2, 0));
-				ref = CodeMiscAddRef(cctrl->statics_label, bin + code_off - 4);
-        ref->patch_cond_br=ARM_adrX;
-        ref->user_data1=use_reg2;
-				ref->offset = src->off;
-			} else
-				AIWNIOS_ADD_CODE(0);
-			if (src->raw_type == RT_F64 && src->raw_type == dst->raw_type) {
-			} else if ((src->raw_type == RT_F64) ^ (RT_F64 == dst->raw_type)) {
-				goto dft;
-			}
-			goto load_r2;
-		} else
-			goto dft;
-		break;
-	default:
-		abort();
-	}
-	return code_off;
+        break;
+      default:
+        abort();
+      }
+      if (indir_off2 < 0) {
+        AIWNIOS_ADD_CODE(ARM_addImmX(use_reg2, use_reg2, -indir_off2));
+      } else if (indir_off2 > 0) {
+        AIWNIOS_ADD_CODE(ARM_subImmX(use_reg2, use_reg2, indir_off2));
+      }
+    } else if (src->mode == MD_INDIR_REG) {
+      use_reg2 = src->reg;
+      indir_off = src->off;
+      if (src->raw_type == RT_F64 && src->raw_type == dst->raw_type) {
+        use_reg2 = src->reg;
+      } else if ((src->raw_type == RT_F64) ^ (RT_F64 == dst->raw_type)) {
+        goto dft;
+      }
+      goto load_r2;
+    } else if (src->mode == MD_I64 && dst->raw_type != RT_F64) {
+      code_off = __ICMoveI64(cctrl, dst->reg, src->integer, bin, code_off);
+    } else if (src->mode == MD_F64 && dst->raw_type == RT_F64) {
+      code_off = __ICMoveF64(cctrl, dst->reg, src->flt, bin, code_off);
+    } else if (src->mode == MD_I64 && dst->raw_type == RT_F64) {
+      code_off = __ICMoveF64(cctrl, dst->reg, src->integer, bin, code_off);
+    } else if (src->mode == MD_F64 && dst->raw_type != RT_F64) {
+      code_off = __ICMoveI64(cctrl, dst->reg, src->flt, bin, code_off);
+    } else if (src->mode == MD_STATIC) {
+      use_reg2 = AIWNIOS_TMP_IREG_POOP;
+      indir_off = 0;
+      if (cctrl->code_ctrl->final_pass) {
+        AIWNIOS_ADD_CODE(ARM_adrX(use_reg2, 0));
+        ref = CodeMiscAddRef(cctrl->statics_label, bin + code_off - 4);
+        ref->patch_cond_br = ARM_adrX;
+        ref->user_data1 = use_reg2;
+        ref->offset = src->off;
+      } else
+        AIWNIOS_ADD_CODE(0);
+      if (src->raw_type == RT_F64 && src->raw_type == dst->raw_type) {
+      } else if ((src->raw_type == RT_F64) ^ (RT_F64 == dst->raw_type)) {
+        goto dft;
+      }
+      goto load_r2;
+    } else
+      goto dft;
+    break;
+  default:
+    abort();
+  }
+  return code_off;
 }
 
 //
 // If we call a function the tmp regs go to poo poo land
 //
-static int64_t SpillsTmpRegs(CRPN* rpn)
-{
-	int64_t idx;
-	switch (rpn->type) {
-		break;
-	case __IC_CALL:
-	case IC_CALL:
-		return 1;
-		break;
-	case __IC_VARGS:
-		for (idx = 0; idx != rpn->length; idx++)
-			if (SpillsTmpRegs(ICArgN(rpn, idx)))
-				return 1;
-		return 0;
-	case IC_TO_F64:
-	case IC_TO_I64:
-	case IC_NEG:
-	unop:
-		return SpillsTmpRegs(rpn->base.next);
-		break;
-	case IC_POS:
-		goto unop;
-		break;
-	case IC_POW:
-		return 1; // calls pow
-	binop:
-		if (SpillsTmpRegs(rpn->base.next))
-			return 1;
-		if (SpillsTmpRegs(ICFwd(rpn->base.next)))
-			return 1;
-		break;
-	case IC_ADD:
-		goto binop;
-		break;
-	case IC_EQ:
-		goto binop;
-		break;
-	case IC_SUB:
-		goto binop;
-		break;
-	case IC_DIV:
-		goto binop;
-		break;
-	case IC_MUL:
-		goto binop;
-		break;
-	case IC_DEREF:
-		goto unop;
-		break;
-	case IC_AND:
-		goto binop;
-		break;
-	case IC_ADDR_OF:
-		goto unop;
-		break;
-	case IC_XOR:
-		goto binop;
-		break;
-	case IC_MOD:
-		goto binop;
-		break;
-	case IC_OR:
-		goto binop;
-		break;
-	case IC_LT:
-		goto binop;
-		break;
-	case IC_GT:
-		goto binop;
-		break;
-	case IC_LNOT:
-		goto unop;
-		break;
-	case IC_BNOT:
-		goto unop;
-		break;
-	case IC_POST_INC:
-		goto binop;
-		break;
-	case IC_POST_DEC:
-		goto binop;
-		break;
-	case IC_PRE_INC:
-		goto binop;
-		break;
-	case IC_PRE_DEC:
-		goto binop;
-		break;
-	case IC_AND_AND:
-		goto binop;
-		break;
-	case IC_OR_OR:
-		goto binop;
-		break;
-	case IC_XOR_XOR:
-		goto binop;
-		break;
-	case IC_EQ_EQ:
-		goto binop;
-		break;
-	case IC_NE:
-		goto binop;
-		break;
-	case IC_LE:
-		goto binop;
-		break;
-	case IC_GE:
-		goto binop;
-		break;
-	case IC_LSH:
-		goto binop;
-		break;
-	case IC_RSH:
-		goto binop;
-		break;
-	case IC_ADD_EQ:
-		goto binop;
-		break;
-	case IC_SUB_EQ:
-		goto binop;
-		break;
-	case IC_MUL_EQ:
-		goto binop;
-		break;
-	case IC_DIV_EQ:
-		goto binop;
-		break;
-	case IC_LSH_EQ:
-		goto binop;
-		break;
-	case IC_RSH_EQ:
-		goto binop;
-		break;
-	case IC_AND_EQ:
-		goto binop;
-		break;
-	case IC_OR_EQ:
-		goto binop;
-		break;
-	case IC_XOR_EQ:
-		goto binop;
-		break;
-	case IC_MOD_EQ:
-		goto binop;
-		break;
-	case IC_STORE:
-		goto binop;
-	case IC_TYPECAST:
-		goto unop;
-	}
-	return 0;
+static int64_t SpillsTmpRegs(CRPN *rpn) {
+  int64_t idx;
+  switch (rpn->type) {
+    break;
+  case __IC_CALL:
+  case IC_CALL:
+    return 1;
+    break;
+  case __IC_VARGS:
+    for (idx = 0; idx != rpn->length; idx++)
+      if (SpillsTmpRegs(ICArgN(rpn, idx)))
+        return 1;
+    return 0;
+  case IC_TO_F64:
+  case IC_TO_I64:
+  case IC_NEG:
+  unop:
+    return SpillsTmpRegs(rpn->base.next);
+    break;
+  case IC_POS:
+    goto unop;
+    break;
+  case IC_POW:
+    return 1; // calls pow
+  binop:
+    if (SpillsTmpRegs(rpn->base.next))
+      return 1;
+    if (SpillsTmpRegs(ICFwd(rpn->base.next)))
+      return 1;
+    break;
+  case IC_ADD:
+    goto binop;
+    break;
+  case IC_EQ:
+    goto binop;
+    break;
+  case IC_SUB:
+    goto binop;
+    break;
+  case IC_DIV:
+    goto binop;
+    break;
+  case IC_MUL:
+    goto binop;
+    break;
+  case IC_DEREF:
+    goto unop;
+    break;
+  case IC_AND:
+    goto binop;
+    break;
+  case IC_ADDR_OF:
+    goto unop;
+    break;
+  case IC_XOR:
+    goto binop;
+    break;
+  case IC_MOD:
+    goto binop;
+    break;
+  case IC_OR:
+    goto binop;
+    break;
+  case IC_LT:
+    goto binop;
+    break;
+  case IC_GT:
+    goto binop;
+    break;
+  case IC_LNOT:
+    goto unop;
+    break;
+  case IC_BNOT:
+    goto unop;
+    break;
+  case IC_POST_INC:
+    goto binop;
+    break;
+  case IC_POST_DEC:
+    goto binop;
+    break;
+  case IC_PRE_INC:
+    goto binop;
+    break;
+  case IC_PRE_DEC:
+    goto binop;
+    break;
+  case IC_AND_AND:
+    goto binop;
+    break;
+  case IC_OR_OR:
+    goto binop;
+    break;
+  case IC_XOR_XOR:
+    goto binop;
+    break;
+  case IC_EQ_EQ:
+    goto binop;
+    break;
+  case IC_NE:
+    goto binop;
+    break;
+  case IC_LE:
+    goto binop;
+    break;
+  case IC_GE:
+    goto binop;
+    break;
+  case IC_LSH:
+    goto binop;
+    break;
+  case IC_RSH:
+    goto binop;
+    break;
+  case IC_ADD_EQ:
+    goto binop;
+    break;
+  case IC_SUB_EQ:
+    goto binop;
+    break;
+  case IC_MUL_EQ:
+    goto binop;
+    break;
+  case IC_DIV_EQ:
+    goto binop;
+    break;
+  case IC_LSH_EQ:
+    goto binop;
+    break;
+  case IC_RSH_EQ:
+    goto binop;
+    break;
+  case IC_AND_EQ:
+    goto binop;
+    break;
+  case IC_OR_EQ:
+    goto binop;
+    break;
+  case IC_XOR_EQ:
+    goto binop;
+    break;
+  case IC_MOD_EQ:
+    goto binop;
+    break;
+  case IC_STORE:
+    goto binop;
+  case IC_TYPECAST:
+    goto unop;
+  }
+  return 0;
 t:
-	return 1;
+  return 1;
 }
 
 //
@@ -1569,525 +1590,537 @@ t:
 // We we need silly sauce to check if we are writing int an typecasted l-value.
 // If so,time to rock
 //
-static int64_t __SexyWriteIntoDst(CCmpCtrl* cctrl, CRPN* deref, CICArg* arg,
-	char* bin, int64_t code_off)
-{
-	CICArg derefed = { 0 }, tmp = { 0 };
-	int64_t tc = 0;
-	CRPN* orig_rpn = deref;
-	code_off = DerefToICArg(cctrl, &derefed, deref, 2, bin, code_off);
-	if (!tc) {
-	dft:
-		code_off = ICMov(cctrl, &derefed, arg, bin, code_off);
-	} else {
-		if (derefed.mode == MD_REG) {
-			if (orig_rpn->raw_type == RT_F64 && arg->raw_type != RT_F64) {
-				code_off = PutICArgIntoReg(cctrl, arg, arg->raw_type, 0, bin, code_off);
-				AIWNIOS_ADD_CODE(ARM_fmovF64I64(derefed.reg, arg->reg));
-			} else if (orig_rpn->raw_type != RT_F64 && arg->raw_type == RT_F64) {
-				code_off = PutICArgIntoReg(cctrl, arg, arg->raw_type, 0, bin, code_off);
-				AIWNIOS_ADD_CODE(ARM_fmovI64F64(derefed.reg, arg->reg));
-			} else {
-				goto dft;
-			}
-		} else {
-			tmp.reg = 1;
-			tmp.mode = MD_REG;
-			tmp.raw_type = orig_rpn->raw_type;
-			if (orig_rpn->raw_type == RT_F64 && arg->raw_type != RT_F64) {
-				code_off = PutICArgIntoReg(cctrl, arg, arg->raw_type, 0, bin, code_off);
-				AIWNIOS_ADD_CODE(ARM_fmovF64I64(1, arg->reg));
-			} else if (orig_rpn->raw_type != RT_F64 && arg->raw_type == RT_F64) {
-				code_off = PutICArgIntoReg(cctrl, arg, arg->raw_type, 0, bin, code_off);
-				AIWNIOS_ADD_CODE(ARM_fmovI64F64(1, arg->reg));
-			} else {
-				goto dft;
-			}
-			arg = &tmp;
-			goto dft;
-		}
-	}
-	return code_off;
+static int64_t __SexyWriteIntoDst(CCmpCtrl *cctrl, CRPN *deref, CICArg *arg,
+                                  char *bin, int64_t code_off) {
+  CICArg derefed = {0}, tmp = {0};
+  int64_t tc = 0;
+  CRPN *orig_rpn = deref;
+  code_off = DerefToICArg(cctrl, &derefed, deref, 2, bin, code_off);
+  if (!tc) {
+  dft:
+    code_off = ICMov(cctrl, &derefed, arg, bin, code_off);
+  } else {
+    if (derefed.mode == MD_REG) {
+      if (orig_rpn->raw_type == RT_F64 && arg->raw_type != RT_F64) {
+        code_off = PutICArgIntoReg(cctrl, arg, arg->raw_type, 0, bin, code_off);
+        AIWNIOS_ADD_CODE(ARM_fmovF64I64(derefed.reg, arg->reg));
+      } else if (orig_rpn->raw_type != RT_F64 && arg->raw_type == RT_F64) {
+        code_off = PutICArgIntoReg(cctrl, arg, arg->raw_type, 0, bin, code_off);
+        AIWNIOS_ADD_CODE(ARM_fmovI64F64(derefed.reg, arg->reg));
+      } else {
+        goto dft;
+      }
+    } else {
+      tmp.reg = 1;
+      tmp.mode = MD_REG;
+      tmp.raw_type = orig_rpn->raw_type;
+      if (orig_rpn->raw_type == RT_F64 && arg->raw_type != RT_F64) {
+        code_off = PutICArgIntoReg(cctrl, arg, arg->raw_type, 0, bin, code_off);
+        AIWNIOS_ADD_CODE(ARM_fmovF64I64(1, arg->reg));
+      } else if (orig_rpn->raw_type != RT_F64 && arg->raw_type == RT_F64) {
+        code_off = PutICArgIntoReg(cctrl, arg, arg->raw_type, 0, bin, code_off);
+        AIWNIOS_ADD_CODE(ARM_fmovI64F64(1, arg->reg));
+      } else {
+        goto dft;
+      }
+      arg = &tmp;
+      goto dft;
+    }
+  }
+  return code_off;
 }
 
-static int64_t __SexyPreOp(CCmpCtrl* cctrl, CRPN* rpn,
-	int64_t (*i_imm_op)(int64_t, int64_t, int64_t),
-	int64_t (*i_reg_op)(int64_t, int64_t, int64_t),
-	int32_t (*f_op)(int64_t, int64_t, int64_t),
-	char* bin, int64_t code_off)
-{
-	int64_t code;
-	CRPN *next = rpn->base.next, *tc;
-	CICArg derefed = { 0 }, tmp = { 0 }, tmp2 = { 0 };
-	if (next->type == IC_TYPECAST) {
-#define TYPECAST_ASSIGN_BEGIN(DST, SRC)                                                    \
-	{                                                                                      \
-		int64_t pop = 0, pop2 = 0;                                                         \
-		CICArg _orig = { 0 };                                                              \
-		CRPN* _tc = DST;                                                                   \
-		CRPN* SRC2 = SRC;                                                                  \
-		DST = DST->base.next;                                                              \
-		if (DST->type == IC_DEREF) {                                                       \
-			code_off = DerefToICArg(cctrl, &_orig, DST, 1, bin, code_off);                 \
-			DST->res = _orig;                                                              \
-			DST->raw_type = _tc->raw_type;                                                 \
-		} else if ((DST->raw_type == RT_F64) ^ (SRC2->raw_type == RT_F64)) {               \
-			pop = pop2 = 1;                                                                \
-			PushTmp(cctrl, DST, NULL);                                                     \
-			_orig = DST->res;                                                              \
-			code_off = PutICArgIntoReg(cctrl, &DST->res, DST->raw_type, 0, bin, code_off); \
-      code_off = PushToStack(cctrl, &DST->res, bin, code_off);                       \
-      DST->res.mode = MD_INDIR_REG;                                                  \
-      DST->res.off = 0;                                                              \
-      DST->res.reg = ARM_REG_SP;                                                     \
-      DST->res.raw_type = _tc->raw_type;                                             \
-			DST->raw_type = _tc->raw_type;                                                 \
-		} else {                                                                           \
-			PushTmp(cctrl, DST, NULL);                                                     \
-			pop2 = 1;                                                                      \
-			DST->res.raw_type = _tc->raw_type;                                             \
-			DST->raw_type = _tc->raw_type;                                                 \
-		}
-#define TYPECAST_ASSIGN_END(DST)                               \
-	if (pop)                                                   \
-		code_off = PopFromStack(cctrl, &_orig, bin, code_off); \
-	if (pop2)                                                  \
-		PopTmp(cctrl, DST);                                    \
-	}
-		TYPECAST_ASSIGN_BEGIN(next, next);
-		if (next->raw_type == RT_F64) {
-			CICArg orig = next->res;
-			code_off = PutICArgIntoReg(cctrl, &next->res, next->raw_type, 2, bin, code_off);
-			code_off = __ICMoveF64(cctrl, 1, rpn->integer, bin, code_off);
-			AIWNIOS_ADD_CODE(f_op(next->res.reg, next->res.reg, 1));
-			code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
-			code_off = ICMov(cctrl, &orig, &next->res, bin, code_off);
-		} else {
-			CICArg orig = next->res;
-			code_off = PutICArgIntoReg(cctrl, &next->res, next->raw_type, 1, bin, code_off);
-			code = i_imm_op(next->res.reg, next->res.reg, rpn->integer);
-			if (code != ARM_ERR_INV_OFF) {
-				AIWNIOS_ADD_CODE(code);
-			} else {
-				code_off = __ICMoveI64(cctrl, 2, rpn->integer, bin, code_off);
-				AIWNIOS_ADD_CODE(i_reg_op(next->res.reg, next->res.reg, 2))
-			}
-			code_off = ICMov(cctrl, &orig, &next->res, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
-		}
-		TYPECAST_ASSIGN_END(next);
-	} else {
-		if (next->raw_type == RT_F64) {
-			code_off = DerefToICArg(cctrl, &derefed, next, 3, bin, code_off);
-			tmp = derefed; //==RT_F64
-			code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, 2, bin, code_off);
-			code_off = __ICMoveF64(cctrl, 1, rpn->integer, bin, code_off);
-			AIWNIOS_ADD_CODE(f_op(tmp.reg, tmp.reg, 1));
-			code_off = ICMov(cctrl, &derefed, &tmp, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		} else {
-			code_off = DerefToICArg(cctrl, &derefed, next, 3, bin, code_off);
-			tmp = derefed;
-			code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, 2, bin, code_off);
-			code = i_imm_op(tmp.reg, tmp.reg, rpn->integer);
-			if (code != ARM_ERR_INV_OFF) {
-				AIWNIOS_ADD_CODE(code);
-			} else {
-				code_off = __ICMoveI64(cctrl, 1, rpn->integer, bin, code_off);
-				AIWNIOS_ADD_CODE(i_reg_op(tmp.reg, tmp.reg, 1))
-			}
-			code_off = ICMov(cctrl, &derefed, &tmp, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		}
-	}
-	return code_off;
+static int64_t __SexyPreOp(CCmpCtrl *cctrl, CRPN *rpn,
+                           int64_t (*i_imm_op)(int64_t, int64_t, int64_t),
+                           int64_t (*i_reg_op)(int64_t, int64_t, int64_t),
+                           int32_t (*f_op)(int64_t, int64_t, int64_t),
+                           char *bin, int64_t code_off) {
+  int64_t code;
+  CRPN *next = rpn->base.next, *tc;
+  CICArg derefed = {0}, tmp = {0}, tmp2 = {0};
+  if (next->type == IC_TYPECAST) {
+#define TYPECAST_ASSIGN_BEGIN(DST, SRC)                                        \
+  {                                                                            \
+    int64_t pop = 0, pop2 = 0;                                                 \
+    CICArg _orig = {0};                                                        \
+    CRPN *_tc = DST;                                                           \
+    CRPN *SRC2 = SRC;                                                          \
+    DST = DST->base.next;                                                      \
+    if (DST->type == IC_DEREF) {                                               \
+      code_off = DerefToICArg(cctrl, &_orig, DST, 1, bin, code_off);           \
+      DST->res = _orig;                                                        \
+      DST->raw_type = _tc->raw_type;                                           \
+    } else if ((DST->raw_type == RT_F64) ^ (SRC2->raw_type == RT_F64)) {       \
+      pop = pop2 = 1;                                                          \
+      PushTmp(cctrl, DST, NULL);                                               \
+      _orig = DST->res;                                                        \
+      code_off =                                                               \
+          PutICArgIntoReg(cctrl, &DST->res, DST->raw_type, 0, bin, code_off);  \
+      code_off = PushToStack(cctrl, &DST->res, bin, code_off);                 \
+      DST->res.mode = MD_INDIR_REG;                                            \
+      DST->res.off = 0;                                                        \
+      DST->res.reg = ARM_REG_SP;                                               \
+      DST->res.raw_type = _tc->raw_type;                                       \
+      DST->raw_type = _tc->raw_type;                                           \
+    } else {                                                                   \
+      PushTmp(cctrl, DST, NULL);                                               \
+      pop2 = 1;                                                                \
+      DST->res.raw_type = _tc->raw_type;                                       \
+      DST->raw_type = _tc->raw_type;                                           \
+    }
+#define TYPECAST_ASSIGN_END(DST)                                               \
+  if (pop)                                                                     \
+    code_off = PopFromStack(cctrl, &_orig, bin, code_off);                     \
+  if (pop2)                                                                    \
+    PopTmp(cctrl, DST);                                                        \
+  }
+    TYPECAST_ASSIGN_BEGIN(next, next);
+    if (next->raw_type == RT_F64) {
+      CICArg orig = next->res;
+      code_off =
+          PutICArgIntoReg(cctrl, &next->res, next->raw_type, 2, bin, code_off);
+      code_off = __ICMoveF64(cctrl, 1, rpn->integer, bin, code_off);
+      AIWNIOS_ADD_CODE(f_op(next->res.reg, next->res.reg, 1));
+      code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
+      code_off = ICMov(cctrl, &orig, &next->res, bin, code_off);
+    } else {
+      CICArg orig = next->res;
+      code_off =
+          PutICArgIntoReg(cctrl, &next->res, next->raw_type, 1, bin, code_off);
+      code = i_imm_op(next->res.reg, next->res.reg, rpn->integer);
+      if (code != ARM_ERR_INV_OFF) {
+        AIWNIOS_ADD_CODE(code);
+      } else {
+        code_off = __ICMoveI64(cctrl, 2, rpn->integer, bin, code_off);
+        AIWNIOS_ADD_CODE(i_reg_op(next->res.reg, next->res.reg, 2))
+      }
+      code_off = ICMov(cctrl, &orig, &next->res, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
+    }
+    TYPECAST_ASSIGN_END(next);
+  } else {
+    if (next->raw_type == RT_F64) {
+      code_off = DerefToICArg(cctrl, &derefed, next, 3, bin, code_off);
+      tmp = derefed; //==RT_F64
+      code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, 2, bin, code_off);
+      code_off = __ICMoveF64(cctrl, 1, rpn->integer, bin, code_off);
+      AIWNIOS_ADD_CODE(f_op(tmp.reg, tmp.reg, 1));
+      code_off = ICMov(cctrl, &derefed, &tmp, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    } else {
+      code_off = DerefToICArg(cctrl, &derefed, next, 3, bin, code_off);
+      tmp = derefed;
+      code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, 2, bin, code_off);
+      code = i_imm_op(tmp.reg, tmp.reg, rpn->integer);
+      if (code != ARM_ERR_INV_OFF) {
+        AIWNIOS_ADD_CODE(code);
+      } else {
+        code_off = __ICMoveI64(cctrl, 1, rpn->integer, bin, code_off);
+        AIWNIOS_ADD_CODE(i_reg_op(tmp.reg, tmp.reg, 1))
+      }
+      code_off = ICMov(cctrl, &derefed, &tmp, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    }
+  }
+  return code_off;
 }
 
-static int64_t __SexyPostOp(CCmpCtrl* cctrl, CRPN* rpn,
-	int64_t (*i_imm_op)(int64_t, int64_t, int64_t),
-	int64_t (*i_reg_op)(int64_t, int64_t, int64_t),
-	int64_t (*f_op)(int64_t, int64_t, int64_t),
-	char* bin, int64_t code_off)
-{
-	CRPN *next = rpn->base.next, *tc;
-	int64_t code;
-	CICArg derefed = { 0 }, tmp = { 0 }, tmp2 = { 0 };
-	if (next->type == IC_TYPECAST) {
-		TYPECAST_ASSIGN_BEGIN(next, next);
-		if (next->raw_type == RT_F64) {
-			CICArg orig = next->res;
-			code_off = PutICArgIntoReg(cctrl, &next->res, next->raw_type, 2, bin, code_off);
-			code_off = __ICMoveF64(cctrl, 1, rpn->integer, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
-			AIWNIOS_ADD_CODE(f_op(next->res.reg, next->res.reg, 1));
-			code_off = ICMov(cctrl, &orig, &next->res, bin, code_off);
-		} else {
-			CICArg orig = next->res;
-			code_off = PutICArgIntoReg(cctrl, &next->res, next->raw_type, 1, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
-			code = i_imm_op(next->res.reg, next->res.reg, rpn->integer);
-			if (code != ARM_ERR_INV_OFF) {
-				AIWNIOS_ADD_CODE(code);
-			} else {
-				code_off = __ICMoveI64(cctrl, 2, rpn->integer, bin, code_off);
-				AIWNIOS_ADD_CODE(i_reg_op(next->res.reg, next->res.reg, 2))
-			}
-			code_off = ICMov(cctrl, &orig, &next->res, bin, code_off);
-		}
-		TYPECAST_ASSIGN_END(next);
-	} else {
-		if (next->raw_type == RT_F64) {
-			code_off = DerefToICArg(cctrl, &derefed, next, 3, bin, code_off);
-			tmp = derefed; //==RT_F64
-			code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, 2, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-			code_off = __ICMoveF64(cctrl, 1, rpn->integer, bin, code_off);
-			AIWNIOS_ADD_CODE(f_op(tmp.reg, tmp.reg, 1));
-			code_off = ICMov(cctrl, &derefed, &tmp, bin, code_off);
-		} else {
-			code_off = DerefToICArg(cctrl, &derefed, next, 3, bin, code_off);
-			tmp = derefed;
-			code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, 2, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-			code = i_imm_op(tmp.reg, tmp.reg, rpn->integer);
-			if (code != ARM_ERR_INV_OFF) {
-				AIWNIOS_ADD_CODE(code);
-			} else {
-				code_off = __ICMoveI64(cctrl, 1, rpn->integer, bin, code_off);
-				AIWNIOS_ADD_CODE(i_reg_op(tmp.reg, tmp.reg, 1))
-			}
-			code_off = ICMov(cctrl, &derefed, &tmp, bin, code_off);
-		}
-	}
-	return code_off;
+static int64_t __SexyPostOp(CCmpCtrl *cctrl, CRPN *rpn,
+                            int64_t (*i_imm_op)(int64_t, int64_t, int64_t),
+                            int64_t (*i_reg_op)(int64_t, int64_t, int64_t),
+                            int64_t (*f_op)(int64_t, int64_t, int64_t),
+                            char *bin, int64_t code_off) {
+  CRPN *next = rpn->base.next, *tc;
+  int64_t code;
+  CICArg derefed = {0}, tmp = {0}, tmp2 = {0};
+  if (next->type == IC_TYPECAST) {
+    TYPECAST_ASSIGN_BEGIN(next, next);
+    if (next->raw_type == RT_F64) {
+      CICArg orig = next->res;
+      code_off =
+          PutICArgIntoReg(cctrl, &next->res, next->raw_type, 2, bin, code_off);
+      code_off = __ICMoveF64(cctrl, 1, rpn->integer, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
+      AIWNIOS_ADD_CODE(f_op(next->res.reg, next->res.reg, 1));
+      code_off = ICMov(cctrl, &orig, &next->res, bin, code_off);
+    } else {
+      CICArg orig = next->res;
+      code_off =
+          PutICArgIntoReg(cctrl, &next->res, next->raw_type, 1, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
+      code = i_imm_op(next->res.reg, next->res.reg, rpn->integer);
+      if (code != ARM_ERR_INV_OFF) {
+        AIWNIOS_ADD_CODE(code);
+      } else {
+        code_off = __ICMoveI64(cctrl, 2, rpn->integer, bin, code_off);
+        AIWNIOS_ADD_CODE(i_reg_op(next->res.reg, next->res.reg, 2))
+      }
+      code_off = ICMov(cctrl, &orig, &next->res, bin, code_off);
+    }
+    TYPECAST_ASSIGN_END(next);
+  } else {
+    if (next->raw_type == RT_F64) {
+      code_off = DerefToICArg(cctrl, &derefed, next, 3, bin, code_off);
+      tmp = derefed; //==RT_F64
+      code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, 2, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+      code_off = __ICMoveF64(cctrl, 1, rpn->integer, bin, code_off);
+      AIWNIOS_ADD_CODE(f_op(tmp.reg, tmp.reg, 1));
+      code_off = ICMov(cctrl, &derefed, &tmp, bin, code_off);
+    } else {
+      code_off = DerefToICArg(cctrl, &derefed, next, 3, bin, code_off);
+      tmp = derefed;
+      code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, 2, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+      code = i_imm_op(tmp.reg, tmp.reg, rpn->integer);
+      if (code != ARM_ERR_INV_OFF) {
+        AIWNIOS_ADD_CODE(code);
+      } else {
+        code_off = __ICMoveI64(cctrl, 1, rpn->integer, bin, code_off);
+        AIWNIOS_ADD_CODE(i_reg_op(tmp.reg, tmp.reg, 1))
+      }
+      code_off = ICMov(cctrl, &derefed, &tmp, bin, code_off);
+    }
+  }
+  return code_off;
 }
-static int64_t FBitOp(CCmpCtrl* cctrl, CICArg* res, CICArg* next, CICArg* next2,
-	int32_t (*bit_op)(int64_t, int64_t, int64_t), int shift,
-	char* bin, int64_t code_off)
-{
-	CICArg tmp = { 0 };
-	if (shift) {
-		code_off = PutICArgIntoReg(cctrl, next, RT_F64, 2, bin, code_off);
-		code_off = PutICArgIntoReg(cctrl, next2, RT_I64i, 1, bin, code_off);
-		AIWNIOS_ADD_CODE(ARM_fmovI64F64(2, next->reg));
-		AIWNIOS_ADD_CODE(bit_op(2, 2, 1));
-		if (res->mode == MD_REG) {
-			AIWNIOS_ADD_CODE(ARM_fmovF64I64(res->reg, 2));
-		} else {
-			tmp.mode = MD_REG;
-			tmp.reg = 2;
-			tmp.raw_type = RT_F64;
-			code_off = ICMov(cctrl, res, &tmp, bin, code_off);
-		}
-	} else {
-		code_off = PutICArgIntoReg(cctrl, next, RT_F64, 2, bin, code_off);
-		code_off = PutICArgIntoReg(cctrl, next2, RT_F64, 1, bin, code_off);
-		if (next->raw_type != RT_F64) {
-			AIWNIOS_ADD_CODE(ARM_fmovI64F64(2, next->reg));
-			next->reg = 2;
-			next->raw_type = RT_F64;
-		}
-		if (next2->raw_type != RT_F64) {
-			next2->reg = 1;
-			next2->raw_type = RT_F64;
-			AIWNIOS_ADD_CODE(ARM_fmovI64F64(1, next2->reg));
-		}
-		AIWNIOS_ADD_CODE(bit_op(2, next2->reg, next->reg));
-		if (res->mode == MD_REG) {
-			AIWNIOS_ADD_CODE(ARM_fmovF64I64(res->reg, 2));
-		} else {
-			tmp.mode = MD_REG;
-			tmp.reg = 2;
-			tmp.raw_type = RT_F64;
-			code_off = ICMov(cctrl, res, &tmp, bin, code_off);
-		}
-	}
-	return code_off;
+static int64_t FBitOp(CCmpCtrl *cctrl, CICArg *res, CICArg *next, CICArg *next2,
+                      int32_t (*bit_op)(int64_t, int64_t, int64_t), int shift,
+                      char *bin, int64_t code_off) {
+  CICArg tmp = {0};
+  if (shift) {
+    code_off = PutICArgIntoReg(cctrl, next, RT_F64, 2, bin, code_off);
+    code_off = PutICArgIntoReg(cctrl, next2, RT_I64i, 1, bin, code_off);
+    AIWNIOS_ADD_CODE(ARM_fmovI64F64(2, next->reg));
+    AIWNIOS_ADD_CODE(bit_op(2, 2, 1));
+    if (res->mode == MD_REG) {
+      AIWNIOS_ADD_CODE(ARM_fmovF64I64(res->reg, 2));
+    } else {
+      tmp.mode = MD_REG;
+      tmp.reg = 2;
+      tmp.raw_type = RT_F64;
+      code_off = ICMov(cctrl, res, &tmp, bin, code_off);
+    }
+  } else {
+    code_off = PutICArgIntoReg(cctrl, next, RT_F64, 2, bin, code_off);
+    code_off = PutICArgIntoReg(cctrl, next2, RT_F64, 1, bin, code_off);
+    if (next->raw_type != RT_F64) {
+      AIWNIOS_ADD_CODE(ARM_fmovI64F64(2, next->reg));
+      next->reg = 2;
+      next->raw_type = RT_F64;
+    }
+    if (next2->raw_type != RT_F64) {
+      next2->reg = 1;
+      next2->raw_type = RT_F64;
+      AIWNIOS_ADD_CODE(ARM_fmovI64F64(1, next2->reg));
+    }
+    AIWNIOS_ADD_CODE(bit_op(2, next2->reg, next->reg));
+    if (res->mode == MD_REG) {
+      AIWNIOS_ADD_CODE(ARM_fmovF64I64(res->reg, 2));
+    } else {
+      tmp.mode = MD_REG;
+      tmp.reg = 2;
+      tmp.raw_type = RT_F64;
+      code_off = ICMov(cctrl, res, &tmp, bin, code_off);
+    }
+  }
+  return code_off;
 }
-static int64_t __SexyAssignBitOp(CCmpCtrl* cctrl, CRPN* rpn,
-	int32_t (*ubit_op)(int64_t, int64_t, int64_t),
-	int32_t (*sbit_op)(int64_t, int64_t, int64_t),
-	int64_t shift, char* bin, int64_t code_off)
-{
-	CRPN *next = ICArgN(rpn, 1), *next2, *next3, *b;
-	CICArg tmp = { 0 }, tmp2 = { 0 }, derefed = { 0 };
-	int64_t i = 0, tc = 0;
-	b = ICArgN(rpn, 0);
-	next2 = rpn->base.next;
-	next3 = next2;
-	if (SpillsTmpRegs(next2))
-		PushSpilledTmp(cctrl, next3);
-	else
-		PushTmp(cctrl, next3, NULL);
-	code_off = __OptPassFinal(cctrl, next3, bin, code_off);
-	tmp2 = derefed;
-	if (next->type == IC_TYPECAST) {
-		tc = 1;
-		TYPECAST_ASSIGN_BEGIN(next, b);
-		goto enter;
-	tc_reenter:;
-		TYPECAST_ASSIGN_END(next);
-		return code_off;
-	}
+static int64_t __SexyAssignBitOp(CCmpCtrl *cctrl, CRPN *rpn,
+                                 int32_t (*ubit_op)(int64_t, int64_t, int64_t),
+                                 int32_t (*sbit_op)(int64_t, int64_t, int64_t),
+                                 int64_t shift, char *bin, int64_t code_off) {
+  CRPN *next = ICArgN(rpn, 1), *next2, *next3, *b;
+  CICArg tmp = {0}, tmp2 = {0}, derefed = {0};
+  int64_t i = 0, tc = 0;
+  b = ICArgN(rpn, 0);
+  next2 = rpn->base.next;
+  next3 = next2;
+  if (SpillsTmpRegs(next2))
+    PushSpilledTmp(cctrl, next3);
+  else
+    PushTmp(cctrl, next3, NULL);
+  code_off = __OptPassFinal(cctrl, next3, bin, code_off);
+  tmp2 = derefed;
+  if (next->type == IC_TYPECAST) {
+    tc = 1;
+    TYPECAST_ASSIGN_BEGIN(next, b);
+    goto enter;
+  tc_reenter:;
+    TYPECAST_ASSIGN_END(next);
+    return code_off;
+  }
 enter:
-	code_off = DerefToICArg(cctrl, &derefed, next2, 2, bin, code_off);
-	PopTmp(cctrl, next2);
-	code_off = PutICArgIntoReg(cctrl, &next3->res, rpn->raw_type, 1, bin, code_off);
-	if (derefed.raw_type == RT_F64)
-		code_off = FBitOp(cctrl, &derefed, &tmp2, &next3->res, sbit_op, shift, bin,
-			code_off);
-	else {
-		code_off = PutICArgIntoReg(cctrl, &tmp2, rpn->raw_type, 3, bin, code_off);
-		if (next3->res.raw_type == RT_F64) {
-			tmp.reg = 0;
-			tmp.mode = MD_REG;
-			tmp.raw_type = RT_I64i;
-			code_off = ICMov(cctrl, &tmp, &next3->res, bin, code_off);
-		} else
-			tmp = next3->res;
-		switch (tmp2.raw_type) {
-		case RT_I16i:
-		case RT_I32i:
-		case RT_I64i:
-		case RT_I8i:
-		case RT_PTR:
-		case RT_FUNC: // func ptr
-			AIWNIOS_ADD_CODE(sbit_op(tmp2.reg, tmp2.reg, &tmp));
-			break;
-		default:
-			AIWNIOS_ADD_CODE(ubit_op(tmp2.reg, tmp2.reg, &tmp));
-		}
-	}
-	code_off = ICMov(cctrl, &rpn->res, &tmp2, bin, code_off);
-	if (tc)
-		goto tc_reenter;
-	return code_off;
+  code_off = DerefToICArg(cctrl, &derefed, next2, 2, bin, code_off);
+  PopTmp(cctrl, next2);
+  code_off =
+      PutICArgIntoReg(cctrl, &next3->res, rpn->raw_type, 1, bin, code_off);
+  if (derefed.raw_type == RT_F64)
+    code_off = FBitOp(cctrl, &derefed, &tmp2, &next3->res, sbit_op, shift, bin,
+                      code_off);
+  else {
+    code_off = PutICArgIntoReg(cctrl, &tmp2, rpn->raw_type, 3, bin, code_off);
+    if (next3->res.raw_type == RT_F64) {
+      tmp.reg = 0;
+      tmp.mode = MD_REG;
+      tmp.raw_type = RT_I64i;
+      code_off = ICMov(cctrl, &tmp, &next3->res, bin, code_off);
+    } else
+      tmp = next3->res;
+    switch (tmp2.raw_type) {
+    case RT_I16i:
+    case RT_I32i:
+    case RT_I64i:
+    case RT_I8i:
+    case RT_PTR:
+    case RT_FUNC: // func ptr
+      AIWNIOS_ADD_CODE(sbit_op(tmp2.reg, tmp2.reg, &tmp));
+      break;
+    default:
+      AIWNIOS_ADD_CODE(ubit_op(tmp2.reg, tmp2.reg, &tmp));
+    }
+  }
+  code_off = ICMov(cctrl, &rpn->res, &tmp2, bin, code_off);
+  if (tc)
+    goto tc_reenter;
+  return code_off;
 }
-static int64_t __SexyAssignOp(CCmpCtrl* cctrl, CRPN* rpn,
-	int32_t (*i_op)(int64_t, int64_t, int64_t),
-	int32_t (*i_imm_op)(int64_t, int64_t, int64_t),
-	int32_t (*f_op)(int64_t, int64_t, int64_t),
-	char* bin, int64_t code_off)
-{
-	CRPN *next = ICArgN(rpn, 1), *next2, *next3, *b;
-	CICArg tmp = { 0 }, tmp2 = { 0 }, derefed = { 0 };
-	int64_t i = 0, const_can = 0;
-	next2 = b = ICArgN(rpn, 0);
-	if (SpillsTmpRegs(next))
-		PushSpilledTmp(cctrl, next2);
-	else
-		PushTmp(cctrl, next2, NULL);
-	if (i_imm_op)
-		if (IsConst(b) && ARM_ERR_INV_OFF != i_imm_op(0, 0, ConstVal(b)))
-			const_can = 1;
-	if (const_can) {
-		if (next->type == IC_TYPECAST) {
-			TYPECAST_ASSIGN_BEGIN(next, b);
-			PushTmp(cctrl, next2, NULL);
-			tmp2 = next->res;
-			if (tmp2.raw_type == RT_F64)
-				goto defacto;
-			code_off = PutICArgIntoReg(cctrl, &tmp2, next->raw_type, 3, bin, code_off);
-			AIWNIOS_ADD_CODE(i_imm_op(tmp2.reg, tmp2.reg, ConstVal(b)));
-			code_off = ICMov(cctrl, &next->res, &tmp2, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &tmp2, bin, code_off);
-			TYPECAST_ASSIGN_END(next);
-			PopTmp(cctrl, next2);
-			return code_off;
-		} else {
-			if (next->raw_type == RT_F64 || rpn->raw_type == RT_F64)
-				goto defacto2;
-			code_off = DerefToICArg(cctrl, &derefed, next, 2, bin, code_off);
-			tmp2 = derefed;
-			code_off = PutICArgIntoReg(cctrl, &tmp2, RT_I64i, 3, bin, code_off);
-			AIWNIOS_ADD_CODE(i_imm_op(tmp2.reg, tmp2.reg, ConstVal(b)));
-			PopTmp(cctrl, next2);
-			code_off = ICMov(cctrl, &derefed, &tmp2, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &tmp2, bin, code_off);
-			return code_off;
-		}
-	} else {
-		if (next->type == IC_TYPECAST) {
-			TYPECAST_ASSIGN_BEGIN(next, b);
-		defacto:
-			code_off = __OptPassFinal(cctrl, next2, bin, code_off);
-			code_off = PutICArgIntoReg(cctrl, &next2->res, next->raw_type, 1, bin,
-				code_off); // 1
-			tmp2 = next->res;
-			code_off = PutICArgIntoReg(cctrl, &tmp2, next->raw_type, 3, bin, code_off);
-			if (tmp2.raw_type == RT_F64) {
-				AIWNIOS_ADD_CODE(f_op(tmp2.reg, tmp2.reg, b->res.reg));
-			} else {
-				AIWNIOS_ADD_CODE(i_op(tmp2.reg, tmp2.reg, b->res.reg));
-			}
-			code_off = ICMov(cctrl, &next->res, &tmp2, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &tmp2, bin, code_off);
-			TYPECAST_ASSIGN_END(next);
-			PopTmp(cctrl, next2);
-			return code_off;
-		} else {
-		defacto2:
-			//
-			code_off = __OptPassFinal(cctrl, next2, bin, code_off);
-			code_off = DerefToICArg(cctrl, &derefed, next, 2, bin, code_off);
-			PopTmp(cctrl, next2);
-			tmp2 = derefed;
-			// Check if different
-			if ((tmp2.raw_type == RT_F64) ^ (b->res.raw_type == RT_F64)) {
-				code_off = PutICArgIntoReg(cctrl, &b->res, RT_F64, 1, bin, code_off);
-				code_off = PutICArgIntoReg(cctrl, &tmp2, RT_F64, 3, bin, code_off);
-				AIWNIOS_ADD_CODE(f_op(tmp2.reg, tmp2.reg, b->res.reg));
-			} else {
-				//                ____________
-				// (o)    (o)    /            \
+static int64_t __SexyAssignOp(CCmpCtrl *cctrl, CRPN *rpn,
+                              int32_t (*i_op)(int64_t, int64_t, int64_t),
+                              int32_t (*i_imm_op)(int64_t, int64_t, int64_t),
+                              int32_t (*f_op)(int64_t, int64_t, int64_t),
+                              char *bin, int64_t code_off) {
+  CRPN *next = ICArgN(rpn, 1), *next2, *next3, *b;
+  CICArg tmp = {0}, tmp2 = {0}, derefed = {0};
+  int64_t i = 0, const_can = 0;
+  next2 = b = ICArgN(rpn, 0);
+  if (SpillsTmpRegs(next))
+    PushSpilledTmp(cctrl, next2);
+  else
+    PushTmp(cctrl, next2, NULL);
+  if (i_imm_op)
+    if (IsConst(b) && ARM_ERR_INV_OFF != i_imm_op(0, 0, ConstVal(b)))
+      const_can = 1;
+  if (const_can) {
+    if (next->type == IC_TYPECAST) {
+      TYPECAST_ASSIGN_BEGIN(next, b);
+      PushTmp(cctrl, next2, NULL);
+      tmp2 = next->res;
+      if (tmp2.raw_type == RT_F64)
+        goto defacto;
+      code_off =
+          PutICArgIntoReg(cctrl, &tmp2, next->raw_type, 3, bin, code_off);
+      AIWNIOS_ADD_CODE(i_imm_op(tmp2.reg, tmp2.reg, ConstVal(b)));
+      code_off = ICMov(cctrl, &next->res, &tmp2, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &tmp2, bin, code_off);
+      TYPECAST_ASSIGN_END(next);
+      PopTmp(cctrl, next2);
+      return code_off;
+    } else {
+      if (next->raw_type == RT_F64 || rpn->raw_type == RT_F64)
+        goto defacto2;
+      code_off = DerefToICArg(cctrl, &derefed, next, 2, bin, code_off);
+      tmp2 = derefed;
+      code_off = PutICArgIntoReg(cctrl, &tmp2, RT_I64i, 3, bin, code_off);
+      AIWNIOS_ADD_CODE(i_imm_op(tmp2.reg, tmp2.reg, ConstVal(b)));
+      PopTmp(cctrl, next2);
+      code_off = ICMov(cctrl, &derefed, &tmp2, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &tmp2, bin, code_off);
+      return code_off;
+    }
+  } else {
+    if (next->type == IC_TYPECAST) {
+      TYPECAST_ASSIGN_BEGIN(next, b);
+    defacto:
+      code_off = __OptPassFinal(cctrl, next2, bin, code_off);
+      code_off = PutICArgIntoReg(cctrl, &next2->res, next->raw_type, 1, bin,
+                                 code_off); // 1
+      tmp2 = next->res;
+      code_off =
+          PutICArgIntoReg(cctrl, &tmp2, next->raw_type, 3, bin, code_off);
+      if (tmp2.raw_type == RT_F64) {
+        AIWNIOS_ADD_CODE(f_op(tmp2.reg, tmp2.reg, b->res.reg));
+      } else {
+        AIWNIOS_ADD_CODE(i_op(tmp2.reg, tmp2.reg, b->res.reg));
+      }
+      code_off = ICMov(cctrl, &next->res, &tmp2, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &tmp2, bin, code_off);
+      TYPECAST_ASSIGN_END(next);
+      PopTmp(cctrl, next2);
+      return code_off;
+    } else {
+    defacto2:
+      //
+      code_off = __OptPassFinal(cctrl, next2, bin, code_off);
+      code_off = DerefToICArg(cctrl, &derefed, next, 2, bin, code_off);
+      PopTmp(cctrl, next2);
+      tmp2 = derefed;
+      // Check if different
+      if ((tmp2.raw_type == RT_F64) ^ (b->res.raw_type == RT_F64)) {
+        code_off = PutICArgIntoReg(cctrl, &b->res, RT_F64, 1, bin, code_off);
+        code_off = PutICArgIntoReg(cctrl, &tmp2, RT_F64, 3, bin, code_off);
+        AIWNIOS_ADD_CODE(f_op(tmp2.reg, tmp2.reg, b->res.reg));
+      } else {
+        //                ____________
+        // (o)    (o)    /            \
           //  \      /    |             |
-				//   \ ___/     |    tmp2 has |
-				//  / _____\    |   register 3|
-				// /  \___/ \___| as fallback |
-				// \ _________________________/
-				//
-				code_off = PutICArgIntoReg(cctrl, &b->res, next->raw_type, 1, bin, code_off); // 1
-				code_off = PutICArgIntoReg(cctrl, &tmp2, next->raw_type, 3, bin, code_off);
-				if (tmp2.raw_type == RT_F64) {
-					AIWNIOS_ADD_CODE(f_op(tmp2.reg, tmp2.reg, b->res.reg));
-				} else {
-					AIWNIOS_ADD_CODE(i_op(tmp2.reg, tmp2.reg, b->res.reg));
-				}
-			}
-			code_off = ICMov(cctrl, &derefed, &tmp2, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &tmp2, bin, code_off);
-			return code_off;
-		}
-	}
-	return code_off;
+        //   \ ___/     |    tmp2 has |
+        //  / _____\    |   register 3|
+        // /  \___/ \___| as fallback |
+        // \ _________________________/
+        //
+        code_off = PutICArgIntoReg(cctrl, &b->res, next->raw_type, 1, bin,
+                                   code_off); // 1
+        code_off =
+            PutICArgIntoReg(cctrl, &tmp2, next->raw_type, 3, bin, code_off);
+        if (tmp2.raw_type == RT_F64) {
+          AIWNIOS_ADD_CODE(f_op(tmp2.reg, tmp2.reg, b->res.reg));
+        } else {
+          AIWNIOS_ADD_CODE(i_op(tmp2.reg, tmp2.reg, b->res.reg));
+        }
+      }
+      code_off = ICMov(cctrl, &derefed, &tmp2, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &tmp2, bin, code_off);
+      return code_off;
+    }
+  }
+  return code_off;
 }
-static int64_t __FMod(int64_t dst, int64_t a, int64_t b, char* bin,
-	int64_t code_off)
-{
-	AIWNIOS_ADD_CODE(ARM_fdivReg(0, a, b));
-	AIWNIOS_ADD_CODE(ARM_fcvtzs(0, 0))
-	AIWNIOS_ADD_CODE(ARM_scvtf(0, 0));
-	AIWNIOS_ADD_CODE(ARM_fmulReg(0, 0, b));
-	AIWNIOS_ADD_CODE(ARM_fsubReg(dst, a, 0));
-	return code_off;
+static int64_t __FMod(int64_t dst, int64_t a, int64_t b, char *bin,
+                      int64_t code_off) {
+  AIWNIOS_ADD_CODE(ARM_fdivReg(0, a, b));
+  AIWNIOS_ADD_CODE(ARM_fcvtzs(0, 0))
+  AIWNIOS_ADD_CODE(ARM_scvtf(0, 0));
+  AIWNIOS_ADD_CODE(ARM_fmulReg(0, 0, b));
+  AIWNIOS_ADD_CODE(ARM_fsubReg(dst, a, 0));
+  return code_off;
 }
 // Also handles IC_MOD_EQ
-static int64_t __CompileMod(CCmpCtrl* cctrl, CRPN* rpn, char* bin,
-	int64_t code_off)
-{
-	CRPN *next, *next2, *tc;
-	CICArg tmp = { 0 }, orig_dst = { 0 }, derefed = { 0 }, tmp2 = { 0 };
-	int64_t into_reg;
-	next = ICArgN(rpn, 1);
-	next2 = ICArgN(rpn, 0);
-	if (SpillsTmpRegs(next))
-		PushSpilledTmp(cctrl, next2);
-	else
-		PushTmp(cctrl, next2, NULL);
-	if (next->type == IC_TYPECAST && rpn->type == IC_MOD_EQ) {
-		code_off = __OptPassFinal(cctrl, next2, bin, code_off);
-		TYPECAST_ASSIGN_BEGIN(next, next2);
-		orig_dst = tmp;
-		code_off = PutICArgIntoReg(cctrl, &tmp, next->raw_type, 2, bin, code_off);
-		code_off = PutICArgIntoReg(cctrl, &next2->res, next->raw_type, 1, bin, code_off);
-		if (next->raw_type == RT_F64) {
-			code_off = __FMod(4, tmp.reg, next2->res.reg, bin, code_off);
-			tmp.mode = MD_REG;
-			tmp.raw_type = RT_F64;
-			tmp.reg = 4;
-			code_off = ICMov(cctrl, &orig_dst, &tmp, bin, code_off);
-			PopTmp(cctrl, next2);
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-			goto tc_fin;
-		}
-		into_reg = 0;
-		if (rpn->raw_type == RT_U64i) {
-			AIWNIOS_ADD_CODE(ARM_udivX(into_reg, tmp.reg, next2->res.reg));
-			AIWNIOS_ADD_CODE(ARM_umullX(into_reg, into_reg, next2->res.reg));
-			AIWNIOS_ADD_CODE(ARM_subRegX(into_reg, tmp.reg, into_reg));
-			AIWNIOS_ADD_CODE(ARM_uxtwX(into_reg, into_reg)); // umull takes into account 32bit operands,so I will "accomodate"
-		} else {
-			AIWNIOS_ADD_CODE(ARM_sdivRegX(into_reg, tmp.reg, next2->res.reg));
-			AIWNIOS_ADD_CODE(ARM_mulRegX(into_reg, into_reg, next2->res.reg));
-			AIWNIOS_ADD_CODE(ARM_subRegX(into_reg, tmp.reg, into_reg));
-		}
-		tmp.mode = MD_REG;
-		tmp.raw_type = RT_I64i;
-		tmp.reg = into_reg;
-		tmp.off = 0;
-		code_off = ICMov(cctrl, &orig_dst, &tmp, bin, code_off);
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-	tc_fin:
-		TYPECAST_ASSIGN_END(next);
-		PopTmp(cctrl, next2);
-		return code_off;
-	}
-	if (rpn->type == IC_MOD_EQ) {
-		code_off = __OptPassFinal(cctrl, next2, bin, code_off);
-		code_off = DerefToICArg(cctrl, &tmp, next, 3, bin, code_off);
-		orig_dst = tmp;
-		code_off = PutICArgIntoReg(cctrl, &tmp, next->raw_type, 2, bin, code_off);
-		code_off = PutICArgIntoReg(cctrl, &next2->res, next->raw_type, 1, bin, code_off);
-		if (next->raw_type == RT_F64) {
-			code_off = __FMod(4, tmp.reg, next2->res.reg, bin, code_off);
-			tmp.mode = MD_REG;
-			tmp.raw_type = RT_F64;
-			tmp.reg = 4;
-			code_off = ICMov(cctrl, &orig_dst, &tmp, bin, code_off);
-			PopTmp(cctrl, next2);
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-			return code_off;
-		}
-		into_reg = 0;
-		if (next->raw_type == RT_U64i) {
-			AIWNIOS_ADD_CODE(ARM_udivX(into_reg, tmp.reg, next2->res.reg));
-			AIWNIOS_ADD_CODE(ARM_umullX(into_reg, into_reg, next2->res.reg));
-			AIWNIOS_ADD_CODE(ARM_subRegX(into_reg, tmp.reg, into_reg));
-			AIWNIOS_ADD_CODE(ARM_uxtwX(into_reg, into_reg)); // umull takes into account 32bit operands,so I will "accomodate"
-		} else {
-			AIWNIOS_ADD_CODE(ARM_sdivRegX(into_reg, tmp.reg, next2->res.reg));
-			AIWNIOS_ADD_CODE(ARM_mulRegX(into_reg, into_reg, next2->res.reg));
-			AIWNIOS_ADD_CODE(ARM_subRegX(into_reg, tmp.reg, into_reg));
-		}
-		tmp.mode = MD_REG;
-		tmp.raw_type = RT_I64i;
-		tmp.reg = into_reg;
-		tmp.off = 0;
-		code_off = ICMov(cctrl, &orig_dst, &tmp, bin, code_off);
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		PopTmp(cctrl, next2);
-		return code_off;
-	}
-	PushTmp(cctrl, next, &rpn->res);
-	code_off = __OptPassFinal(cctrl, next2, bin, code_off);
-	code_off = __OptPassFinal(cctrl, next, bin, code_off);
-	code_off = PutICArgIntoReg(cctrl, &next2->res, rpn->raw_type, 1, bin, code_off);
-	code_off = PutICArgIntoReg(cctrl, &next->res, rpn->raw_type, 2, bin, code_off);
-	if (rpn->raw_type == RT_F64) {
-		code_off = __FMod(4, next->res.reg, next2->res.reg, bin, code_off);
-		tmp.mode = MD_REG;
-		tmp.raw_type = RT_F64;
-		tmp.reg = 4;
-	} else {
-		into_reg = 0;
-		tmp.reg = 0;
-		tmp.raw_type = RT_I64i;
-		tmp.mode = MD_REG;
-		if (rpn->raw_type == RT_U64i) {
-			AIWNIOS_ADD_CODE(ARM_udivX(into_reg, next->res.reg, next2->res.reg));
-			AIWNIOS_ADD_CODE(ARM_umullX(into_reg, into_reg, next2->res.reg));
-			AIWNIOS_ADD_CODE(ARM_subRegX(into_reg, next->res.reg, into_reg));
-			AIWNIOS_ADD_CODE(ARM_uxtwX(into_reg, into_reg)); // umull takes into account 32bit operands,so I will "accomodate"
-		} else {
-			AIWNIOS_ADD_CODE(ARM_sdivRegX(into_reg, next->res.reg, next2->res.reg));
-			AIWNIOS_ADD_CODE(ARM_mulRegX(into_reg, into_reg, next2->res.reg));
-			AIWNIOS_ADD_CODE(ARM_subRegX(into_reg, next->res.reg, into_reg));
-		}
-	}
-	code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-	PopTmp(cctrl, next);
-	PopTmp(cctrl, next2);
-	return code_off;
+static int64_t __CompileMod(CCmpCtrl *cctrl, CRPN *rpn, char *bin,
+                            int64_t code_off) {
+  CRPN *next, *next2, *tc;
+  CICArg tmp = {0}, orig_dst = {0}, derefed = {0}, tmp2 = {0};
+  int64_t into_reg;
+  next = ICArgN(rpn, 1);
+  next2 = ICArgN(rpn, 0);
+  if (SpillsTmpRegs(next))
+    PushSpilledTmp(cctrl, next2);
+  else
+    PushTmp(cctrl, next2, NULL);
+  if (next->type == IC_TYPECAST && rpn->type == IC_MOD_EQ) {
+    code_off = __OptPassFinal(cctrl, next2, bin, code_off);
+    TYPECAST_ASSIGN_BEGIN(next, next2);
+    orig_dst = tmp;
+    code_off = PutICArgIntoReg(cctrl, &tmp, next->raw_type, 2, bin, code_off);
+    code_off =
+        PutICArgIntoReg(cctrl, &next2->res, next->raw_type, 1, bin, code_off);
+    if (next->raw_type == RT_F64) {
+      code_off = __FMod(4, tmp.reg, next2->res.reg, bin, code_off);
+      tmp.mode = MD_REG;
+      tmp.raw_type = RT_F64;
+      tmp.reg = 4;
+      code_off = ICMov(cctrl, &orig_dst, &tmp, bin, code_off);
+      PopTmp(cctrl, next2);
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+      goto tc_fin;
+    }
+    into_reg = 0;
+    if (rpn->raw_type == RT_U64i) {
+      AIWNIOS_ADD_CODE(ARM_udivX(into_reg, tmp.reg, next2->res.reg));
+      AIWNIOS_ADD_CODE(ARM_umullX(into_reg, into_reg, next2->res.reg));
+      AIWNIOS_ADD_CODE(ARM_subRegX(into_reg, tmp.reg, into_reg));
+      AIWNIOS_ADD_CODE(
+          ARM_uxtwX(into_reg, into_reg)); // umull takes into account 32bit
+                                          // operands,so I will "accomodate"
+    } else {
+      AIWNIOS_ADD_CODE(ARM_sdivRegX(into_reg, tmp.reg, next2->res.reg));
+      AIWNIOS_ADD_CODE(ARM_mulRegX(into_reg, into_reg, next2->res.reg));
+      AIWNIOS_ADD_CODE(ARM_subRegX(into_reg, tmp.reg, into_reg));
+    }
+    tmp.mode = MD_REG;
+    tmp.raw_type = RT_I64i;
+    tmp.reg = into_reg;
+    tmp.off = 0;
+    code_off = ICMov(cctrl, &orig_dst, &tmp, bin, code_off);
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+  tc_fin:
+    TYPECAST_ASSIGN_END(next);
+    PopTmp(cctrl, next2);
+    return code_off;
+  }
+  if (rpn->type == IC_MOD_EQ) {
+    code_off = __OptPassFinal(cctrl, next2, bin, code_off);
+    code_off = DerefToICArg(cctrl, &tmp, next, 3, bin, code_off);
+    orig_dst = tmp;
+    code_off = PutICArgIntoReg(cctrl, &tmp, next->raw_type, 2, bin, code_off);
+    code_off =
+        PutICArgIntoReg(cctrl, &next2->res, next->raw_type, 1, bin, code_off);
+    if (next->raw_type == RT_F64) {
+      code_off = __FMod(4, tmp.reg, next2->res.reg, bin, code_off);
+      tmp.mode = MD_REG;
+      tmp.raw_type = RT_F64;
+      tmp.reg = 4;
+      code_off = ICMov(cctrl, &orig_dst, &tmp, bin, code_off);
+      PopTmp(cctrl, next2);
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+      return code_off;
+    }
+    into_reg = 0;
+    if (next->raw_type == RT_U64i) {
+      AIWNIOS_ADD_CODE(ARM_udivX(into_reg, tmp.reg, next2->res.reg));
+      AIWNIOS_ADD_CODE(ARM_umullX(into_reg, into_reg, next2->res.reg));
+      AIWNIOS_ADD_CODE(ARM_subRegX(into_reg, tmp.reg, into_reg));
+      AIWNIOS_ADD_CODE(
+          ARM_uxtwX(into_reg, into_reg)); // umull takes into account 32bit
+                                          // operands,so I will "accomodate"
+    } else {
+      AIWNIOS_ADD_CODE(ARM_sdivRegX(into_reg, tmp.reg, next2->res.reg));
+      AIWNIOS_ADD_CODE(ARM_mulRegX(into_reg, into_reg, next2->res.reg));
+      AIWNIOS_ADD_CODE(ARM_subRegX(into_reg, tmp.reg, into_reg));
+    }
+    tmp.mode = MD_REG;
+    tmp.raw_type = RT_I64i;
+    tmp.reg = into_reg;
+    tmp.off = 0;
+    code_off = ICMov(cctrl, &orig_dst, &tmp, bin, code_off);
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    PopTmp(cctrl, next2);
+    return code_off;
+  }
+  PushTmp(cctrl, next, &rpn->res);
+  code_off = __OptPassFinal(cctrl, next2, bin, code_off);
+  code_off = __OptPassFinal(cctrl, next, bin, code_off);
+  code_off =
+      PutICArgIntoReg(cctrl, &next2->res, rpn->raw_type, 1, bin, code_off);
+  code_off =
+      PutICArgIntoReg(cctrl, &next->res, rpn->raw_type, 2, bin, code_off);
+  if (rpn->raw_type == RT_F64) {
+    code_off = __FMod(4, next->res.reg, next2->res.reg, bin, code_off);
+    tmp.mode = MD_REG;
+    tmp.raw_type = RT_F64;
+    tmp.reg = 4;
+  } else {
+    into_reg = 0;
+    tmp.reg = 0;
+    tmp.raw_type = RT_I64i;
+    tmp.mode = MD_REG;
+    if (rpn->raw_type == RT_U64i) {
+      AIWNIOS_ADD_CODE(ARM_udivX(into_reg, next->res.reg, next2->res.reg));
+      AIWNIOS_ADD_CODE(ARM_umullX(into_reg, into_reg, next2->res.reg));
+      AIWNIOS_ADD_CODE(ARM_subRegX(into_reg, next->res.reg, into_reg));
+      AIWNIOS_ADD_CODE(
+          ARM_uxtwX(into_reg, into_reg)); // umull takes into account 32bit
+                                          // operands,so I will "accomodate"
+    } else {
+      AIWNIOS_ADD_CODE(ARM_sdivRegX(into_reg, next->res.reg, next2->res.reg));
+      AIWNIOS_ADD_CODE(ARM_mulRegX(into_reg, into_reg, next2->res.reg));
+      AIWNIOS_ADD_CODE(ARM_subRegX(into_reg, next->res.reg, into_reg));
+    }
+  }
+  code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+  PopTmp(cctrl, next);
+  PopTmp(cctrl, next2);
+  return code_off;
 }
 
 // This is used for FuncProlog/Epilog. It is used for finding the non-violatle
@@ -2097,490 +2130,509 @@ static int64_t __CompileMod(CCmpCtrl* cctrl, CRPN* rpn, char* bin,
 //
 // Returns number of pushed regs
 //
-static int64_t __FindPushedIRegs(CCmpCtrl* cctrl, char* to_push)
-{
-	CMemberLst* lst;
-	CRPN* r;
-	int64_t cnt = 0;
-	memset(to_push, 0, 32);
-	if (!cctrl->cur_fun) {
-		// Perhaps we are being called from HolyC and we aren't using a "cur_fun"
-		for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code; r = r->base.next) {
-			if (r->type == IC_IREG && r->raw_type != RT_F64) {
-				if (!to_push[r->integer])
-					if (AIWNIOS_IREG_START <= r->integer)
-						if (AIWNIOS_IREG_CNT > r->integer - AIWNIOS_IREG_START) {
-							to_push[r->integer] = 1;
-							cnt++;
-						}
-			}
-		}
-		return cnt;
-	}
-	for (lst = cctrl->cur_fun->base.members_lst; lst; lst = lst->next) {
-		if (lst->reg != REG_NONE && lst->member_class->raw_type != RT_F64) {
-			assert(lst->reg >= 0);
-			to_push[lst->reg] = 1;
-			cnt++;
-		}
-	}
-	return cnt;
+static int64_t __FindPushedIRegs(CCmpCtrl *cctrl, char *to_push) {
+  CMemberLst *lst;
+  CRPN *r;
+  int64_t cnt = 0;
+  memset(to_push, 0, 32);
+  if (!cctrl->cur_fun) {
+    // Perhaps we are being called from HolyC and we aren't using a "cur_fun"
+    for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code;
+         r = r->base.next) {
+      if (r->type == IC_IREG && r->raw_type != RT_F64) {
+        if (!to_push[r->integer])
+          if (AIWNIOS_IREG_START <= r->integer)
+            if (AIWNIOS_IREG_CNT > r->integer - AIWNIOS_IREG_START) {
+              to_push[r->integer] = 1;
+              cnt++;
+            }
+      }
+    }
+    return cnt;
+  }
+  for (lst = cctrl->cur_fun->base.members_lst; lst; lst = lst->next) {
+    if (lst->reg != REG_NONE && lst->member_class->raw_type != RT_F64) {
+      assert(lst->reg >= 0);
+      to_push[lst->reg] = 1;
+      cnt++;
+    }
+  }
+  return cnt;
 }
 
-static int64_t __FindPushedFRegs(CCmpCtrl* cctrl, char* to_push)
-{
-	CMemberLst* lst;
-	int64_t cnt = 0;
-	memset(to_push, 0, 32);
-	CRPN* r;
-	if (!cctrl->cur_fun) {
-		// Perhaps we are being called from HolyC and we aren't using a "cur_fun"
-		for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code; r = r->base.next) {
-			if (r->type == IC_FREG && r->raw_type == RT_F64) {
-				if (!to_push[r->integer])
-					if (AIWNIOS_FREG_START <= r->integer)
-						if (AIWNIOS_FREG_CNT > r->integer - AIWNIOS_FREG_START) {
-							to_push[r->integer] = 1;
-							cnt++;
-						}
-			}
-		}
-		return cnt;
-	}
-	for (lst = cctrl->cur_fun->base.members_lst; lst; lst = lst->next) {
-		if (lst->reg != REG_NONE && lst->member_class->raw_type == RT_F64) {
-			assert(lst->reg >= 0);
-			to_push[lst->reg] = 1;
-			cnt++;
-		}
-	}
-	return cnt;
+static int64_t __FindPushedFRegs(CCmpCtrl *cctrl, char *to_push) {
+  CMemberLst *lst;
+  int64_t cnt = 0;
+  memset(to_push, 0, 32);
+  CRPN *r;
+  if (!cctrl->cur_fun) {
+    // Perhaps we are being called from HolyC and we aren't using a "cur_fun"
+    for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code;
+         r = r->base.next) {
+      if (r->type == IC_FREG && r->raw_type == RT_F64) {
+        if (!to_push[r->integer])
+          if (AIWNIOS_FREG_START <= r->integer)
+            if (AIWNIOS_FREG_CNT > r->integer - AIWNIOS_FREG_START) {
+              to_push[r->integer] = 1;
+              cnt++;
+            }
+      }
+    }
+    return cnt;
+  }
+  for (lst = cctrl->cur_fun->base.members_lst; lst; lst = lst->next) {
+    if (lst->reg != REG_NONE && lst->member_class->raw_type == RT_F64) {
+      assert(lst->reg >= 0);
+      to_push[lst->reg] = 1;
+      cnt++;
+    }
+  }
+  return cnt;
 }
 
-static int64_t FuncProlog(CCmpCtrl* cctrl, char* bin, int64_t code_off)
-{
-	char push_ireg[32];
-	char push_freg[32];
-	char ilist[32];
-	char flist[32];
-	int64_t i, i2, i3, r, r2, ireg_arg_cnt, freg_arg_cnt, stk_arg_cnt, fsz, code, off;
-	CMemberLst* lst;
-	CICArg fun_arg = { 0 }, write_to = { 0 };
-	CRPN *rpn, *arg;
-	/* Old SP
-	 * saved regs
-	 * wiggle room
-	 * locals
-	 * old_FP,old_LR
-	 * <===FP=SP
-	 */
-	if (cctrl->cur_fun) {
-		fsz = cctrl->cur_fun->base.sz + 16; //+16 for LR/FP
-	} else {
-		fsz = 16;
-		for (rpn = cctrl->code_ctrl->ir_code->next; rpn != cctrl->code_ctrl->ir_code; rpn = rpn->base.next) {
-			if (rpn->type == __IC_SET_FRAME_SIZE) {
-				fsz = rpn->integer;
-				break;
-			}
-		}
-	}
-	// ALIGN TO 8
-	if (fsz % 8)
-		fsz += 8 - fsz % 8;
-	int64_t to_push = (i2 = __FindPushedIRegs(cctrl, push_ireg)) * 8 + (i3 = __FindPushedFRegs(cctrl, push_freg)) * 8 + cctrl->backend_user_data0 + fsz, old_regs_start;
-	if (i2 % 2)
-		to_push += 8; // We push a dummy register in a pair if not aligned to 2
-	if (i3 % 2)
-		to_push += 8; // Ditto
+static int64_t FuncProlog(CCmpCtrl *cctrl, char *bin, int64_t code_off) {
+  char push_ireg[32];
+  char push_freg[32];
+  char ilist[32];
+  char flist[32];
+  int64_t i, i2, i3, r, r2, ireg_arg_cnt, freg_arg_cnt, stk_arg_cnt, fsz, code,
+      off;
+  CMemberLst *lst;
+  CICArg fun_arg = {0}, write_to = {0};
+  CRPN *rpn, *arg;
+  /* Old SP
+   * saved regs
+   * wiggle room
+   * locals
+   * old_FP,old_LR
+   * <===FP=SP
+   */
+  if (cctrl->cur_fun) {
+    fsz = cctrl->cur_fun->base.sz + 16; //+16 for LR/FP
+  } else {
+    fsz = 16;
+    for (rpn = cctrl->code_ctrl->ir_code->next;
+         rpn != cctrl->code_ctrl->ir_code; rpn = rpn->base.next) {
+      if (rpn->type == __IC_SET_FRAME_SIZE) {
+        fsz = rpn->integer;
+        break;
+      }
+    }
+  }
+  // ALIGN TO 8
+  if (fsz % 8)
+    fsz += 8 - fsz % 8;
+  int64_t to_push = (i2 = __FindPushedIRegs(cctrl, push_ireg)) * 8 +
+                    (i3 = __FindPushedFRegs(cctrl, push_freg)) * 8 +
+                    cctrl->backend_user_data0 + fsz,
+          old_regs_start;
+  if (i2 % 2)
+    to_push += 8; // We push a dummy register in a pair if not aligned to 2
+  if (i3 % 2)
+    to_push += 8; // Ditto
 
-	if (to_push % 16)
-		to_push += 8;
-	cctrl->backend_user_data4 = fsz;
-	old_regs_start = fsz + cctrl->backend_user_data0;
+  if (to_push % 16)
+    to_push += 8;
+  cctrl->backend_user_data4 = fsz;
+  old_regs_start = fsz + cctrl->backend_user_data0;
 
-	i2 = 0;
-	for (i = 0; i != 32; i++)
-		if (push_ireg[i])
-			ilist[i2++] = i;
-	if (i2 % 2)
-		ilist[i2++] = 1; // Dont use 0 as it is a reutrn register
-	i3 = 0;
-	for (i = 0; i != 32; i++)
-		if (push_freg[i])
-			flist[i3++] = i;
-	if (i3 % 2)
-		flist[i3++] = 1; // Dont use 0 as it is a reutrn register
+  i2 = 0;
+  for (i = 0; i != 32; i++)
+    if (push_ireg[i])
+      ilist[i2++] = i;
+  if (i2 % 2)
+    ilist[i2++] = 1; // Dont use 0 as it is a reutrn register
+  i3 = 0;
+  for (i = 0; i != 32; i++)
+    if (push_freg[i])
+      flist[i3++] = i;
+  if (i3 % 2)
+    flist[i3++] = 1; // Dont use 0 as it is a reutrn register
 
-	//<==== OLD SP
-	// first saved reg pair<==-16
-	// next saved reg pair<===-32
-	//
-	off = 16;
-	for (i = 0; i != i2; i += 2) {
-		AIWNIOS_ADD_CODE(ARM_stpImmX(ilist[i], ilist[i + 1], ARM_REG_SP, -off));
-		off += 16;
-	}
-	for (i = 0; i != i3; i += 2) {
-		AIWNIOS_ADD_CODE(ARM_stpImmF64(flist[i], flist[i + 1], ARM_REG_SP, -off));
-		off += 16;
-	}
-	if (ARM_ERR_INV_OFF != ARM_subImmX(ARM_REG_SP, ARM_REG_SP, to_push)) {
-		AIWNIOS_ADD_CODE(ARM_subImmX(ARM_REG_SP, ARM_REG_SP, to_push));
-	} else {
-		code_off = __ICMoveI64(cctrl, 8, to_push, bin, code_off);
-		AIWNIOS_ADD_CODE(ARM_subRegX(ARM_REG_SP, ARM_REG_SP, 8));
-	}
-	AIWNIOS_ADD_CODE(ARM_stpImmX(ARM_REG_FP, ARM_REG_LR, ARM_REG_SP, 0));
-	AIWNIOS_ADD_CODE(ARM_movRegX(ARM_REG_FP, ARM_REG_SP));
-	stk_arg_cnt = ireg_arg_cnt = freg_arg_cnt = 0;
-	if (cctrl->cur_fun) {
-		lst = cctrl->cur_fun->base.members_lst;
-		for (i = 0; i != cctrl->cur_fun->argc; i++) {
-			if (lst->member_class->raw_type == RT_F64) {
-        #ifdef USE_TEMPLEOS_ABI
+  //<==== OLD SP
+  // first saved reg pair<==-16
+  // next saved reg pair<===-32
+  //
+  off = 16;
+  for (i = 0; i != i2; i += 2) {
+    AIWNIOS_ADD_CODE(ARM_stpImmX(ilist[i], ilist[i + 1], ARM_REG_SP, -off));
+    off += 16;
+  }
+  for (i = 0; i != i3; i += 2) {
+    AIWNIOS_ADD_CODE(ARM_stpImmF64(flist[i], flist[i + 1], ARM_REG_SP, -off));
+    off += 16;
+  }
+  if (ARM_ERR_INV_OFF != ARM_subImmX(ARM_REG_SP, ARM_REG_SP, to_push)) {
+    AIWNIOS_ADD_CODE(ARM_subImmX(ARM_REG_SP, ARM_REG_SP, to_push));
+  } else {
+    code_off = __ICMoveI64(cctrl, 8, to_push, bin, code_off);
+    AIWNIOS_ADD_CODE(ARM_subRegX(ARM_REG_SP, ARM_REG_SP, 8));
+  }
+  AIWNIOS_ADD_CODE(ARM_stpImmX(ARM_REG_FP, ARM_REG_LR, ARM_REG_SP, 0));
+  AIWNIOS_ADD_CODE(ARM_movRegX(ARM_REG_FP, ARM_REG_SP));
+  stk_arg_cnt = ireg_arg_cnt = freg_arg_cnt = 0;
+  if (cctrl->cur_fun) {
+    lst = cctrl->cur_fun->base.members_lst;
+    for (i = 0; i != cctrl->cur_fun->argc; i++) {
+      if (lst->member_class->raw_type == RT_F64) {
+#ifdef USE_TEMPLEOS_ABI
         goto stk;
-        #endif
-				if (freg_arg_cnt < 8) {
-					fun_arg.mode = MD_REG;
-					fun_arg.raw_type = RT_F64;
-					fun_arg.reg = freg_arg_cnt++;
-				} else {
-				stk:
-					fun_arg.mode = MD_FRAME;
-					fun_arg.raw_type = lst->member_class->raw_type;
-					fun_arg.off = to_push + stk_arg_cnt++ * 8;
-				}
-			} else {
-				#ifdef USE_TEMPLEOS_ABI
+#endif
+        if (freg_arg_cnt < 8) {
+          fun_arg.mode = MD_REG;
+          fun_arg.raw_type = RT_F64;
+          fun_arg.reg = freg_arg_cnt++;
+        } else {
+        stk:
+          fun_arg.mode = MD_FRAME;
+          fun_arg.raw_type = lst->member_class->raw_type;
+          fun_arg.off = to_push + stk_arg_cnt++ * 8;
+        }
+      } else {
+#ifdef USE_TEMPLEOS_ABI
         goto stk;
-        #endif
+#endif
         if (ireg_arg_cnt < 8) {
-					fun_arg.mode = MD_REG;
-					fun_arg.raw_type = RT_I64i;
-					fun_arg.reg = ireg_arg_cnt++;
-				} else
-					goto stk;
-			}
-			// This *shoudlnt* mutate any of the argument registers
-			if (lst->reg >= 0 && lst->reg != REG_NONE) {
-				write_to.mode = MD_REG;
-				write_to.reg = lst->reg;
-				write_to.off = 0;
-				write_to.raw_type = lst->member_class->raw_type;
-			} else {
-				write_to.mode = MD_FRAME;
-				write_to.off = lst->off + 16; // We added 16 for FP/LR everywhere else
-				write_to.raw_type = lst->member_class->raw_type;
-			}
-			lst = lst->next;
-			code_off = ICMov(cctrl, &write_to, &fun_arg, bin, code_off);
-		}
-	} else {
-		// Things from the HolyC side use __IC_ARG
-		// We go backwards as this is REVERSE polish notation
-		for (rpn = cctrl->code_ctrl->ir_code->last; rpn != cctrl->code_ctrl->ir_code; rpn = rpn->base.last) {
-			if (rpn->type == __IC_ARG) {
-				if ((arg = ICArgN(rpn, 0))->raw_type == RT_F64) {
-					#ifdef USE_TEMPLEOS_ABI
+          fun_arg.mode = MD_REG;
+          fun_arg.raw_type = RT_I64i;
+          fun_arg.reg = ireg_arg_cnt++;
+        } else
+          goto stk;
+      }
+      // This *shoudlnt* mutate any of the argument registers
+      if (lst->reg >= 0 && lst->reg != REG_NONE) {
+        write_to.mode = MD_REG;
+        write_to.reg = lst->reg;
+        write_to.off = 0;
+        write_to.raw_type = lst->member_class->raw_type;
+      } else {
+        write_to.mode = MD_FRAME;
+        write_to.off = lst->off + 16; // We added 16 for FP/LR everywhere else
+        write_to.raw_type = lst->member_class->raw_type;
+      }
+      lst = lst->next;
+      code_off = ICMov(cctrl, &write_to, &fun_arg, bin, code_off);
+    }
+  } else {
+    // Things from the HolyC side use __IC_ARG
+    // We go backwards as this is REVERSE polish notation
+    for (rpn = cctrl->code_ctrl->ir_code->last;
+         rpn != cctrl->code_ctrl->ir_code; rpn = rpn->base.last) {
+      if (rpn->type == __IC_ARG) {
+        if ((arg = ICArgN(rpn, 0))->raw_type == RT_F64) {
+#ifdef USE_TEMPLEOS_ABI
           goto stk2;
-          #endif
+#endif
           if (freg_arg_cnt < 8) {
-						fun_arg.mode = MD_REG;
-						fun_arg.raw_type = RT_F64;
-						fun_arg.reg = freg_arg_cnt++;
-					} else {
-					stk2:
-						fun_arg.mode = MD_FRAME;
-						fun_arg.raw_type = arg->raw_type;
-						if (arg->raw_type < RT_I64i)
-							arg->raw_type = RT_I64i;
-						fun_arg.off = to_push + stk_arg_cnt++ * 8;
-					}
-				} else {
-          #ifdef USE_TEMPLEOS_ABI
+            fun_arg.mode = MD_REG;
+            fun_arg.raw_type = RT_F64;
+            fun_arg.reg = freg_arg_cnt++;
+          } else {
+          stk2:
+            fun_arg.mode = MD_FRAME;
+            fun_arg.raw_type = arg->raw_type;
+            if (arg->raw_type < RT_I64i)
+              arg->raw_type = RT_I64i;
+            fun_arg.off = to_push + stk_arg_cnt++ * 8;
+          }
+        } else {
+#ifdef USE_TEMPLEOS_ABI
           goto stk2;
-          #endif
-					if (ireg_arg_cnt < 8) {
-						fun_arg.mode = MD_REG;
-						fun_arg.raw_type = RT_I64i;
-						fun_arg.reg = ireg_arg_cnt++;
-					} else
-						goto stk2;
-				}
+#endif
+          if (ireg_arg_cnt < 8) {
+            fun_arg.mode = MD_REG;
+            fun_arg.raw_type = RT_I64i;
+            fun_arg.reg = ireg_arg_cnt++;
+          } else
+            goto stk2;
+        }
 
-				PushTmp(cctrl, arg, NULL); // This will default to the things reg/frame address
-				code_off = ICMov(cctrl, &arg->res, &fun_arg, bin, code_off);
-				PopTmp(cctrl, arg);
-			}
-		}
-	}
-	return code_off;
+        PushTmp(cctrl, arg,
+                NULL); // This will default to the things reg/frame address
+        code_off = ICMov(cctrl, &arg->res, &fun_arg, bin, code_off);
+        PopTmp(cctrl, arg);
+      }
+    }
+  }
+  return code_off;
 }
 
 //
 // DO NOT CHANGE WITHOUT LOOKING CLOSEY AT FuncProlog
 //
-static int64_t FuncEpilog(CCmpCtrl* cctrl, char* bin, int64_t code_off)
-{
-	char push_ireg[32], ilist[32];
-	char push_freg[32], flist[32];
-	int64_t i, r, r2, fsz, i2, i3, off;
-	CICArg spill_loc = { 0 }, write_to = { 0 };
+static int64_t FuncEpilog(CCmpCtrl *cctrl, char *bin, int64_t code_off) {
+  char push_ireg[32], ilist[32];
+  char push_freg[32], flist[32];
+  int64_t i, r, r2, fsz, i2, i3, off;
+  CICArg spill_loc = {0}, write_to = {0};
   CCodeMiscRef *ref;
-	CRPN* rpn;
-	/* <== OLD SP
-	 * saved regs
-	 * wiggle room
-	 * locals
-	 * OLD FP,LR<===FP=SP
-	 */
-	if (cctrl->cur_fun)
-		fsz = cctrl->cur_fun->base.sz + 16; //+16 for LR/FP
-	else {
-		fsz = 16;
-		for (rpn = cctrl->code_ctrl->ir_code->next; rpn != cctrl->code_ctrl->ir_code; rpn = rpn->base.next) {
-			if (rpn->type == __IC_SET_FRAME_SIZE) {
-				fsz = rpn->integer;
-				break;
-			}
-		}
-	}
-	// ALIGN TO 8
-	if (fsz % 8)
-		fsz += 8 - fsz % 8;
-	int64_t to_push = (i2 = __FindPushedIRegs(cctrl, push_ireg)) * 8 + (i3 = __FindPushedFRegs(cctrl, push_freg)) * 8 + fsz + cctrl->backend_user_data0, old_regs_start; // old_FP,old_LR
-	if (i2 % 2)
-		to_push += 8; // We push a dummy register in a pair if not aligned to 2
-	if (i3 % 2)
-		to_push += 8; // Ditto
-	if (to_push % 16)
-		to_push += 8;
-	old_regs_start = fsz + cctrl->backend_user_data0;
-	i2 = 0;
-	for (i = 0; i != 32; i++)
-		if (push_ireg[i])
-			ilist[i2++] = i;
-	if (i2 % 2)
-		ilist[i2++] = 1; // Dont use 0 as it is a reutrn register
-	i3 = 0;
-	for (i = 0; i != 32; i++)
-		if (push_freg[i])
-			flist[i3++] = i;
-	if (i3 % 2)
-		flist[i3++] = 1; // Dont use 0 as it is a reutrn register
+  CRPN *rpn;
+  /* <== OLD SP
+   * saved regs
+   * wiggle room
+   * locals
+   * OLD FP,LR<===FP=SP
+   */
+  if (cctrl->cur_fun)
+    fsz = cctrl->cur_fun->base.sz + 16; //+16 for LR/FP
+  else {
+    fsz = 16;
+    for (rpn = cctrl->code_ctrl->ir_code->next;
+         rpn != cctrl->code_ctrl->ir_code; rpn = rpn->base.next) {
+      if (rpn->type == __IC_SET_FRAME_SIZE) {
+        fsz = rpn->integer;
+        break;
+      }
+    }
+  }
+  // ALIGN TO 8
+  if (fsz % 8)
+    fsz += 8 - fsz % 8;
+  int64_t to_push = (i2 = __FindPushedIRegs(cctrl, push_ireg)) * 8 +
+                    (i3 = __FindPushedFRegs(cctrl, push_freg)) * 8 + fsz +
+                    cctrl->backend_user_data0,
+          old_regs_start; // old_FP,old_LR
+  if (i2 % 2)
+    to_push += 8; // We push a dummy register in a pair if not aligned to 2
+  if (i3 % 2)
+    to_push += 8; // Ditto
+  if (to_push % 16)
+    to_push += 8;
+  old_regs_start = fsz + cctrl->backend_user_data0;
+  i2 = 0;
+  for (i = 0; i != 32; i++)
+    if (push_ireg[i])
+      ilist[i2++] = i;
+  if (i2 % 2)
+    ilist[i2++] = 1; // Dont use 0 as it is a reutrn register
+  i3 = 0;
+  for (i = 0; i != 32; i++)
+    if (push_freg[i])
+      flist[i3++] = i;
+  if (i3 % 2)
+    flist[i3++] = 1; // Dont use 0 as it is a reutrn register
 
-	AIWNIOS_ADD_CODE(ARM_ldpImmX(ARM_REG_FP, ARM_REG_LR, ARM_REG_SP, 0));
+  AIWNIOS_ADD_CODE(ARM_ldpImmX(ARM_REG_FP, ARM_REG_LR, ARM_REG_SP, 0));
 
-	if (ARM_ERR_INV_OFF != ARM_addImmX(ARM_REG_SP, ARM_REG_SP, to_push)) {
-		AIWNIOS_ADD_CODE(ARM_addImmX(ARM_REG_SP, ARM_REG_SP, to_push));
-	} else {
-		code_off = __ICMoveI64(cctrl, 8, to_push, bin, code_off);
-		AIWNIOS_ADD_CODE(ARM_addRegX(ARM_REG_SP, ARM_REG_SP, 8));
-	}
+  if (ARM_ERR_INV_OFF != ARM_addImmX(ARM_REG_SP, ARM_REG_SP, to_push)) {
+    AIWNIOS_ADD_CODE(ARM_addImmX(ARM_REG_SP, ARM_REG_SP, to_push));
+  } else {
+    code_off = __ICMoveI64(cctrl, 8, to_push, bin, code_off);
+    AIWNIOS_ADD_CODE(ARM_addRegX(ARM_REG_SP, ARM_REG_SP, 8));
+  }
 
-	off = 16;
-	//<==== OLD SP
-	// first saved reg pair<==-16
-	// next saved reg pair<===-32
-	//
-	for (i = 0; i != i2; i += 2) {
-		AIWNIOS_ADD_CODE(ARM_ldpImmX(ilist[i], ilist[i + 1], ARM_REG_SP, -off));
-		off += 16;
-	}
-	for (i = 0; i != i3; i += 2) {
-		AIWNIOS_ADD_CODE(ARM_ldpImmF64(flist[i], flist[i + 1], ARM_REG_SP, -off));
-		off += 16;
-	}
-	AIWNIOS_ADD_CODE(ARM_ret());
-	return code_off;
+  off = 16;
+  //<==== OLD SP
+  // first saved reg pair<==-16
+  // next saved reg pair<===-32
+  //
+  for (i = 0; i != i2; i += 2) {
+    AIWNIOS_ADD_CODE(ARM_ldpImmX(ilist[i], ilist[i + 1], ARM_REG_SP, -off));
+    off += 16;
+  }
+  for (i = 0; i != i3; i += 2) {
+    AIWNIOS_ADD_CODE(ARM_ldpImmF64(flist[i], flist[i + 1], ARM_REG_SP, -off));
+    off += 16;
+  }
+  AIWNIOS_ADD_CODE(ARM_ret());
+  return code_off;
 }
-static int64_t IsCompoundCompare(CRPN* r)
-{
-	CRPN* next = r->base.next;
-	switch (r->type) {
-	case IC_LT:
-	case IC_GT:
-	case IC_LE:
-	case IC_GE:
-		next = ICFwd(next);
-		switch (next->type) {
-		case IC_LT:
-		case IC_GT:
-		case IC_LE:
-		case IC_GE:
-			return 1;
-		}
-		return 0;
-		/*case IC_NE:
-	case IC_EQ_EQ:
-		next = ICFwd(next);
-		switch (next->type) {
-		case IC_EQ_EQ:
-		case IC_NE:
-			return 1;
-		}
-		return 0;
+static int64_t IsCompoundCompare(CRPN *r) {
+  CRPN *next = r->base.next;
+  switch (r->type) {
+  case IC_LT:
+  case IC_GT:
+  case IC_LE:
+  case IC_GE:
+    next = ICFwd(next);
+    switch (next->type) {
+    case IC_LT:
+    case IC_GT:
+    case IC_LE:
+    case IC_GE:
+      return 1;
+    }
+    return 0;
+    /*case IC_NE:
+  case IC_EQ_EQ:
+    next = ICFwd(next);
+    switch (next->type) {
+    case IC_EQ_EQ:
+    case IC_NE:
+      return 1;
+    }
+    return 0;
   */
-	}
-	return 0;
+  }
+  return 0;
 }
 //
 // ALWAYS ASSUME WORST CASE if we dont have a ALLOC'ed peice of RAM
 //
-static int64_t __OptPassFinal(CCmpCtrl* cctrl, CRPN* rpn, char* bin,
-	int64_t code_off)
-{
-	CCodeMisc* misc;
-	CCodeMiscRef* ref;
-	CRPN *next, *next2, **range, **range_args, *next3, *a, *b;
-	CICArg tmp = { 0 }, orig_dst = { 0 }, tmp2 = { 0 };
-	int64_t i = 0, cnt, i2, use_reg, a_reg, b_reg, into_reg, use_flt_cmp, reverse;
-	int64_t *range_cmp_types, use_flags = rpn->res.set_flags, old_fail_addr=0, old_pass_addr=0;
-	rpn->res.set_flags = 0;
-	char *enter_addr2, *enter_addr, *exit_addr, **fail1_addr, **fail2_addr, ***range_fail_addrs;
-	if (cctrl->code_ctrl->dbg_info && cctrl->code_ctrl->final_pass && rpn->ic_line) { // Final run
-		if (MSize(cctrl->code_ctrl->dbg_info) / 8 > rpn->ic_line - cctrl->code_ctrl->min_ln) {
-			i = cctrl->code_ctrl->dbg_info[rpn->ic_line - cctrl->code_ctrl->min_ln];
-			if (!i)
-				cctrl->code_ctrl->dbg_info[rpn->ic_line - cctrl->code_ctrl->min_ln] = bin + code_off;
-			else if ((int64_t)bin + code_off < i)
-				cctrl->code_ctrl->dbg_info[rpn->ic_line - cctrl->code_ctrl->min_ln] = bin + code_off;
-		}
-	}
-	if (cctrl->backend_user_data5 && cctrl->backend_user_data6) {
-		old_fail_addr = cctrl->backend_user_data5;
-		old_pass_addr = cctrl->backend_user_data6;
-		cctrl->backend_user_data5 = 0;
-		cctrl->backend_user_data6 = 0;
-	}
-	switch (rpn->type) {
-		break;
-	case IC_SHORT_ADDR:
-		// This is used for function calls only!!!
-		abort();
-		break;
-	case IC_RELOC:
-		if (rpn->res.mode == MD_REG)
-			into_reg = rpn->res.reg;
-		else
-			into_reg = 0;
-		misc = rpn->code_misc;
-		i = -code_off + misc->aot_before_hint;
-		// See __HC_SetAOTRelocBeforeRIP(Seriously read it)
-		if ((cctrl->flags & CCF_AOT_COMPILE) && (ARM_ERR_INV_OFF != ARM_adrX(into_reg, i)) && misc->aot_before_hint < 0) {
-			AIWNIOS_ADD_CODE(ARM_adrX(into_reg, i));
-		} else {
-			misc->use_cnt++;
-			AIWNIOS_ADD_CODE(ARM_ldrLabelX(into_reg, 0));
-			if (bin) {
-				ref=CodeMiscAddRef(misc, bin + code_off - 4);
-        ref->patch_cond_br=ARM_ldrLabelX;
-        ref->user_data1=into_reg;
+static int64_t __OptPassFinal(CCmpCtrl *cctrl, CRPN *rpn, char *bin,
+                              int64_t code_off) {
+  CCodeMisc *misc;
+  CCodeMiscRef *ref;
+  CRPN *next, *next2, **range, **range_args, *next3, *a, *b;
+  CICArg tmp = {0}, orig_dst = {0}, tmp2 = {0};
+  int64_t i = 0, cnt, i2, use_reg, a_reg, b_reg, into_reg, use_flt_cmp, reverse;
+  int64_t *range_cmp_types, use_flags = rpn->res.set_flags, old_fail_addr = 0,
+                            old_pass_addr = 0;
+  rpn->res.set_flags = 0;
+  char *enter_addr2, *enter_addr, *exit_addr, **fail1_addr, **fail2_addr,
+      ***range_fail_addrs;
+  if (cctrl->code_ctrl->dbg_info && cctrl->code_ctrl->final_pass &&
+      rpn->ic_line) { // Final run
+    if (MSize(cctrl->code_ctrl->dbg_info) / 8 >
+        rpn->ic_line - cctrl->code_ctrl->min_ln) {
+      i = cctrl->code_ctrl->dbg_info[rpn->ic_line - cctrl->code_ctrl->min_ln];
+      if (!i)
+        cctrl->code_ctrl->dbg_info[rpn->ic_line - cctrl->code_ctrl->min_ln] =
+            bin + code_off;
+      else if ((int64_t)bin + code_off < i)
+        cctrl->code_ctrl->dbg_info[rpn->ic_line - cctrl->code_ctrl->min_ln] =
+            bin + code_off;
+    }
+  }
+  if (cctrl->backend_user_data5 && cctrl->backend_user_data6) {
+    old_fail_addr = cctrl->backend_user_data5;
+    old_pass_addr = cctrl->backend_user_data6;
+    cctrl->backend_user_data5 = 0;
+    cctrl->backend_user_data6 = 0;
+  }
+  switch (rpn->type) {
+    break;
+  case IC_SHORT_ADDR:
+    // This is used for function calls only!!!
+    abort();
+    break;
+  case IC_RELOC:
+    if (rpn->res.mode == MD_REG)
+      into_reg = rpn->res.reg;
+    else
+      into_reg = 0;
+    misc = rpn->code_misc;
+    i = -code_off + misc->aot_before_hint;
+    // See __HC_SetAOTRelocBeforeRIP(Seriously read it)
+    if ((cctrl->flags & CCF_AOT_COMPILE) &&
+        (ARM_ERR_INV_OFF != ARM_adrX(into_reg, i)) &&
+        misc->aot_before_hint < 0) {
+      AIWNIOS_ADD_CODE(ARM_adrX(into_reg, i));
+    } else {
+      misc->use_cnt++;
+      AIWNIOS_ADD_CODE(ARM_ldrLabelX(into_reg, 0));
+      if (bin) {
+        ref = CodeMiscAddRef(misc, bin + code_off - 4);
+        ref->patch_cond_br = ARM_ldrLabelX;
+        ref->user_data1 = into_reg;
       }
-		}
-		if (rpn->res.mode != MD_REG) {
-			tmp.mode = MD_REG;
-			tmp.raw_type = RT_I64i;
-			tmp.reg = 0;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		}
-		break;
-	case IC_GOTO_IF:
-		reverse = 0;
-		next = rpn->base.next;
-	gti_enter:
-		if (!IsCompoundCompare(next))
-			switch (next->type) {
-				break;
-			case IC_LNOT:
-				reverse = !reverse;
-				next = next->base.next;
-				goto gti_enter;
-				break;
-			case IC_EQ_EQ:
-#define CMP_AND_JMP(COND)                                                                            \
-	{                                                                                                \
-		next3 = next->base.next;                                                                     \
-		next2 = ICFwd(next3);                                                                        \
-		PushTmp(cctrl, next2, NULL);                                                                 \
-		if (SpillsTmpRegs(next2))                                                                    \
-			PushSpilledTmp(cctrl, next3);                                                            \
-		else                                                                                         \
-			PushTmp(cctrl, next3, NULL);                                                             \
-		code_off = __OptPassFinal(cctrl, next3, bin, code_off);                                      \
-		code_off = __OptPassFinal(cctrl, next2, bin, code_off);                                      \
-		if (next3->raw_type == RT_F64 || next2->raw_type == RT_F64) {                                \
-			code_off = PutICArgIntoReg(cctrl, &next2->res, RT_F64, 2, bin, code_off);                \
-			code_off = PutICArgIntoReg(cctrl, &next3->res, RT_F64, 3, bin, code_off);                \
-			AIWNIOS_ADD_CODE(ARM_fcmp(next2->res.reg, next3->res.reg));                              \
-		} else {                                                                                     \
-			code_off = PutICArgIntoReg(cctrl, &next2->res, RT_I64i, 2, bin, code_off);               \
-			code_off = PutICArgIntoReg(cctrl, &next3->res, RT_I64i, 3, bin, code_off);               \
-			AIWNIOS_ADD_CODE(ARM_cmpRegX(next2->res.reg, next3->res.reg));                           \
-		}                                                                                            \
-		PopTmp(cctrl, next3);                                                                        \
-		PopTmp(cctrl, next2);                                                                        \
-		if (cctrl->code_ctrl->final_pass) {                                                          \
-			if (reverse) {                                                                           \
-				AIWNIOS_ADD_CODE(ARM_bcc(COND ^ 1, 0)); \
-			} else                                                                                   \
-				AIWNIOS_ADD_CODE(ARM_bcc(COND,0));     \
-			if (bin) {                                                                                 \
-				ref=CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);                    \
-        ref->patch_cond_br=ARM_bcc; \
-        ref->user_data1=reverse?COND^1:COND; \
-      } \
-		} else                                                                                       \
-			AIWNIOS_ADD_CODE(0);                                                                     \
-	}
-				CMP_AND_JMP(ARM_EQ);
-				return code_off;
-				break;
-			case IC_NE:
-				CMP_AND_JMP(ARM_NE);
-				return code_off;
-				break;
-			case IC_LT:
-				next3 = next->base.next;
-				next2 = ICFwd(next3);
-				if (next3->raw_type == RT_U64i || next2->raw_type == RT_U64i) {
-					CMP_AND_JMP(ARM_LO);
-				} else {
-					CMP_AND_JMP(ARM_LT);
-				}
-				return code_off;
-				break;
-			case IC_GT:
-				next3 = next->base.next;
-				next2 = ICFwd(next3);
-				if (next3->raw_type == RT_U64i || next2->raw_type == RT_U64i) {
-					CMP_AND_JMP(ARM_HI);
-				} else {
-					CMP_AND_JMP(ARM_GT);
-				}
-				return code_off;
-				break;
-			case IC_LE:
-				next3 = next->base.next;
-				next2 = ICFwd(next3);
-				if (next3->raw_type == RT_U64i || next2->raw_type == RT_U64i) {
-					CMP_AND_JMP(ARM_LS);
-				} else {
-					CMP_AND_JMP(ARM_LE);
-				}
-				return code_off;
-				break;
-			case IC_GE:
-				next3 = next->base.next;
-				next2 = ICFwd(next3);
-				if (next3->raw_type == RT_U64i || next2->raw_type == RT_U64i) {
-					CMP_AND_JMP(ARM_HS);
-				} else {
-					CMP_AND_JMP(ARM_GE);
-				}
-				return code_off;
-			}
+    }
+    if (rpn->res.mode != MD_REG) {
+      tmp.mode = MD_REG;
+      tmp.raw_type = RT_I64i;
+      tmp.reg = 0;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    }
+    break;
+  case IC_GOTO_IF:
+    reverse = 0;
+    next = rpn->base.next;
+  gti_enter:
+    if (!IsCompoundCompare(next))
+      switch (next->type) {
+        break;
+      case IC_LNOT:
+        reverse = !reverse;
+        next = next->base.next;
+        goto gti_enter;
+        break;
+      case IC_EQ_EQ:
+#define CMP_AND_JMP(COND)                                                      \
+  {                                                                            \
+    next3 = next->base.next;                                                   \
+    next2 = ICFwd(next3);                                                      \
+    PushTmp(cctrl, next2, NULL);                                               \
+    if (SpillsTmpRegs(next2))                                                  \
+      PushSpilledTmp(cctrl, next3);                                            \
+    else                                                                       \
+      PushTmp(cctrl, next3, NULL);                                             \
+    code_off = __OptPassFinal(cctrl, next3, bin, code_off);                    \
+    code_off = __OptPassFinal(cctrl, next2, bin, code_off);                    \
+    if (next3->raw_type == RT_F64 || next2->raw_type == RT_F64) {              \
+      code_off =                                                               \
+          PutICArgIntoReg(cctrl, &next2->res, RT_F64, 2, bin, code_off);       \
+      code_off =                                                               \
+          PutICArgIntoReg(cctrl, &next3->res, RT_F64, 3, bin, code_off);       \
+      AIWNIOS_ADD_CODE(ARM_fcmp(next2->res.reg, next3->res.reg));              \
+    } else {                                                                   \
+      code_off =                                                               \
+          PutICArgIntoReg(cctrl, &next2->res, RT_I64i, 2, bin, code_off);      \
+      code_off =                                                               \
+          PutICArgIntoReg(cctrl, &next3->res, RT_I64i, 3, bin, code_off);      \
+      AIWNIOS_ADD_CODE(ARM_cmpRegX(next2->res.reg, next3->res.reg));           \
+    }                                                                          \
+    PopTmp(cctrl, next3);                                                      \
+    PopTmp(cctrl, next2);                                                      \
+    if (cctrl->code_ctrl->final_pass) {                                        \
+      if (reverse) {                                                           \
+        AIWNIOS_ADD_CODE(ARM_bcc(COND ^ 1, 0));                                \
+      } else                                                                   \
+        AIWNIOS_ADD_CODE(ARM_bcc(COND, 0));                                    \
+      if (bin) {                                                               \
+        ref = CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);              \
+        ref->patch_cond_br = ARM_bcc;                                          \
+        ref->user_data1 = reverse ? COND ^ 1 : COND;                           \
+      }                                                                        \
+    } else                                                                     \
+      AIWNIOS_ADD_CODE(0);                                                     \
+  }
+        CMP_AND_JMP(ARM_EQ);
+        return code_off;
+        break;
+      case IC_NE:
+        CMP_AND_JMP(ARM_NE);
+        return code_off;
+        break;
+      case IC_LT:
+        next3 = next->base.next;
+        next2 = ICFwd(next3);
+        if (next3->raw_type == RT_U64i || next2->raw_type == RT_U64i) {
+          CMP_AND_JMP(ARM_LO);
+        } else {
+          CMP_AND_JMP(ARM_LT);
+        }
+        return code_off;
+        break;
+      case IC_GT:
+        next3 = next->base.next;
+        next2 = ICFwd(next3);
+        if (next3->raw_type == RT_U64i || next2->raw_type == RT_U64i) {
+          CMP_AND_JMP(ARM_HI);
+        } else {
+          CMP_AND_JMP(ARM_GT);
+        }
+        return code_off;
+        break;
+      case IC_LE:
+        next3 = next->base.next;
+        next2 = ICFwd(next3);
+        if (next3->raw_type == RT_U64i || next2->raw_type == RT_U64i) {
+          CMP_AND_JMP(ARM_LS);
+        } else {
+          CMP_AND_JMP(ARM_LE);
+        }
+        return code_off;
+        break;
+      case IC_GE:
+        next3 = next->base.next;
+        next2 = ICFwd(next3);
+        if (next3->raw_type == RT_U64i || next2->raw_type == RT_U64i) {
+          CMP_AND_JMP(ARM_HS);
+        } else {
+          CMP_AND_JMP(ARM_GE);
+        }
+        return code_off;
+      }
 
     PushTmp(cctrl, next, NULL);
     if (!rpn->code_misc2)
@@ -2596,251 +2648,256 @@ static int64_t __OptPassFinal(CCmpCtrl* cctrl, CRPN* rpn, char* bin,
       code_off = __OptPassFinal(cctrl, next, bin, code_off);
       rpn->code_misc2->addr = bin + code_off;
     }
-		PopTmp(cctrl, next);
-		break;
-		// These both do the same thing,only thier type detirmines what happens
-	case IC_TO_F64:
-	case IC_TO_I64:
-		PushTmp(cctrl, next = rpn->base.next, &rpn->res);
-		code_off = __OptPassFinal(cctrl, next, bin, code_off);
-		code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
-		PopTmp(cctrl, next);
-		break;
-	case IC_TYPECAST:
-		next = rpn->base.next;
-		PushTmp(cctrl, next, &rpn->res);
-		if (next->raw_type == RT_F64 && rpn->raw_type != RT_F64) {
-			code_off = __OptPassFinal(cctrl, next, bin, code_off);
-			code_off = PutICArgIntoReg(cctrl, &next->res, next->raw_type, 0, bin, code_off);
-			if (rpn->res.reg == MD_REG) {
-				AIWNIOS_ADD_CODE(ARM_fmovI64F64(rpn->res.reg, next->res.reg));
-			} else {
-				AIWNIOS_ADD_CODE(ARM_fmovI64F64(1, next->res.reg));
-				tmp.mode = MD_REG;
-				tmp.raw_type = RT_I64i;
-				tmp.reg = 1;
-				code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-			}
-		} else if (next->raw_type != RT_F64 && rpn->raw_type == RT_F64) {
-			code_off = __OptPassFinal(cctrl, next, bin, code_off);
-			code_off = PutICArgIntoReg(cctrl, &next->res, next->raw_type, 0, bin, code_off);
-			if (rpn->res.mode == MD_REG) {
-				AIWNIOS_ADD_CODE(ARM_fmovF64I64(rpn->res.reg, next->res.reg));
-			} else {
-				AIWNIOS_ADD_CODE(ARM_fmovF64I64(1, next->res.reg));
-				tmp.mode = MD_REG;
-				tmp.raw_type = RT_F64;
-				tmp.reg = 1;
-				code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-			}
-		} else if (next->type == IC_DEREF) {
-			code_off = DerefToICArg(cctrl, &tmp, next, 1, bin, code_off);
-			tmp.raw_type = rpn->raw_type;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		} else {
-			code_off = __OptPassFinal(cctrl, next, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
-		}
-		PopTmp(cctrl, next);
-		break;
-	case IC_GOTO:
-		if (cctrl->code_ctrl->final_pass) {
-			AIWNIOS_ADD_CODE(ARM_b(0));
-			if (bin) {
-				ref=CodeMiscAddRef(rpn->code_misc, code_off + bin - 4);
-        ref->patch_uncond_br=ARM_b;
+    PopTmp(cctrl, next);
+    break;
+    // These both do the same thing,only thier type detirmines what happens
+  case IC_TO_F64:
+  case IC_TO_I64:
+    PushTmp(cctrl, next = rpn->base.next, &rpn->res);
+    code_off = __OptPassFinal(cctrl, next, bin, code_off);
+    code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
+    PopTmp(cctrl, next);
+    break;
+  case IC_TYPECAST:
+    next = rpn->base.next;
+    PushTmp(cctrl, next, &rpn->res);
+    if (next->raw_type == RT_F64 && rpn->raw_type != RT_F64) {
+      code_off = __OptPassFinal(cctrl, next, bin, code_off);
+      code_off =
+          PutICArgIntoReg(cctrl, &next->res, next->raw_type, 0, bin, code_off);
+      if (rpn->res.reg == MD_REG) {
+        AIWNIOS_ADD_CODE(ARM_fmovI64F64(rpn->res.reg, next->res.reg));
+      } else {
+        AIWNIOS_ADD_CODE(ARM_fmovI64F64(1, next->res.reg));
+        tmp.mode = MD_REG;
+        tmp.raw_type = RT_I64i;
+        tmp.reg = 1;
+        code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
       }
-		} else
-			AIWNIOS_ADD_CODE(ARM_b(0));
-		break;
-	case IC_LABEL:
-		rpn->code_misc->addr = bin + code_off;
-		break;
-	case IC_GLOBAL:
-		//
-		// Here's the deal. Global arrays should be acceessed via
-		// IC_ADDR_OF. So loading int register here
-		//
-		if (rpn->global_var->base.type & HTT_FUN) {
-			next = rpn;
-			goto get_glbl_ptr;
-		} else {
-			assert(!rpn->global_var->dim.next);
-			tmp.mode = MD_PTR;
-			tmp.off = rpn->global_var->data_addr;
-			tmp.raw_type = rpn->global_var->var_class->raw_type;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		}
-		break;
-	case IC_NOP:
-		// Bungis
-		break;
-	case IC_PAREN:
-		abort();
-		break;
-	case IC_NEG:
-#define BACKEND_UNOP(flt_op, int_op)                                                \
-	next = rpn->base.next;                                                          \
-	PushTmp(cctrl, next, &rpn->res);                                                \
-	code_off = __OptPassFinal(cctrl, next, bin, code_off);                          \
-	PopTmp(cctrl, next);                                                            \
-	if (rpn->res.mode == MD_REG) {                                                  \
-		into_reg = rpn->res.reg;                                                    \
-	} else                                                                          \
-		into_reg = 0;                                                               \
-	code_off = PutICArgIntoReg(cctrl, &next->res, rpn->raw_type, 0, bin, code_off); \
-	if (rpn->raw_type == RT_F64) {                                                  \
-		AIWNIOS_ADD_CODE(flt_op(into_reg, next->res.reg));                          \
-	} else                                                                          \
-		AIWNIOS_ADD_CODE(int_op(into_reg, next->res.reg));                          \
-	if (rpn->res.mode != MD_REG) {                                                  \
-		tmp.raw_type = rpn->raw_type;                                               \
-		tmp.reg = 0;                                                                \
-		tmp.mode = MD_REG;                                                          \
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);                    \
-	}
-		BACKEND_UNOP(ARM_fnegReg, ARM_negsRegX);
-		break;
-	case IC_POS:
-		BACKEND_UNOP(ARM_fmovReg, ARM_movRegX);
-		break;
-	case IC_NAME:
-		abort();
-		break;
-	case IC_STR:
-		if (rpn->res.mode == MD_REG) {
-			into_reg = rpn->res.reg;
-		} else
-			into_reg = 0; // Store into reg 0
+    } else if (next->raw_type != RT_F64 && rpn->raw_type == RT_F64) {
+      code_off = __OptPassFinal(cctrl, next, bin, code_off);
+      code_off =
+          PutICArgIntoReg(cctrl, &next->res, next->raw_type, 0, bin, code_off);
+      if (rpn->res.mode == MD_REG) {
+        AIWNIOS_ADD_CODE(ARM_fmovF64I64(rpn->res.reg, next->res.reg));
+      } else {
+        AIWNIOS_ADD_CODE(ARM_fmovF64I64(1, next->res.reg));
+        tmp.mode = MD_REG;
+        tmp.raw_type = RT_F64;
+        tmp.reg = 1;
+        code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+      }
+    } else if (next->type == IC_DEREF) {
+      code_off = DerefToICArg(cctrl, &tmp, next, 1, bin, code_off);
+      tmp.raw_type = rpn->raw_type;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    } else {
+      code_off = __OptPassFinal(cctrl, next, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
+    }
+    PopTmp(cctrl, next);
+    break;
+  case IC_GOTO:
+    if (cctrl->code_ctrl->final_pass) {
+      AIWNIOS_ADD_CODE(ARM_b(0));
+      if (bin) {
+        ref = CodeMiscAddRef(rpn->code_misc, code_off + bin - 4);
+        ref->patch_uncond_br = ARM_b;
+      }
+    } else
+      AIWNIOS_ADD_CODE(ARM_b(0));
+    break;
+  case IC_LABEL:
+    rpn->code_misc->addr = bin + code_off;
+    break;
+  case IC_GLOBAL:
+    //
+    // Here's the deal. Global arrays should be acceessed via
+    // IC_ADDR_OF. So loading int register here
+    //
+    if (rpn->global_var->base.type & HTT_FUN) {
+      next = rpn;
+      goto get_glbl_ptr;
+    } else {
+      assert(!rpn->global_var->dim.next);
+      tmp.mode = MD_PTR;
+      tmp.off = rpn->global_var->data_addr;
+      tmp.raw_type = rpn->global_var->var_class->raw_type;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    }
+    break;
+  case IC_NOP:
+    // Bungis
+    break;
+  case IC_PAREN:
+    abort();
+    break;
+  case IC_NEG:
+#define BACKEND_UNOP(flt_op, int_op)                                           \
+  next = rpn->base.next;                                                       \
+  PushTmp(cctrl, next, &rpn->res);                                             \
+  code_off = __OptPassFinal(cctrl, next, bin, code_off);                       \
+  PopTmp(cctrl, next);                                                         \
+  if (rpn->res.mode == MD_REG) {                                               \
+    into_reg = rpn->res.reg;                                                   \
+  } else                                                                       \
+    into_reg = 0;                                                              \
+  code_off =                                                                   \
+      PutICArgIntoReg(cctrl, &next->res, rpn->raw_type, 0, bin, code_off);     \
+  if (rpn->raw_type == RT_F64) {                                               \
+    AIWNIOS_ADD_CODE(flt_op(into_reg, next->res.reg));                         \
+  } else                                                                       \
+    AIWNIOS_ADD_CODE(int_op(into_reg, next->res.reg));                         \
+  if (rpn->res.mode != MD_REG) {                                               \
+    tmp.raw_type = rpn->raw_type;                                              \
+    tmp.reg = 0;                                                               \
+    tmp.mode = MD_REG;                                                         \
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);                   \
+  }
+    BACKEND_UNOP(ARM_fnegReg, ARM_negsRegX);
+    break;
+  case IC_POS:
+    BACKEND_UNOP(ARM_fmovReg, ARM_movRegX);
+    break;
+  case IC_NAME:
+    abort();
+    break;
+  case IC_STR:
+    if (rpn->res.mode == MD_REG) {
+      into_reg = rpn->res.reg;
+    } else
+      into_reg = 0; // Store into reg 0
 
-		if (cctrl->flags & CCF_STRINGS_ON_HEAP) {
-			//
-			// README: We will "NULL"ify the rpn->code_misc->str later so we dont free it
-			//
-			code_off = __ICMoveI64(cctrl, into_reg, rpn->code_misc->str, bin, code_off);
-		} else {
-			if (cctrl->code_ctrl->final_pass) {
-				AIWNIOS_ADD_CODE(
-					ARM_adrX(into_reg, 0));
-				if (bin) {
-					ref=CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
-          ref->patch_cond_br=ARM_adrX;;
-          ref->user_data1=into_reg;
+    if (cctrl->flags & CCF_STRINGS_ON_HEAP) {
+      //
+      // README: We will "NULL"ify the rpn->code_misc->str later so we dont free
+      // it
+      //
+      code_off =
+          __ICMoveI64(cctrl, into_reg, rpn->code_misc->str, bin, code_off);
+    } else {
+      if (cctrl->code_ctrl->final_pass) {
+        AIWNIOS_ADD_CODE(ARM_adrX(into_reg, 0));
+        if (bin) {
+          ref = CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
+          ref->patch_cond_br = ARM_adrX;
+          ;
+          ref->user_data1 = into_reg;
         }
-			} else {
-				AIWNIOS_ADD_CODE(0);
-			}
-		}
-		if (rpn->res.mode != MD_REG) {
-			tmp.raw_type = rpn->raw_type;
-			tmp.reg = 0;
-			tmp.mode = MD_REG;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		}
-		break;
-	case IC_CHR:
-		if (rpn->res.mode == MD_REG) {
-			into_reg = rpn->res.reg;
-		} else
-			into_reg = 0; // Store into reg 0
-
-		code_off = __ICMoveI64(cctrl, into_reg, rpn->integer, bin, code_off);
-
-		if (rpn->res.mode != MD_REG) {
-			tmp.raw_type = rpn->raw_type;
-			tmp.reg = 0;
-			tmp.mode = MD_REG;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		}
-		break;
-	case IC_POW:
-		// TODO
-		break;
-		break;
-	case IC_UNBOUNDED_SWITCH:
-		//
-		// Load poop into tmp,then we continue the sexyness as normal
-		//
-		// Also make sure X1 has lo bound(See IC_BOUNDED_SWITCH)
-		//
-		next2 = ICArgN(rpn, 0);
-		PushTmp(cctrl, next2, NULL);
-		PopTmp(cctrl, next2);
-		tmp.raw_type = RT_I64i;
-		tmp.mode = MD_REG;
-		tmp.reg = 0;
-		code_off = ICMov(cctrl, &tmp, &next2->res, bin, code_off);
-		code_off = __ICMoveI64(cctrl, 1, rpn->code_misc->lo, bin, code_off); // X1
-		goto jmp_tab_sexy;
-		break;
-	case IC_BOUNDED_SWITCH:
-		next2 = ICArgN(rpn, 0);
-		PushTmp(cctrl, next2, NULL);
-		code_off = __OptPassFinal(cctrl, next2, bin, code_off);
-		PopTmp(cctrl, next2);
-		tmp.raw_type = RT_I64i;
-		tmp.mode = MD_REG;
-		tmp.reg = 0;
-		code_off = ICMov(cctrl, &tmp, &next2->res, bin, code_off);
-		code_off = __ICMoveI64(cctrl, 1, rpn->code_misc->lo, bin, code_off);
-		code_off = __ICMoveI64(cctrl, 2, rpn->code_misc->hi, bin, code_off);
-		AIWNIOS_ADD_CODE(ARM_cmpRegX(tmp.reg, 1));
-		fail1_addr = bin + code_off;
-		AIWNIOS_ADD_CODE(ARM_bcc(ARM_LT, 0));
-		AIWNIOS_ADD_CODE(ARM_cmpRegX(tmp.reg, 2));
-		fail2_addr = bin + code_off;
-		AIWNIOS_ADD_CODE(ARM_bcc(ARM_GT, 0));
-	jmp_tab_sexy:
-		//
-		// See LAMA snail
-		//
-		// The jump table offsets are relative to the start of the function
-		//   to make it so the code is Position-Independant
-		AIWNIOS_ADD_CODE(ARM_subRegX(tmp.reg, tmp.reg, 1)); // 1 has low bound
-		if (cctrl->code_ctrl->final_pass) {
-			AIWNIOS_ADD_CODE(
-				ARM_adrX(2, 0));
-			if (bin) {
-				ref=CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
-        ref->patch_cond_br=ARM_adrX;;
-        ref->user_data1=2;
+      } else {
+        AIWNIOS_ADD_CODE(0);
       }
-		} else {
-			AIWNIOS_ADD_CODE(0);
-		}
-		AIWNIOS_ADD_CODE(ARM_ldrRegRegShiftX(tmp.reg, 2, tmp.reg));
-		// Load the function base address
-		AIWNIOS_ADD_CODE(ARM_br(tmp.reg));
-		if (rpn->type == IC_BOUNDED_SWITCH && cctrl->code_ctrl->final_pass) {
-			ref=CodeMiscAddRef(rpn->code_misc->dft_lab, fail1_addr);
-      ref->patch_cond_br=ARM_bcc;
-      ref->user_data1=ARM_LT;
-			ref=CodeMiscAddRef(rpn->code_misc->dft_lab, fail2_addr);
-      ref->patch_cond_br=ARM_bcc;
-      ref->user_data1=ARM_GT;
-		}
-		break;
-	case IC_SUB_RET:
-		AIWNIOS_ADD_CODE(ARM_ldrPostImmX(ARM_REG_LR, ARM_REG_SP, 16));
-		AIWNIOS_ADD_CODE(ARM_ret());
-		break;
-	case IC_SUB_PROLOG:
-		break;
-	case IC_SUB_CALL:
-		// adr LR,exit +0
-		// str LR,[sp-=16] +4
-		// b start_enter +8
-		// exit: +12
-		AIWNIOS_ADD_CODE(ARM_adrX(ARM_REG_LR, 12));
-		AIWNIOS_ADD_CODE(ARM_strPreImmX(ARM_REG_LR, ARM_REG_SP, -16));
-		if (cctrl->code_ctrl->final_pass) {
-			AIWNIOS_ADD_CODE(ARM_b(0)); 
-			ref=CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
-      ref->patch_uncond_br=ARM_b;
-		} else
-			AIWNIOS_ADD_CODE(0);
-		break;
-	case IC_ADD:
+    }
+    if (rpn->res.mode != MD_REG) {
+      tmp.raw_type = rpn->raw_type;
+      tmp.reg = 0;
+      tmp.mode = MD_REG;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    }
+    break;
+  case IC_CHR:
+    if (rpn->res.mode == MD_REG) {
+      into_reg = rpn->res.reg;
+    } else
+      into_reg = 0; // Store into reg 0
+
+    code_off = __ICMoveI64(cctrl, into_reg, rpn->integer, bin, code_off);
+
+    if (rpn->res.mode != MD_REG) {
+      tmp.raw_type = rpn->raw_type;
+      tmp.reg = 0;
+      tmp.mode = MD_REG;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    }
+    break;
+  case IC_POW:
+    // TODO
+    break;
+    break;
+  case IC_UNBOUNDED_SWITCH:
+    //
+    // Load poop into tmp,then we continue the sexyness as normal
+    //
+    // Also make sure X1 has lo bound(See IC_BOUNDED_SWITCH)
+    //
+    next2 = ICArgN(rpn, 0);
+    PushTmp(cctrl, next2, NULL);
+    PopTmp(cctrl, next2);
+    tmp.raw_type = RT_I64i;
+    tmp.mode = MD_REG;
+    tmp.reg = 0;
+    code_off = ICMov(cctrl, &tmp, &next2->res, bin, code_off);
+    code_off = __ICMoveI64(cctrl, 1, rpn->code_misc->lo, bin, code_off); // X1
+    goto jmp_tab_sexy;
+    break;
+  case IC_BOUNDED_SWITCH:
+    next2 = ICArgN(rpn, 0);
+    PushTmp(cctrl, next2, NULL);
+    code_off = __OptPassFinal(cctrl, next2, bin, code_off);
+    PopTmp(cctrl, next2);
+    tmp.raw_type = RT_I64i;
+    tmp.mode = MD_REG;
+    tmp.reg = 0;
+    code_off = ICMov(cctrl, &tmp, &next2->res, bin, code_off);
+    code_off = __ICMoveI64(cctrl, 1, rpn->code_misc->lo, bin, code_off);
+    code_off = __ICMoveI64(cctrl, 2, rpn->code_misc->hi, bin, code_off);
+    AIWNIOS_ADD_CODE(ARM_cmpRegX(tmp.reg, 1));
+    fail1_addr = bin + code_off;
+    AIWNIOS_ADD_CODE(ARM_bcc(ARM_LT, 0));
+    AIWNIOS_ADD_CODE(ARM_cmpRegX(tmp.reg, 2));
+    fail2_addr = bin + code_off;
+    AIWNIOS_ADD_CODE(ARM_bcc(ARM_GT, 0));
+  jmp_tab_sexy:
+    //
+    // See LAMA snail
+    //
+    // The jump table offsets are relative to the start of the function
+    //   to make it so the code is Position-Independant
+    AIWNIOS_ADD_CODE(ARM_subRegX(tmp.reg, tmp.reg, 1)); // 1 has low bound
+    if (cctrl->code_ctrl->final_pass) {
+      AIWNIOS_ADD_CODE(ARM_adrX(2, 0));
+      if (bin) {
+        ref = CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
+        ref->patch_cond_br = ARM_adrX;
+        ;
+        ref->user_data1 = 2;
+      }
+    } else {
+      AIWNIOS_ADD_CODE(0);
+    }
+    AIWNIOS_ADD_CODE(ARM_ldrRegRegShiftX(tmp.reg, 2, tmp.reg));
+    // Load the function base address
+    AIWNIOS_ADD_CODE(ARM_br(tmp.reg));
+    if (rpn->type == IC_BOUNDED_SWITCH && cctrl->code_ctrl->final_pass) {
+      ref = CodeMiscAddRef(rpn->code_misc->dft_lab, fail1_addr);
+      ref->patch_cond_br = ARM_bcc;
+      ref->user_data1 = ARM_LT;
+      ref = CodeMiscAddRef(rpn->code_misc->dft_lab, fail2_addr);
+      ref->patch_cond_br = ARM_bcc;
+      ref->user_data1 = ARM_GT;
+    }
+    break;
+  case IC_SUB_RET:
+    AIWNIOS_ADD_CODE(ARM_ldrPostImmX(ARM_REG_LR, ARM_REG_SP, 16));
+    AIWNIOS_ADD_CODE(ARM_ret());
+    break;
+  case IC_SUB_PROLOG:
+    break;
+  case IC_SUB_CALL:
+    // adr LR,exit +0
+    // str LR,[sp-=16] +4
+    // b start_enter +8
+    // exit: +12
+    AIWNIOS_ADD_CODE(ARM_adrX(ARM_REG_LR, 12));
+    AIWNIOS_ADD_CODE(ARM_strPreImmX(ARM_REG_LR, ARM_REG_SP, -16));
+    if (cctrl->code_ctrl->final_pass) {
+      AIWNIOS_ADD_CODE(ARM_b(0));
+      ref = CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
+      ref->patch_uncond_br = ARM_b;
+    } else
+      AIWNIOS_ADD_CODE(0);
+    break;
+  case IC_ADD:
 //
 //  /\   /\      ____
 //  ||___||     /    \
@@ -2856,965 +2913,996 @@ static int64_t __OptPassFinal(CCmpCtrl* cctrl, CRPN* rpn, char* bin,
 // LEFT ==> may have a MD_INDIR_REG(where reg is a tmp reg)
 // *LEFT=RIHGT ==> Write into the left's address
 //
-#define BACKEND_BINOP(f_op, i_op)                                                    \
-	next = ICArgN(rpn, 1);                                                           \
-	next2 = ICArgN(rpn, 0);                                                          \
-	orig_dst = next->res;                                                            \
-	if (!SpillsTmpRegs(next))                                                        \
-		PushTmp(cctrl, next2, NULL);                                                 \
-	else                                                                             \
-		PushSpilledTmp(cctrl, next2);                                                \
-	PushTmp(cctrl, next, &rpn->res);                                                 \
-	code_off = __OptPassFinal(cctrl, next2, bin, code_off);                          \
-	code_off = __OptPassFinal(cctrl, next, bin, code_off);                           \
-	PopTmp(cctrl, next2);                                                            \
-	PopTmp(cctrl, next);                                                             \
-	if (rpn->res.mode == MD_REG) {                                                   \
-		into_reg = rpn->res.reg;                                                     \
-	} else                                                                           \
-		into_reg = 0;                                                                \
-	code_off = PutICArgIntoReg(cctrl, &next->res, rpn->raw_type, 2, bin, code_off);  \
-	code_off = PutICArgIntoReg(cctrl, &next2->res, rpn->raw_type, 1, bin, code_off); \
-	if (rpn->raw_type == RT_F64) {                                                   \
-		AIWNIOS_ADD_CODE(f_op(into_reg, next->res.reg, next2->res.reg));             \
-	} else {                                                                         \
-		AIWNIOS_ADD_CODE(i_op(into_reg, next->res.reg, next2->res.reg));             \
-	}                                                                                \
-	if (rpn->res.mode != MD_REG && rpn->res.mode != MD_NULL) {                       \
-		tmp.raw_type = rpn->raw_type;                                                \
-		tmp.reg = 0;                                                                 \
-		tmp.mode = MD_REG;                                                           \
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);                     \
-	}
-#define BACKEND_BINOP_IMM(i_imm_op, i_op)                                                            \
-	next = ICArgN(rpn, 1);                                                                           \
-	next2 = ICArgN(rpn, 0);                                                                          \
-	if (rpn->raw_type != RT_F64 && IsConst(next2) && next2->type != IC_F64 && next2->integer >= 0) { \
-		PushTmp(cctrl, next, &rpn->res);                                                             \
-		code_off = __OptPassFinal(cctrl, next, bin, code_off);                                       \
-		code_off = PutICArgIntoReg(cctrl, &next->res, RT_I64i, 1, bin, code_off);                    \
-		if (rpn->res.mode == MD_REG)                                                                 \
-			into_reg = rpn->res.reg;                                                                 \
-		else                                                                                         \
-			into_reg = 0;                                                                            \
-		if (i_imm_op(into_reg, next->res.reg, next2->integer) != ARM_ERR_INV_OFF) {                  \
-			AIWNIOS_ADD_CODE(i_imm_op(into_reg, next->res.reg, next2->integer));                     \
-		} else {                                                                                     \
-			tmp.mode = MD_REG;                                                                       \
-			tmp.reg = 2;                                                                             \
-			tmp.raw_type = RT_I64i;                                                                  \
-			PushTmp(cctrl, next2, NULL);                                                             \
-			code_off = ICMov(cctrl, &tmp, &next2->res, bin, code_off);                               \
-			AIWNIOS_ADD_CODE(i_op(into_reg, next->res.reg, tmp.reg));                                \
-			PopTmp(cctrl, next2);                                                                    \
-		}                                                                                            \
-		if (rpn->res.mode != MD_REG && rpn->res.mode != MD_NULL) {                                   \
-			tmp.raw_type = rpn->raw_type;                                                            \
-			tmp.reg = 0;                                                                             \
-			tmp.mode = MD_REG;                                                                       \
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);                                 \
-		}                                                                                            \
-		PopTmp(cctrl, next);                                                                         \
-		break;                                                                                       \
-	}
-		if (use_flags && rpn->res.raw_type != RT_F64) {
-			rpn->res.set_flags = 1;
-			rpn->res.mode = MD_NULL;
-			BACKEND_BINOP_IMM(ARM_addsImmX, ARM_addsRegX);
-			BACKEND_BINOP(ARM_faddReg, ARM_addsRegX);
-		} else {
-			BACKEND_BINOP_IMM(ARM_addImmX, ARM_addRegX);
-			BACKEND_BINOP(ARM_faddReg, ARM_addRegX);
-		}
-		break;
-	case IC_COMMA:
-		next = ICArgN(rpn, 1);
-		next2 = ICArgN(rpn, 0);
-		orig_dst = next->res;
-		if (!SpillsTmpRegs(next))
-			PushTmp(cctrl, next2, NULL);
-		else
-			PushSpilledTmp(cctrl, next2);
-		PushTmp(cctrl, next, &rpn->res);
-		code_off = __OptPassFinal(cctrl, next2, bin, code_off);
-		code_off = __OptPassFinal(cctrl, next, bin, code_off);
-		PopTmp(cctrl, next);
-		PopTmp(cctrl, next2);
-		// TODO WHICH ONE
-		code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
-		break;
-	case IC_EQ:
-		next = ICArgN(rpn, 1);
-		next2 = ICArgN(rpn, 0);
-		orig_dst = next->res;
-		if (!SpillsTmpRegs(next))
-			PushTmp(cctrl, next2, NULL);
-		else
-			PushSpilledTmp(cctrl, next2);
-		code_off = __OptPassFinal(cctrl, next2, bin, code_off);
-		if (next->type == IC_TYPECAST) {
-			TYPECAST_ASSIGN_BEGIN(next, next2);
-			code_off = ICMov(cctrl, &next->res, &next2->res, bin, code_off);
-			TYPECAST_ASSIGN_END(next);
-		} else if (next->type == IC_DEREF) {
-			code_off = __SexyWriteIntoDst(cctrl, next, &next2->res, bin, code_off);
-		} else {
-			PushTmp(cctrl, next, &rpn->res);
-			code_off = __OptPassFinal(cctrl, next, bin, code_off);
-			PopTmp(cctrl, next);
-			code_off = ICMov(cctrl, &next->res, &next2->res, bin, code_off);
-		}
-		code_off = ICMov(cctrl, &rpn->res, &next2->res, bin, code_off);
-		PopTmp(cctrl, next2);
-		break;
-	case IC_SUB:
-		if (use_flags && rpn->res.raw_type != RT_F64) {
-			rpn->res.set_flags = 1;
-			rpn->res.mode = MD_NULL;
-			BACKEND_BINOP_IMM(ARM_subsImmX, ARM_subsRegX);
-			BACKEND_BINOP(ARM_fsubReg, ARM_subsRegX);
-		} else {
-			BACKEND_BINOP_IMM(ARM_subImmX, ARM_subRegX);
-			BACKEND_BINOP(ARM_fsubReg, ARM_subRegX);
-		}
-		break;
-	case IC_DIV:
-		next = rpn->base.next;
-		next2 = ICArgN(rpn, 1);
-		if (next->type == IC_I64 && next2->raw_type != RT_F64) {
-			if (__builtin_popcountll(next->integer) == 1) {
-				PushTmp(cctrl, next2, &rpn->res);
-				code_off = __OptPassFinal(cctrl, next2, bin, code_off);
-				code_off = PutICArgIntoReg(cctrl, &next2->res, next2->raw_type, 1, bin, code_off);
-				PopTmp(cctrl, next2);
-				switch (next2->raw_type) {
-				case RT_I8i:
-				case RT_I16i:
-				case RT_I32i:
-				case RT_I64i:
-					if (rpn->res.mode == MD_REG) {
-						AIWNIOS_ADD_CODE(ARM_asrImmX(rpn->res.reg, next2->res.reg, __builtin_ffsll(next->integer) - 1));
-					} else {
-						AIWNIOS_ADD_CODE(ARM_asrImmX(1, next2->res.reg, __builtin_ffsll(next->integer) - 1));
-						tmp.raw_type = RT_I64i;
-						tmp.reg = 1;
-						tmp.mode = MD_REG;
-						code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-					}
-					break;
-				default:
-					if (rpn->res.mode == MD_REG) {
-						AIWNIOS_ADD_CODE(ARM_lsrImmX(rpn->res.reg, next2->res.reg, __builtin_ffsll(next->integer) - 1));
-					} else {
-						AIWNIOS_ADD_CODE(ARM_lsrImmX(1, next2->res.reg, __builtin_ffsll(next->integer) - 1));
-						tmp.raw_type = RT_I64i;
-						tmp.reg = 1;
-						tmp.mode = MD_REG;
-						code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-					}
-				}
-				break;
-			}
-		}
-		if (rpn->raw_type == RT_U64i) {
-			BACKEND_BINOP(ARM_fdivReg, ARM_udivX);
-		} else {
-			BACKEND_BINOP(ARM_fdivReg, ARM_sdivRegX);
-		}
-		break;
-	case IC_MUL:
-		next = rpn->base.next;
-		next2 = ICArgN(rpn, 1);
-		if (next->type == IC_I64 && next2->raw_type != RT_F64) {
-			if (__builtin_popcountll(next->integer) == 1) {
-				PushTmp(cctrl, next2, &rpn->res);
-				code_off = __OptPassFinal(cctrl, next2, bin, code_off);
-				code_off = PutICArgIntoReg(cctrl, &next2->res, next2->raw_type, 1, bin, code_off);
-				PopTmp(cctrl, next2);
-				if (rpn->res.mode == MD_REG && rpn->raw_type != RT_F64) {
-					AIWNIOS_ADD_CODE(ARM_lslImmX(rpn->res.reg, next2->res.reg, __builtin_ffsll(next->integer) - 1));
-				} else {
-					AIWNIOS_ADD_CODE(ARM_lslImmX(1, next2->res.reg, __builtin_ffsll(next->integer) - 1));
-					tmp.raw_type = RT_I64i;
-					tmp.reg = 1;
-					tmp.mode = MD_REG;
-					code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-				}
-				break;
-			}
-		}
-		if (rpn->raw_type == RT_U64i) {
-			BACKEND_BINOP(ARM_fmulReg, ARM_umullX);
-		} else {
-			BACKEND_BINOP(ARM_fmulReg, ARM_mulRegX);
-		}
-		break;
-	case IC_DEREF:
-		next = rpn->base.next;
-		i = 0;
-		//
-		// Here's the Donald Trump deal,Derefernced function pointers
-		// don't derefence(you dont copy a function into memory).
-		//
-		// I64 (*fptr)()=&Foo;
-		// (*fptr)(); //Doesn't "dereference"
-		//
-		if (rpn->raw_type == RT_FUNC) {
-			PushTmp(cctrl, next, &rpn->res);
-			code_off = __OptPassFinal(cctrl, next, bin, code_off);
-			PopTmp(cctrl, next);
-			code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
-			return code_off;
-		}
-		code_off = DerefToICArg(cctrl, &tmp, rpn, 2, bin, code_off);
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		break;
-	case IC_AND:
-#define BACKEND_BIT_BINOP(bit_op, shift)                                     \
-	if (rpn->raw_type == RT_F64) {                                           \
-		next = ICArgN(rpn, 1);                                               \
-		next2 = ICArgN(rpn, 0);                                              \
-		PushTmp(cctrl, next, &rpn->res);                                     \
-		if (SpillsTmpRegs(next))                                             \
-			PushSpilledTmp(cctrl, next2);                                    \
-		else                                                                 \
-			PushTmp(cctrl, next2, NULL);                                     \
-		code_off = __OptPassFinal(cctrl, next2, bin, code_off);              \
-		code_off = __OptPassFinal(cctrl, next, bin, code_off);               \
-		code_off = FBitOp(cctrl, &rpn->res, &next->res, &next2->res, bit_op, \
-			shift, bin, code_off);                                           \
-	} else {                                                                 \
-		BACKEND_BINOP(bit_op, bit_op);                                       \
-	}
-		if (use_flags && rpn->res.raw_type != RT_F64) {
-			rpn->res.set_flags = 1;
-			rpn->res.mode = MD_NULL;
-			BACKEND_BINOP_IMM(ARM_andsImmX, ARM_andsRegX);
-			BACKEND_BIT_BINOP(ARM_andsRegX, 0);
-		} else {
-			BACKEND_BINOP_IMM(ARM_andImmX, ARM_andRegX);
-			BACKEND_BIT_BINOP(ARM_andRegX, 0);
-		}
-		break;
-	case IC_ADDR_OF:
-		next = rpn->base.next;
-		switch (next->type) {
-			break;
-		case __IC_STATIC_REF:
-			if (rpn->res.mode == MD_REG)
-				into_reg = rpn->res.reg;
-			else
-				into_reg = 0;
-			AIWNIOS_ADD_CODE(ARM_adrX(into_reg, 0));
-      if(bin) {
+#define BACKEND_BINOP(f_op, i_op)                                              \
+  next = ICArgN(rpn, 1);                                                       \
+  next2 = ICArgN(rpn, 0);                                                      \
+  orig_dst = next->res;                                                        \
+  if (!SpillsTmpRegs(next))                                                    \
+    PushTmp(cctrl, next2, NULL);                                               \
+  else                                                                         \
+    PushSpilledTmp(cctrl, next2);                                              \
+  PushTmp(cctrl, next, &rpn->res);                                             \
+  code_off = __OptPassFinal(cctrl, next2, bin, code_off);                      \
+  code_off = __OptPassFinal(cctrl, next, bin, code_off);                       \
+  PopTmp(cctrl, next2);                                                        \
+  PopTmp(cctrl, next);                                                         \
+  if (rpn->res.mode == MD_REG) {                                               \
+    into_reg = rpn->res.reg;                                                   \
+  } else                                                                       \
+    into_reg = 0;                                                              \
+  code_off =                                                                   \
+      PutICArgIntoReg(cctrl, &next->res, rpn->raw_type, 2, bin, code_off);     \
+  code_off =                                                                   \
+      PutICArgIntoReg(cctrl, &next2->res, rpn->raw_type, 1, bin, code_off);    \
+  if (rpn->raw_type == RT_F64) {                                               \
+    AIWNIOS_ADD_CODE(f_op(into_reg, next->res.reg, next2->res.reg));           \
+  } else {                                                                     \
+    AIWNIOS_ADD_CODE(i_op(into_reg, next->res.reg, next2->res.reg));           \
+  }                                                                            \
+  if (rpn->res.mode != MD_REG && rpn->res.mode != MD_NULL) {                   \
+    tmp.raw_type = rpn->raw_type;                                              \
+    tmp.reg = 0;                                                               \
+    tmp.mode = MD_REG;                                                         \
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);                   \
+  }
+#define BACKEND_BINOP_IMM(i_imm_op, i_op)                                      \
+  next = ICArgN(rpn, 1);                                                       \
+  next2 = ICArgN(rpn, 0);                                                      \
+  if (rpn->raw_type != RT_F64 && IsConst(next2) && next2->type != IC_F64 &&    \
+      next2->integer >= 0) {                                                   \
+    PushTmp(cctrl, next, &rpn->res);                                           \
+    code_off = __OptPassFinal(cctrl, next, bin, code_off);                     \
+    code_off = PutICArgIntoReg(cctrl, &next->res, RT_I64i, 1, bin, code_off);  \
+    if (rpn->res.mode == MD_REG)                                               \
+      into_reg = rpn->res.reg;                                                 \
+    else                                                                       \
+      into_reg = 0;                                                            \
+    if (i_imm_op(into_reg, next->res.reg, next2->integer) !=                   \
+        ARM_ERR_INV_OFF) {                                                     \
+      AIWNIOS_ADD_CODE(i_imm_op(into_reg, next->res.reg, next2->integer));     \
+    } else {                                                                   \
+      tmp.mode = MD_REG;                                                       \
+      tmp.reg = 2;                                                             \
+      tmp.raw_type = RT_I64i;                                                  \
+      PushTmp(cctrl, next2, NULL);                                             \
+      code_off = ICMov(cctrl, &tmp, &next2->res, bin, code_off);               \
+      AIWNIOS_ADD_CODE(i_op(into_reg, next->res.reg, tmp.reg));                \
+      PopTmp(cctrl, next2);                                                    \
+    }                                                                          \
+    if (rpn->res.mode != MD_REG && rpn->res.mode != MD_NULL) {                 \
+      tmp.raw_type = rpn->raw_type;                                            \
+      tmp.reg = 0;                                                             \
+      tmp.mode = MD_REG;                                                       \
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);                 \
+    }                                                                          \
+    PopTmp(cctrl, next);                                                       \
+    break;                                                                     \
+  }
+    if (use_flags && rpn->res.raw_type != RT_F64) {
+      rpn->res.set_flags = 1;
+      rpn->res.mode = MD_NULL;
+      BACKEND_BINOP_IMM(ARM_addsImmX, ARM_addsRegX);
+      BACKEND_BINOP(ARM_faddReg, ARM_addsRegX);
+    } else {
+      BACKEND_BINOP_IMM(ARM_addImmX, ARM_addRegX);
+      BACKEND_BINOP(ARM_faddReg, ARM_addRegX);
+    }
+    break;
+  case IC_COMMA:
+    next = ICArgN(rpn, 1);
+    next2 = ICArgN(rpn, 0);
+    orig_dst = next->res;
+    if (!SpillsTmpRegs(next))
+      PushTmp(cctrl, next2, NULL);
+    else
+      PushSpilledTmp(cctrl, next2);
+    PushTmp(cctrl, next, &rpn->res);
+    code_off = __OptPassFinal(cctrl, next2, bin, code_off);
+    code_off = __OptPassFinal(cctrl, next, bin, code_off);
+    PopTmp(cctrl, next);
+    PopTmp(cctrl, next2);
+    // TODO WHICH ONE
+    code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
+    break;
+  case IC_EQ:
+    next = ICArgN(rpn, 1);
+    next2 = ICArgN(rpn, 0);
+    orig_dst = next->res;
+    if (!SpillsTmpRegs(next))
+      PushTmp(cctrl, next2, NULL);
+    else
+      PushSpilledTmp(cctrl, next2);
+    code_off = __OptPassFinal(cctrl, next2, bin, code_off);
+    if (next->type == IC_TYPECAST) {
+      TYPECAST_ASSIGN_BEGIN(next, next2);
+      code_off = ICMov(cctrl, &next->res, &next2->res, bin, code_off);
+      TYPECAST_ASSIGN_END(next);
+    } else if (next->type == IC_DEREF) {
+      code_off = __SexyWriteIntoDst(cctrl, next, &next2->res, bin, code_off);
+    } else {
+      PushTmp(cctrl, next, &rpn->res);
+      code_off = __OptPassFinal(cctrl, next, bin, code_off);
+      PopTmp(cctrl, next);
+      code_off = ICMov(cctrl, &next->res, &next2->res, bin, code_off);
+    }
+    code_off = ICMov(cctrl, &rpn->res, &next2->res, bin, code_off);
+    PopTmp(cctrl, next2);
+    break;
+  case IC_SUB:
+    if (use_flags && rpn->res.raw_type != RT_F64) {
+      rpn->res.set_flags = 1;
+      rpn->res.mode = MD_NULL;
+      BACKEND_BINOP_IMM(ARM_subsImmX, ARM_subsRegX);
+      BACKEND_BINOP(ARM_fsubReg, ARM_subsRegX);
+    } else {
+      BACKEND_BINOP_IMM(ARM_subImmX, ARM_subRegX);
+      BACKEND_BINOP(ARM_fsubReg, ARM_subRegX);
+    }
+    break;
+  case IC_DIV:
+    next = rpn->base.next;
+    next2 = ICArgN(rpn, 1);
+    if (next->type == IC_I64 && next2->raw_type != RT_F64) {
+      if (__builtin_popcountll(next->integer) == 1) {
+        PushTmp(cctrl, next2, &rpn->res);
+        code_off = __OptPassFinal(cctrl, next2, bin, code_off);
+        code_off = PutICArgIntoReg(cctrl, &next2->res, next2->raw_type, 1, bin,
+                                   code_off);
+        PopTmp(cctrl, next2);
+        switch (next2->raw_type) {
+        case RT_I8i:
+        case RT_I16i:
+        case RT_I32i:
+        case RT_I64i:
+          if (rpn->res.mode == MD_REG) {
+            AIWNIOS_ADD_CODE(ARM_asrImmX(rpn->res.reg, next2->res.reg,
+                                         __builtin_ffsll(next->integer) - 1));
+          } else {
+            AIWNIOS_ADD_CODE(ARM_asrImmX(1, next2->res.reg,
+                                         __builtin_ffsll(next->integer) - 1));
+            tmp.raw_type = RT_I64i;
+            tmp.reg = 1;
+            tmp.mode = MD_REG;
+            code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+          }
+          break;
+        default:
+          if (rpn->res.mode == MD_REG) {
+            AIWNIOS_ADD_CODE(ARM_lsrImmX(rpn->res.reg, next2->res.reg,
+                                         __builtin_ffsll(next->integer) - 1));
+          } else {
+            AIWNIOS_ADD_CODE(ARM_lsrImmX(1, next2->res.reg,
+                                         __builtin_ffsll(next->integer) - 1));
+            tmp.raw_type = RT_I64i;
+            tmp.reg = 1;
+            tmp.mode = MD_REG;
+            code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+          }
+        }
+        break;
+      }
+    }
+    if (rpn->raw_type == RT_U64i) {
+      BACKEND_BINOP(ARM_fdivReg, ARM_udivX);
+    } else {
+      BACKEND_BINOP(ARM_fdivReg, ARM_sdivRegX);
+    }
+    break;
+  case IC_MUL:
+    next = rpn->base.next;
+    next2 = ICArgN(rpn, 1);
+    if (next->type == IC_I64 && next2->raw_type != RT_F64) {
+      if (__builtin_popcountll(next->integer) == 1) {
+        PushTmp(cctrl, next2, &rpn->res);
+        code_off = __OptPassFinal(cctrl, next2, bin, code_off);
+        code_off = PutICArgIntoReg(cctrl, &next2->res, next2->raw_type, 1, bin,
+                                   code_off);
+        PopTmp(cctrl, next2);
+        if (rpn->res.mode == MD_REG && rpn->raw_type != RT_F64) {
+          AIWNIOS_ADD_CODE(ARM_lslImmX(rpn->res.reg, next2->res.reg,
+                                       __builtin_ffsll(next->integer) - 1));
+        } else {
+          AIWNIOS_ADD_CODE(ARM_lslImmX(1, next2->res.reg,
+                                       __builtin_ffsll(next->integer) - 1));
+          tmp.raw_type = RT_I64i;
+          tmp.reg = 1;
+          tmp.mode = MD_REG;
+          code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+        }
+        break;
+      }
+    }
+    if (rpn->raw_type == RT_U64i) {
+      BACKEND_BINOP(ARM_fmulReg, ARM_umullX);
+    } else {
+      BACKEND_BINOP(ARM_fmulReg, ARM_mulRegX);
+    }
+    break;
+  case IC_DEREF:
+    next = rpn->base.next;
+    i = 0;
+    //
+    // Here's the Donald Trump deal,Derefernced function pointers
+    // don't derefence(you dont copy a function into memory).
+    //
+    // I64 (*fptr)()=&Foo;
+    // (*fptr)(); //Doesn't "dereference"
+    //
+    if (rpn->raw_type == RT_FUNC) {
+      PushTmp(cctrl, next, &rpn->res);
+      code_off = __OptPassFinal(cctrl, next, bin, code_off);
+      PopTmp(cctrl, next);
+      code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
+      return code_off;
+    }
+    code_off = DerefToICArg(cctrl, &tmp, rpn, 2, bin, code_off);
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    break;
+  case IC_AND:
+#define BACKEND_BIT_BINOP(bit_op, shift)                                       \
+  if (rpn->raw_type == RT_F64) {                                               \
+    next = ICArgN(rpn, 1);                                                     \
+    next2 = ICArgN(rpn, 0);                                                    \
+    PushTmp(cctrl, next, &rpn->res);                                           \
+    if (SpillsTmpRegs(next))                                                   \
+      PushSpilledTmp(cctrl, next2);                                            \
+    else                                                                       \
+      PushTmp(cctrl, next2, NULL);                                             \
+    code_off = __OptPassFinal(cctrl, next2, bin, code_off);                    \
+    code_off = __OptPassFinal(cctrl, next, bin, code_off);                     \
+    code_off = FBitOp(cctrl, &rpn->res, &next->res, &next2->res, bit_op,       \
+                      shift, bin, code_off);                                   \
+  } else {                                                                     \
+    BACKEND_BINOP(bit_op, bit_op);                                             \
+  }
+    if (use_flags && rpn->res.raw_type != RT_F64) {
+      rpn->res.set_flags = 1;
+      rpn->res.mode = MD_NULL;
+      BACKEND_BINOP_IMM(ARM_andsImmX, ARM_andsRegX);
+      BACKEND_BIT_BINOP(ARM_andsRegX, 0);
+    } else {
+      BACKEND_BINOP_IMM(ARM_andImmX, ARM_andRegX);
+      BACKEND_BIT_BINOP(ARM_andRegX, 0);
+    }
+    break;
+  case IC_ADDR_OF:
+    next = rpn->base.next;
+    switch (next->type) {
+      break;
+    case __IC_STATIC_REF:
+      if (rpn->res.mode == MD_REG)
+        into_reg = rpn->res.reg;
+      else
+        into_reg = 0;
+      AIWNIOS_ADD_CODE(ARM_adrX(into_reg, 0));
+      if (bin) {
         ref = CodeMiscAddRef(cctrl->statics_label, bin + code_off - 4);
-        ref->patch_cond_br=ARM_adrX;
-        ref->user_data1=into_reg;
+        ref->patch_cond_br = ARM_adrX;
+        ref->user_data1 = into_reg;
         ref->offset = rpn->res.integer;
       }
       goto restore_reg;
-			break;
-		case IC_DEREF:
-			next = rpn->base.next;
-			PushTmp(cctrl, next, &rpn->res);
-			code_off = __OptPassFinal(cctrl, next, bin, code_off);
-			PopTmp(cctrl, next);
-			code_off = PutICArgIntoReg(cctrl, &next->res, RT_PTR, 1, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
-			break;
-		case IC_BASE_PTR:
-			if (rpn->res.mode == MD_REG)
-				into_reg = rpn->res.reg;
-			else
-				into_reg = 0;
-			AIWNIOS_ADD_CODE(ARM_addImmX(into_reg, ARM_REG_FP, next->integer));
-			goto restore_reg;
-			break;
-		case IC_STATIC:
-			if (rpn->res.mode == MD_REG)
-				into_reg = rpn->res.reg;
-			else
-				into_reg = 0;
-			if (cctrl->code_ctrl->final_pass) {
-				i = ARM_adrX(into_reg, (char*)rpn->integer - (bin + code_off));
-				if (i != ARM_ERR_INV_OFF) {
-					AIWNIOS_ADD_CODE(i);
-					goto restore_reg;
-				}
-			}
-			code_off = __ICMoveI64(cctrl, into_reg, rpn->integer, bin,
-				code_off);
-			goto restore_reg;
-		case IC_GLOBAL:
-		get_glbl_ptr:
-			if (rpn->res.mode == MD_REG)
-				into_reg = rpn->res.reg;
-			else
-				into_reg = 0;
-			if (next->global_var->base.type & HTT_GLBL_VAR) {
-				enter_addr = next->global_var->data_addr;
-			} else if (next->global_var->base.type & HTT_FUN) {
-				enter_addr = ((CHashFun*)next->global_var)->fun_ptr;
-			} else
-				abort();
-			// Undefined?
-			if (!enter_addr) {
-				misc = AddRelocMisc(cctrl, next->global_var->base.str);
-				if (cctrl->code_ctrl->final_pass) {
-					AIWNIOS_ADD_CODE(ARM_ldrLabelX(into_reg, 0))
-					ref=CodeMiscAddRef(misc, bin + code_off - 4);
-          ref->patch_cond_br=ARM_ldrLabelX;
-          ref->user_data1=into_reg;
-				} else
-					AIWNIOS_ADD_CODE(0);
-				goto restore_reg;
-			} else if (cctrl->code_ctrl->final_pass) {
-				i = ARM_adrX(into_reg, (char*)enter_addr - (bin + code_off));
-				if (i != ARM_ERR_INV_OFF) {
-					AIWNIOS_ADD_CODE(i);
-					goto restore_reg;
-				}
-			} else
-				AIWNIOS_ADD_CODE(0);
-			code_off = __ICMoveI64(cctrl, into_reg, enter_addr, bin,
-				code_off);
-		restore_reg:
-			tmp.mode = MD_REG;
-			tmp.raw_type = rpn->raw_type;
-			tmp.reg = into_reg;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-			break;
-		default:
-			abort();
-		}
-		break;
-	case IC_XOR:
-		BACKEND_BINOP_IMM(ARM_eorImmX, ARM_eorRegX);
-		BACKEND_BIT_BINOP(ARM_eorRegX, 0);
-		break;
-	case IC_MOD:
-		code_off = __CompileMod(cctrl, rpn, bin, code_off);
-		break;
-	case IC_OR:
-		BACKEND_BINOP_IMM(ARM_orrImmX, ARM_orrRegX);
-		BACKEND_BIT_BINOP(ARM_orrRegX, 0);
-		break;
-	case IC_LT:
-	case IC_GT:
-	case IC_LE:
-	case IC_GE:
-		//
-		// Ask nroot how this works if you want to know
-		//
-		// X/V3 is for lefthand side
-		// X/V4 is for righthand side
-		range = NULL;
-		range_args = NULL;
-		range_fail_addrs = NULL;
-		range_cmp_types = NULL;
-	get_range_items:
-		cnt = 0;
-		for (next = rpn; 1; next = ICFwd(next->base.next) // TODO explain
-		) {
-			switch (next->type) {
-			case IC_LT:
-			case IC_GT:
-			case IC_LE:
-			case IC_GE:
-				goto cmp_pass;
-			}
-			if (range_args)
-				range_args[cnt] = next; // See below
-			break;
-		cmp_pass:
-			//
-			// <
-			//    right rpn.next
-			//    left  ICFwd(rpn.next)
-			//
-			if (range_args)
-				range_args[cnt] = next->base.next;
-			if (range)
-				range[cnt] = next;
-			cnt++;
-		}
-		if (!range) {
-			// This are reversed
-			range_args = A_MALLOC(sizeof(CRPN*) * (cnt + 1), cctrl->hc);
-			range = A_MALLOC(sizeof(CRPN*) * cnt, cctrl->hc);
-			range_fail_addrs = A_MALLOC(sizeof(CRPN*) * cnt, cctrl->hc);
-			range_cmp_types = A_MALLOC(sizeof(int64_t) * cnt, cctrl->hc);
-			goto get_range_items;
-		}
-		for (i = 0; i <= cnt; i++) {
-			// We compile front[cnt] to back[0]
-			for (i2 = i - 1; i2 >= 0; i2--) {
-				if (SpillsTmpRegs(range_args[i2])) {
-					PushSpilledTmp(cctrl, range_args[i]);
-					goto rppass;
-				}
-			}
-			PushTmp(cctrl, range_args[i], NULL);
-		rppass:;
-		}
-		code_off = __OptPassFinal(cctrl, next = range_args[cnt], bin, code_off);
-		for (i = cnt - 1; i >= 0; i--) {
-			next2 = range_args[i];
-			code_off = __OptPassFinal(cctrl, next2, bin, code_off);
-			memcpy(&tmp, &next->res, sizeof(CICArg));
-			memcpy(&tmp2, &next2->res, sizeof(CICArg));
-			use_flt_cmp = next->raw_type == RT_F64 || next2->raw_type == RT_F64;
-			i2 = RT_I64i;
-			i2 = next->res.raw_type > i2 ? next->res.raw_type : i2;
-			i2 = next2->res.raw_type > i2 ? next2->res.raw_type : i2;
-			code_off = PutICArgIntoReg(cctrl, &tmp, i2, 3, bin, code_off);
-			code_off = PutICArgIntoReg(cctrl, &tmp2, i2, 4, bin, code_off);
-			if (use_flt_cmp) {
-				AIWNIOS_ADD_CODE(ARM_fcmp(tmp.reg, tmp2.reg));
-			} else {
-				AIWNIOS_ADD_CODE(ARM_cmpRegX(tmp.reg, tmp2.reg));
-			}
-			//
-			// We use the opposite compare because if fail we jump to the fail
-			// zone
-			//
-			if (use_flt_cmp) {
-			signed_cmp:
-				switch (range[i]->type) {
-					break;
-				case IC_LT:
-					range_cmp_types[i] = ARM_GE;
-					break;
-				case IC_GT:
-					range_cmp_types[i] = ARM_LE;
-					break;
-				case IC_LE:
-					range_cmp_types[i] = ARM_GT;
-					break;
-				case IC_GE:
-					range_cmp_types[i] = ARM_LT;
-				}
-			} else if (next->raw_type == RT_U64i || next2->raw_type == RT_U64i) {
-				switch (range[i]->type) {
-					break;
-				case IC_LT:
-					range_cmp_types[i] = ARM_HS;
-					break;
-				case IC_GT:
-					range_cmp_types[i] = ARM_LS;
-					break;
-				case IC_LE:
-					range_cmp_types[i] = ARM_HI;
-					break;
-				case IC_GE:
-					range_cmp_types[i] = ARM_LO;
-				}
-			} else {
-				goto signed_cmp;
-			}
-			if (old_fail_addr && old_pass_addr) {
-				AIWNIOS_ADD_CODE(ARM_bcc(range_cmp_types[i], 0));
-				if (bin) {
-					ref=CodeMiscAddRef(old_fail_addr, bin + code_off - 4);
-          ref->patch_cond_br=ARM_bcc;
-          ref->user_data1=range_cmp_types[i];
+      break;
+    case IC_DEREF:
+      next = rpn->base.next;
+      PushTmp(cctrl, next, &rpn->res);
+      code_off = __OptPassFinal(cctrl, next, bin, code_off);
+      PopTmp(cctrl, next);
+      code_off = PutICArgIntoReg(cctrl, &next->res, RT_PTR, 1, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
+      break;
+    case IC_BASE_PTR:
+      if (rpn->res.mode == MD_REG)
+        into_reg = rpn->res.reg;
+      else
+        into_reg = 0;
+      AIWNIOS_ADD_CODE(ARM_addImmX(into_reg, ARM_REG_FP, next->integer));
+      goto restore_reg;
+      break;
+    case IC_STATIC:
+      if (rpn->res.mode == MD_REG)
+        into_reg = rpn->res.reg;
+      else
+        into_reg = 0;
+      if (cctrl->code_ctrl->final_pass) {
+        i = ARM_adrX(into_reg, (char *)rpn->integer - (bin + code_off));
+        if (i != ARM_ERR_INV_OFF) {
+          AIWNIOS_ADD_CODE(i);
+          goto restore_reg;
         }
-			} else {
-				range_fail_addrs[i] = bin + code_off;
-				AIWNIOS_ADD_CODE(0); // WILL BE FILLED IN LATER
-			}
-			next = next2;
-		}
-		if (old_pass_addr && old_fail_addr) {
-			AIWNIOS_ADD_CODE(ARM_b(0));
-			ref=CodeMiscAddRef(old_pass_addr, bin + code_off - 4);
-      ref->patch_uncond_br=ARM_b;
-		} else {
-			tmp.mode = MD_I64;
-			tmp.off = 1;
-			tmp.raw_type = RT_I64i;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-			exit_addr = bin + code_off;
-			AIWNIOS_ADD_CODE(ARM_b(0));
-			if (bin)
-				for (i = 0; i != cnt; i++) {
-					*(int32_t*)range_fail_addrs[i] = ARM_bcc(
-						range_cmp_types[i],
-						(bin + code_off) - (char*)range_fail_addrs[i]); // TODO unsigned
-				}
-			tmp.mode = MD_I64;
-			tmp.off = 0;
-			tmp.raw_type = RT_I64i;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-			if (bin)
-				*(int32_t*)exit_addr = ARM_b((bin + code_off) - exit_addr);
-			for (i = cnt; i >= 0; i--)
-				PopTmp(cctrl, range_args[i]);
-		}
-		A_FREE(range);
-		A_FREE(range_args);
-		A_FREE(range_fail_addrs);
-		A_FREE(range_cmp_types);
-		break;
-	case IC_LNOT:
-		next = rpn->base.next;
-    if (old_fail_addr && old_pass_addr) {
-			cctrl->backend_user_data6 = old_fail_addr;
-			cctrl->backend_user_data5 = old_pass_addr;
-			PushTmp(cctrl, next, &rpn->res);
-			code_off = __OptPassFinal(cctrl, next, bin, code_off);
-			PopTmp(cctrl, next);
-			break;
-		}
-		PushTmp(cctrl, next, &rpn->res);
-		code_off = __OptPassFinal(cctrl, next, bin, code_off);
-		PopTmp(cctrl, next);
-		code_off = PutICArgIntoReg(cctrl, &next->res, rpn->raw_type, 1, bin, code_off);
-		AIWNIOS_ADD_CODE(ARM_cmpImmX(next->res.reg, 0));
-		if (rpn->res.mode == MD_REG) {
-			into_reg = rpn->res.reg;
-		} else
-			into_reg = 0; // Store into reg 0
-		AIWNIOS_ADD_CODE(ARM_csetX(into_reg, ARM_EQ));
-		if (rpn->res.mode != MD_REG) {
-			tmp.raw_type = rpn->raw_type;
-			tmp.reg = 0;
-			tmp.mode = MD_REG;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		}
-		break;
-	case IC_BNOT:
-		if (rpn->raw_type == RT_F64)
-			abort(); // TODO
-		BACKEND_UNOP(ARM_mvnRegX, ARM_mvnRegX);
-		break;
-	case IC_POST_INC:
-		code_off = __SexyPostOp(cctrl, rpn, ARM_addImmX, ARM_addRegX, ARM_faddReg, bin, code_off);
-		break;
-	case IC_POST_DEC:
-		code_off = __SexyPostOp(cctrl, rpn, ARM_subImmX, ARM_subRegX, ARM_fsubReg, bin, code_off);
-		break;
-	case IC_PRE_INC:
-		code_off = __SexyPreOp(cctrl, rpn, ARM_addImmX, ARM_addRegX, ARM_faddReg, bin, code_off);
-		break;
-	case IC_PRE_DEC:
-		code_off = __SexyPreOp(cctrl, rpn, ARM_subImmX, ARM_subRegX, ARM_fsubReg, bin, code_off);
-		break;
-	case IC_AND_AND:
-#define ARM_TEST(arg)                                                   \
-	if ((arg)->res.raw_type == RT_F64) {                                    \
-		code_off=PutICArgIntoReg(cctrl, &(arg)->res, RT_F64, 0, bin, code_off);  \
-		code_off = __ICMoveF64(cctrl, 2, 0, bin, code_off);             \
-		AIWNIOS_ADD_CODE(ARM_fcmp((arg)->res.reg, 2));                  \
-	} else {                                                            \
-		code_off=PutICArgIntoReg(cctrl, &(arg)->res, RT_I64i, 0, bin, code_off); \
-		AIWNIOS_ADD_CODE(ARM_cmpImmX((arg)->res.reg, 0));                          \
-	}
-		if (old_pass_addr && old_fail_addr) {
-			a = ICArgN(rpn, 1);
-			b = ICArgN(rpn, 0);
-      PushTmp(cctrl,a,NULL);
-			code_off = __OptPassFinal(cctrl, a, bin, code_off);
-			PopTmp(cctrl,a);
-      ARM_TEST(a);
-			AIWNIOS_ADD_CODE(ARM_bcc(ARM_EQ,0));
-      if(bin) {
-        ref=CodeMiscAddRef(old_fail_addr, bin + code_off - 4);
-        ref->patch_cond_br=ARM_bcc;
-        ref->user_data1=ARM_EQ;
       }
-			PushTmp(cctrl,b,NULL);
+      code_off = __ICMoveI64(cctrl, into_reg, rpn->integer, bin, code_off);
+      goto restore_reg;
+    case IC_GLOBAL:
+    get_glbl_ptr:
+      if (rpn->res.mode == MD_REG)
+        into_reg = rpn->res.reg;
+      else
+        into_reg = 0;
+      if (next->global_var->base.type & HTT_GLBL_VAR) {
+        enter_addr = next->global_var->data_addr;
+      } else if (next->global_var->base.type & HTT_FUN) {
+        enter_addr = ((CHashFun *)next->global_var)->fun_ptr;
+      } else
+        abort();
+      // Undefined?
+      if (!enter_addr) {
+        misc = AddRelocMisc(cctrl, next->global_var->base.str);
+        if (cctrl->code_ctrl->final_pass) {
+          AIWNIOS_ADD_CODE(ARM_ldrLabelX(into_reg, 0))
+          ref = CodeMiscAddRef(misc, bin + code_off - 4);
+          ref->patch_cond_br = ARM_ldrLabelX;
+          ref->user_data1 = into_reg;
+        } else
+          AIWNIOS_ADD_CODE(0);
+        goto restore_reg;
+      } else if (cctrl->code_ctrl->final_pass) {
+        i = ARM_adrX(into_reg, (char *)enter_addr - (bin + code_off));
+        if (i != ARM_ERR_INV_OFF) {
+          AIWNIOS_ADD_CODE(i);
+          goto restore_reg;
+        }
+      } else
+        AIWNIOS_ADD_CODE(0);
+      code_off = __ICMoveI64(cctrl, into_reg, enter_addr, bin, code_off);
+    restore_reg:
+      tmp.mode = MD_REG;
+      tmp.raw_type = rpn->raw_type;
+      tmp.reg = into_reg;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+      break;
+    default:
+      abort();
+    }
+    break;
+  case IC_XOR:
+    BACKEND_BINOP_IMM(ARM_eorImmX, ARM_eorRegX);
+    BACKEND_BIT_BINOP(ARM_eorRegX, 0);
+    break;
+  case IC_MOD:
+    code_off = __CompileMod(cctrl, rpn, bin, code_off);
+    break;
+  case IC_OR:
+    BACKEND_BINOP_IMM(ARM_orrImmX, ARM_orrRegX);
+    BACKEND_BIT_BINOP(ARM_orrRegX, 0);
+    break;
+  case IC_LT:
+  case IC_GT:
+  case IC_LE:
+  case IC_GE:
+    //
+    // Ask nroot how this works if you want to know
+    //
+    // X/V3 is for lefthand side
+    // X/V4 is for righthand side
+    range = NULL;
+    range_args = NULL;
+    range_fail_addrs = NULL;
+    range_cmp_types = NULL;
+  get_range_items:
+    cnt = 0;
+    for (next = rpn; 1; next = ICFwd(next->base.next) // TODO explain
+    ) {
+      switch (next->type) {
+      case IC_LT:
+      case IC_GT:
+      case IC_LE:
+      case IC_GE:
+        goto cmp_pass;
+      }
+      if (range_args)
+        range_args[cnt] = next; // See below
+      break;
+    cmp_pass:
+      //
+      // <
+      //    right rpn.next
+      //    left  ICFwd(rpn.next)
+      //
+      if (range_args)
+        range_args[cnt] = next->base.next;
+      if (range)
+        range[cnt] = next;
+      cnt++;
+    }
+    if (!range) {
+      // This are reversed
+      range_args = A_MALLOC(sizeof(CRPN *) * (cnt + 1), cctrl->hc);
+      range = A_MALLOC(sizeof(CRPN *) * cnt, cctrl->hc);
+      range_fail_addrs = A_MALLOC(sizeof(CRPN *) * cnt, cctrl->hc);
+      range_cmp_types = A_MALLOC(sizeof(int64_t) * cnt, cctrl->hc);
+      goto get_range_items;
+    }
+    for (i = 0; i <= cnt; i++) {
+      // We compile front[cnt] to back[0]
+      for (i2 = i - 1; i2 >= 0; i2--) {
+        if (SpillsTmpRegs(range_args[i2])) {
+          PushSpilledTmp(cctrl, range_args[i]);
+          goto rppass;
+        }
+      }
+      PushTmp(cctrl, range_args[i], NULL);
+    rppass:;
+    }
+    code_off = __OptPassFinal(cctrl, next = range_args[cnt], bin, code_off);
+    for (i = cnt - 1; i >= 0; i--) {
+      next2 = range_args[i];
+      code_off = __OptPassFinal(cctrl, next2, bin, code_off);
+      memcpy(&tmp, &next->res, sizeof(CICArg));
+      memcpy(&tmp2, &next2->res, sizeof(CICArg));
+      use_flt_cmp = next->raw_type == RT_F64 || next2->raw_type == RT_F64;
+      i2 = RT_I64i;
+      i2 = next->res.raw_type > i2 ? next->res.raw_type : i2;
+      i2 = next2->res.raw_type > i2 ? next2->res.raw_type : i2;
+      code_off = PutICArgIntoReg(cctrl, &tmp, i2, 3, bin, code_off);
+      code_off = PutICArgIntoReg(cctrl, &tmp2, i2, 4, bin, code_off);
+      if (use_flt_cmp) {
+        AIWNIOS_ADD_CODE(ARM_fcmp(tmp.reg, tmp2.reg));
+      } else {
+        AIWNIOS_ADD_CODE(ARM_cmpRegX(tmp.reg, tmp2.reg));
+      }
+      //
+      // We use the opposite compare because if fail we jump to the fail
+      // zone
+      //
+      if (use_flt_cmp) {
+      signed_cmp:
+        switch (range[i]->type) {
+          break;
+        case IC_LT:
+          range_cmp_types[i] = ARM_GE;
+          break;
+        case IC_GT:
+          range_cmp_types[i] = ARM_LE;
+          break;
+        case IC_LE:
+          range_cmp_types[i] = ARM_GT;
+          break;
+        case IC_GE:
+          range_cmp_types[i] = ARM_LT;
+        }
+      } else if (next->raw_type == RT_U64i || next2->raw_type == RT_U64i) {
+        switch (range[i]->type) {
+          break;
+        case IC_LT:
+          range_cmp_types[i] = ARM_HS;
+          break;
+        case IC_GT:
+          range_cmp_types[i] = ARM_LS;
+          break;
+        case IC_LE:
+          range_cmp_types[i] = ARM_HI;
+          break;
+        case IC_GE:
+          range_cmp_types[i] = ARM_LO;
+        }
+      } else {
+        goto signed_cmp;
+      }
+      if (old_fail_addr && old_pass_addr) {
+        AIWNIOS_ADD_CODE(ARM_bcc(range_cmp_types[i], 0));
+        if (bin) {
+          ref = CodeMiscAddRef(old_fail_addr, bin + code_off - 4);
+          ref->patch_cond_br = ARM_bcc;
+          ref->user_data1 = range_cmp_types[i];
+        }
+      } else {
+        range_fail_addrs[i] = bin + code_off;
+        AIWNIOS_ADD_CODE(0); // WILL BE FILLED IN LATER
+      }
+      next = next2;
+    }
+    if (old_pass_addr && old_fail_addr) {
+      AIWNIOS_ADD_CODE(ARM_b(0));
+      ref = CodeMiscAddRef(old_pass_addr, bin + code_off - 4);
+      ref->patch_uncond_br = ARM_b;
+    } else {
+      tmp.mode = MD_I64;
+      tmp.off = 1;
+      tmp.raw_type = RT_I64i;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+      exit_addr = bin + code_off;
+      AIWNIOS_ADD_CODE(ARM_b(0));
+      if (bin)
+        for (i = 0; i != cnt; i++) {
+          *(int32_t *)range_fail_addrs[i] = ARM_bcc(
+              range_cmp_types[i],
+              (bin + code_off) - (char *)range_fail_addrs[i]); // TODO unsigned
+        }
+      tmp.mode = MD_I64;
+      tmp.off = 0;
+      tmp.raw_type = RT_I64i;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+      if (bin)
+        *(int32_t *)exit_addr = ARM_b((bin + code_off) - exit_addr);
+      for (i = cnt; i >= 0; i--)
+        PopTmp(cctrl, range_args[i]);
+    }
+    A_FREE(range);
+    A_FREE(range_args);
+    A_FREE(range_fail_addrs);
+    A_FREE(range_cmp_types);
+    break;
+  case IC_LNOT:
+    next = rpn->base.next;
+    if (old_fail_addr && old_pass_addr) {
+      cctrl->backend_user_data6 = old_fail_addr;
+      cctrl->backend_user_data5 = old_pass_addr;
+      PushTmp(cctrl, next, &rpn->res);
+      code_off = __OptPassFinal(cctrl, next, bin, code_off);
+      PopTmp(cctrl, next);
+      break;
+    }
+    PushTmp(cctrl, next, &rpn->res);
+    code_off = __OptPassFinal(cctrl, next, bin, code_off);
+    PopTmp(cctrl, next);
+    code_off =
+        PutICArgIntoReg(cctrl, &next->res, rpn->raw_type, 1, bin, code_off);
+    AIWNIOS_ADD_CODE(ARM_cmpImmX(next->res.reg, 0));
+    if (rpn->res.mode == MD_REG) {
+      into_reg = rpn->res.reg;
+    } else
+      into_reg = 0; // Store into reg 0
+    AIWNIOS_ADD_CODE(ARM_csetX(into_reg, ARM_EQ));
+    if (rpn->res.mode != MD_REG) {
+      tmp.raw_type = rpn->raw_type;
+      tmp.reg = 0;
+      tmp.mode = MD_REG;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    }
+    break;
+  case IC_BNOT:
+    if (rpn->raw_type == RT_F64)
+      abort(); // TODO
+    BACKEND_UNOP(ARM_mvnRegX, ARM_mvnRegX);
+    break;
+  case IC_POST_INC:
+    code_off = __SexyPostOp(cctrl, rpn, ARM_addImmX, ARM_addRegX, ARM_faddReg,
+                            bin, code_off);
+    break;
+  case IC_POST_DEC:
+    code_off = __SexyPostOp(cctrl, rpn, ARM_subImmX, ARM_subRegX, ARM_fsubReg,
+                            bin, code_off);
+    break;
+  case IC_PRE_INC:
+    code_off = __SexyPreOp(cctrl, rpn, ARM_addImmX, ARM_addRegX, ARM_faddReg,
+                           bin, code_off);
+    break;
+  case IC_PRE_DEC:
+    code_off = __SexyPreOp(cctrl, rpn, ARM_subImmX, ARM_subRegX, ARM_fsubReg,
+                           bin, code_off);
+    break;
+  case IC_AND_AND:
+#define ARM_TEST(arg)                                                          \
+  if ((arg)->res.raw_type == RT_F64) {                                         \
+    code_off = PutICArgIntoReg(cctrl, &(arg)->res, RT_F64, 0, bin, code_off);  \
+    code_off = __ICMoveF64(cctrl, 2, 0, bin, code_off);                        \
+    AIWNIOS_ADD_CODE(ARM_fcmp((arg)->res.reg, 2));                             \
+  } else {                                                                     \
+    code_off = PutICArgIntoReg(cctrl, &(arg)->res, RT_I64i, 0, bin, code_off); \
+    AIWNIOS_ADD_CODE(ARM_cmpImmX((arg)->res.reg, 0));                          \
+  }
+    if (old_pass_addr && old_fail_addr) {
+      a = ICArgN(rpn, 1);
+      b = ICArgN(rpn, 0);
+      PushTmp(cctrl, a, NULL);
+      code_off = __OptPassFinal(cctrl, a, bin, code_off);
+      PopTmp(cctrl, a);
+      ARM_TEST(a);
+      AIWNIOS_ADD_CODE(ARM_bcc(ARM_EQ, 0));
+      if (bin) {
+        ref = CodeMiscAddRef(old_fail_addr, bin + code_off - 4);
+        ref->patch_cond_br = ARM_bcc;
+        ref->user_data1 = ARM_EQ;
+      }
+      PushTmp(cctrl, b, NULL);
       code_off = __OptPassFinal(cctrl, b, bin, code_off);
-      PopTmp(cctrl,b);
-			ARM_TEST(b);
-			AIWNIOS_ADD_CODE(ARM_bcc(ARM_EQ,0));
-      if(bin) {
-        ref=CodeMiscAddRef(old_fail_addr, bin + code_off - 4);
-        ref->patch_cond_br=ARM_bcc;
-        ref->user_data1=ARM_EQ;
+      PopTmp(cctrl, b);
+      ARM_TEST(b);
+      AIWNIOS_ADD_CODE(ARM_bcc(ARM_EQ, 0));
+      if (bin) {
+        ref = CodeMiscAddRef(old_fail_addr, bin + code_off - 4);
+        ref->patch_cond_br = ARM_bcc;
+        ref->user_data1 = ARM_EQ;
       }
       AIWNIOS_ADD_CODE(ARM_b(0));
-      if(bin) {
-        ref=CodeMiscAddRef(old_pass_addr, bin + code_off - 4);
-        ref->patch_uncond_br=ARM_b;
+      if (bin) {
+        ref = CodeMiscAddRef(old_pass_addr, bin + code_off - 4);
+        ref->patch_uncond_br = ARM_b;
       }
       break;
-		}
-#define BACKEND_BOOLIFY(to, reg, rt)                        \
-	if ((rt) != RT_F64) {                                   \
-		AIWNIOS_ADD_CODE(ARM_cmpImmX(reg, 0));              \
-		AIWNIOS_ADD_CODE(ARM_csetX(to, ARM_NE));            \
-	} else {                                                \
-		code_off = __ICMoveF64(cctrl, 2, 0, bin, code_off); \
-		AIWNIOS_ADD_CODE(ARM_fcmp(reg, 2));                 \
-		AIWNIOS_ADD_CODE(ARM_csetX(to, ARM_NE));           \
-	}
-  //A
-  //rpn->code_misc2
-  //B
-  //rpn->code_misc
-  //res=0
-  //JMP rpn->code_misc4
-  //rpn->code_misc3
-  //res=1
-  //rpn->code_misc4
+    }
+#define BACKEND_BOOLIFY(to, reg, rt)                                           \
+  if ((rt) != RT_F64) {                                                        \
+    AIWNIOS_ADD_CODE(ARM_cmpImmX(reg, 0));                                     \
+    AIWNIOS_ADD_CODE(ARM_csetX(to, ARM_NE));                                   \
+  } else {                                                                     \
+    code_off = __ICMoveF64(cctrl, 2, 0, bin, code_off);                        \
+    AIWNIOS_ADD_CODE(ARM_fcmp(reg, 2));                                        \
+    AIWNIOS_ADD_CODE(ARM_csetX(to, ARM_NE));                                   \
+  }
+    // A
+    // rpn->code_misc2
+    // B
+    // rpn->code_misc
+    // res=0
+    // JMP rpn->code_misc4
+    // rpn->code_misc3
+    // res=1
+    // rpn->code_misc4
     if (!rpn->code_misc)
-			rpn->code_misc = CodeMiscNew(cctrl, CMT_LABEL);
-		if (!rpn->code_misc2)
-			rpn->code_misc2 = CodeMiscNew(cctrl, CMT_LABEL);
-		if (!rpn->code_misc3)
-			rpn->code_misc3 = CodeMiscNew(cctrl, CMT_LABEL);
-		if (!rpn->code_misc4)
-			rpn->code_misc4 = CodeMiscNew(cctrl, CMT_LABEL);
-		a = ICArgN(rpn, 1);
-		b = ICArgN(rpn, 0);
-		cctrl->backend_user_data5 = rpn->code_misc;
-		cctrl->backend_user_data6 = rpn->code_misc2;
-    PushTmp(cctrl,a,NULL);
-		code_off = __OptPassFinal(cctrl, a, bin, code_off);
-    PopTmp(cctrl,a);
-    cctrl->backend_user_data5=rpn->code_misc;
-		cctrl->backend_user_data6 = rpn->code_misc3;
-		rpn->code_misc2->addr = bin + code_off;
-		PushTmp(cctrl,b,NULL);
-		code_off = __OptPassFinal(cctrl, b, bin, code_off);
-		PopTmp(cctrl,b);
+      rpn->code_misc = CodeMiscNew(cctrl, CMT_LABEL);
+    if (!rpn->code_misc2)
+      rpn->code_misc2 = CodeMiscNew(cctrl, CMT_LABEL);
+    if (!rpn->code_misc3)
+      rpn->code_misc3 = CodeMiscNew(cctrl, CMT_LABEL);
+    if (!rpn->code_misc4)
+      rpn->code_misc4 = CodeMiscNew(cctrl, CMT_LABEL);
+    a = ICArgN(rpn, 1);
+    b = ICArgN(rpn, 0);
+    cctrl->backend_user_data5 = rpn->code_misc;
+    cctrl->backend_user_data6 = rpn->code_misc2;
+    PushTmp(cctrl, a, NULL);
+    code_off = __OptPassFinal(cctrl, a, bin, code_off);
+    PopTmp(cctrl, a);
+    cctrl->backend_user_data5 = rpn->code_misc;
+    cctrl->backend_user_data6 = rpn->code_misc3;
+    rpn->code_misc2->addr = bin + code_off;
+    PushTmp(cctrl, b, NULL);
+    code_off = __OptPassFinal(cctrl, b, bin, code_off);
+    PopTmp(cctrl, b);
     rpn->code_misc->addr = bin + code_off;
-		tmp.mode = MD_I64;
-		tmp.raw_type = RT_I64i;
-		tmp.integer = 0;
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		AIWNIOS_ADD_CODE(ARM_b(0));
-		ref=CodeMiscAddRef(rpn->code_misc4, bin + code_off - 4);
-    ref->patch_uncond_br=ARM_b;
-		rpn->code_misc3->addr = bin + code_off;
-		tmp.integer = 1;
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		rpn->code_misc4->addr = bin + code_off;
-		break;
-	case IC_OR_OR:
-		if (old_fail_addr && old_pass_addr) {
-			b = ICArgN(rpn, 0);
-			a = ICArgN(rpn, 1);
-      PushTmp(cctrl,a,NULL);
-			code_off = __OptPassFinal(cctrl, a, bin, code_off);
-			ARM_TEST(a);
-      PopTmp(cctrl,a);
-			if (bin) {
-				AIWNIOS_ADD_CODE(ARM_bcc(ARM_NE, 0));
-				ref=CodeMiscAddRef(old_pass_addr, bin + code_off - 4);
-        ref->patch_cond_br=ARM_bcc;
-        ref->user_data1=ARM_NE;
-			} else
-				AIWNIOS_ADD_CODE(0);
-      PushTmp(cctrl,b,NULL);
-			code_off = __OptPassFinal(cctrl, b, bin, code_off);
-			ARM_TEST(b);
-      PopTmp(cctrl,b);
-			if (bin) {
-				AIWNIOS_ADD_CODE(ARM_bcc(ARM_NE, 0));
-				ref=CodeMiscAddRef(old_pass_addr, bin + code_off - 4);
-        ref->patch_cond_br=ARM_bcc;
-        ref->user_data1=ARM_NE;
-			}
-			AIWNIOS_ADD_CODE(ARM_b(0));
-			ref=CodeMiscAddRef(old_fail_addr, bin + code_off - 4);
-      ref->patch_uncond_br=ARM_b;
-			break;
-		}
-	// A
-		// rpn->code_misc3:
-		// B
-		// rpn->code_misc4:
-		// res=0;
-		// JMP rpn->code_misc2
-		// rpn->code_misc:
-		// res=1
-		// rpn->code_misc2:
-		if (!rpn->code_misc)
-			rpn->code_misc = CodeMiscNew(cctrl, CMT_LABEL);
-		if (!rpn->code_misc2)
-			rpn->code_misc2 = CodeMiscNew(cctrl, CMT_LABEL);
-		if (!rpn->code_misc3)
-			rpn->code_misc3 = CodeMiscNew(cctrl, CMT_LABEL);
-		if (!rpn->code_misc4)
-			rpn->code_misc4 = CodeMiscNew(cctrl, CMT_LABEL);
-		a = ICArgN(rpn, 1);
-		b = ICArgN(rpn, 0);
-		cctrl->backend_user_data5 = rpn->code_misc3;
-		cctrl->backend_user_data6 = rpn->code_misc;
-    PushTmp(cctrl,a,NULL);
-		code_off = __OptPassFinal(cctrl, a, bin, code_off);
-    PopTmp(cctrl,a);
-		rpn->code_misc3->addr = bin + code_off;
-		cctrl->backend_user_data5 = rpn->code_misc4;
-    PushTmp(cctrl,b,NULL);
-		code_off = __OptPassFinal(cctrl, b, bin, code_off);
-    PopTmp(cctrl,b);
-		rpn->code_misc4->addr = bin + code_off;
-		tmp.mode = MD_I64;
-		tmp.integer = 0;
-		tmp.raw_type = RT_I64i;
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		AIWNIOS_ADD_CODE(ARM_b(0));
-		ref=CodeMiscAddRef(rpn->code_misc2, bin + code_off - 4);
-    ref->patch_uncond_br=ARM_b;
-		rpn->code_misc->addr = bin + code_off;
-		tmp.integer = 1;
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		rpn->code_misc2->addr = bin + code_off;
-		break;
-		break;
-	case IC_XOR_XOR:
-#define BACKEND_LOGICAL_BINOP(op)                                                    \
-	next = ICArgN(rpn, 1);                                                           \
-	next2 = ICArgN(rpn, 0);                                                          \
-	if (!SpillsTmpRegs(next2))                                                       \
-		PushTmp(cctrl, next, NULL);                                                  \
-	else                                                                             \
-		PushSpilledTmp(cctrl, next);                                                 \
-	PushTmp(cctrl, next2, &rpn->res);                                                \
-	code_off = __OptPassFinal(cctrl, next, bin, code_off);                           \
-	code_off = __OptPassFinal(cctrl, next2, bin, code_off);                          \
-	PopTmp(cctrl, next2);                                                            \
-	PopTmp(cctrl, next);                                                             \
-	if (rpn->res.mode == MD_REG) {                                                   \
-		into_reg = rpn->res.reg;                                                     \
-	} else                                                                           \
-		into_reg = 0;                                                                \
-	code_off = PutICArgIntoReg(cctrl, &next->res, rpn->raw_type, 2, bin, code_off);  \
-	code_off = PutICArgIntoReg(cctrl, &next2->res, rpn->raw_type, 1, bin, code_off); \
-	BACKEND_BOOLIFY(2, next->res.reg, next->res.raw_type);                           \
-	BACKEND_BOOLIFY(1, next2->res.reg, next2->res.raw_type);                         \
-	AIWNIOS_ADD_CODE(op(into_reg, 1, 2));                                            \
-	if (rpn->res.mode != MD_REG) {                                                   \
-		tmp.raw_type = rpn->raw_type;                                                \
-		tmp.reg = 0;                                                                 \
-		tmp.mode = MD_REG;                                                           \
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);                     \
-	}
-		BACKEND_LOGICAL_BINOP(ARM_eorRegX);
-		break;
-	case IC_EQ_EQ:
-#define BACKEND_CMP                                                                  \
-	next = ICArgN(rpn, 1);                                                           \
-	next2 = ICArgN(rpn, 0);                                                          \
-	if (!SpillsTmpRegs(next2))                                                       \
-		PushTmp(cctrl, next, NULL);                                                  \
-	else                                                                             \
-		PushSpilledTmp(cctrl, next);                                                 \
-	PushTmp(cctrl, next2, &rpn->res);                                                \
-	code_off = __OptPassFinal(cctrl, next, bin, code_off);                           \
-	code_off = __OptPassFinal(cctrl, next2, bin, code_off);                          \
-	PopTmp(cctrl, next2);                                                            \
-	PopTmp(cctrl, next);                                                             \
-	code_off = PutICArgIntoReg(cctrl, &next->res, rpn->raw_type, 2, bin, code_off);  \
-	code_off = PutICArgIntoReg(cctrl, &next2->res, rpn->raw_type, 1, bin, code_off); \
-	if (rpn->raw_type == RT_F64) {                                                   \
-		AIWNIOS_ADD_CODE(ARM_fcmp(next->res.reg, next2->res.reg));                   \
-	} else {                                                                         \
-		AIWNIOS_ADD_CODE(ARM_cmpRegX(next->res.reg, next2->res.reg));                \
-	}
-		BACKEND_CMP;
-		if (old_fail_addr && old_pass_addr) {
-			AIWNIOS_ADD_CODE(ARM_bcc(ARM_EQ, 0));
-			if (bin) {
-				ref=CodeMiscAddRef(old_pass_addr, bin + code_off - 4);
-        ref->patch_cond_br=ARM_bcc;
-        ref->user_data1=ARM_EQ;
+    tmp.mode = MD_I64;
+    tmp.raw_type = RT_I64i;
+    tmp.integer = 0;
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    AIWNIOS_ADD_CODE(ARM_b(0));
+    ref = CodeMiscAddRef(rpn->code_misc4, bin + code_off - 4);
+    ref->patch_uncond_br = ARM_b;
+    rpn->code_misc3->addr = bin + code_off;
+    tmp.integer = 1;
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    rpn->code_misc4->addr = bin + code_off;
+    break;
+  case IC_OR_OR:
+    if (old_fail_addr && old_pass_addr) {
+      b = ICArgN(rpn, 0);
+      a = ICArgN(rpn, 1);
+      PushTmp(cctrl, a, NULL);
+      code_off = __OptPassFinal(cctrl, a, bin, code_off);
+      ARM_TEST(a);
+      PopTmp(cctrl, a);
+      if (bin) {
+        AIWNIOS_ADD_CODE(ARM_bcc(ARM_NE, 0));
+        ref = CodeMiscAddRef(old_pass_addr, bin + code_off - 4);
+        ref->patch_cond_br = ARM_bcc;
+        ref->user_data1 = ARM_NE;
+      } else
+        AIWNIOS_ADD_CODE(0);
+      PushTmp(cctrl, b, NULL);
+      code_off = __OptPassFinal(cctrl, b, bin, code_off);
+      ARM_TEST(b);
+      PopTmp(cctrl, b);
+      if (bin) {
+        AIWNIOS_ADD_CODE(ARM_bcc(ARM_NE, 0));
+        ref = CodeMiscAddRef(old_pass_addr, bin + code_off - 4);
+        ref->patch_cond_br = ARM_bcc;
+        ref->user_data1 = ARM_NE;
       }
-			AIWNIOS_ADD_CODE(ARM_b(0));
-			if (bin) {
-				ref=CodeMiscAddRef(old_fail_addr, bin + code_off - 4);
-        ref->patch_uncond_br=ARM_b;
+      AIWNIOS_ADD_CODE(ARM_b(0));
+      ref = CodeMiscAddRef(old_fail_addr, bin + code_off - 4);
+      ref->patch_uncond_br = ARM_b;
+      break;
+    }
+    // A
+    // rpn->code_misc3:
+    // B
+    // rpn->code_misc4:
+    // res=0;
+    // JMP rpn->code_misc2
+    // rpn->code_misc:
+    // res=1
+    // rpn->code_misc2:
+    if (!rpn->code_misc)
+      rpn->code_misc = CodeMiscNew(cctrl, CMT_LABEL);
+    if (!rpn->code_misc2)
+      rpn->code_misc2 = CodeMiscNew(cctrl, CMT_LABEL);
+    if (!rpn->code_misc3)
+      rpn->code_misc3 = CodeMiscNew(cctrl, CMT_LABEL);
+    if (!rpn->code_misc4)
+      rpn->code_misc4 = CodeMiscNew(cctrl, CMT_LABEL);
+    a = ICArgN(rpn, 1);
+    b = ICArgN(rpn, 0);
+    cctrl->backend_user_data5 = rpn->code_misc3;
+    cctrl->backend_user_data6 = rpn->code_misc;
+    PushTmp(cctrl, a, NULL);
+    code_off = __OptPassFinal(cctrl, a, bin, code_off);
+    PopTmp(cctrl, a);
+    rpn->code_misc3->addr = bin + code_off;
+    cctrl->backend_user_data5 = rpn->code_misc4;
+    PushTmp(cctrl, b, NULL);
+    code_off = __OptPassFinal(cctrl, b, bin, code_off);
+    PopTmp(cctrl, b);
+    rpn->code_misc4->addr = bin + code_off;
+    tmp.mode = MD_I64;
+    tmp.integer = 0;
+    tmp.raw_type = RT_I64i;
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    AIWNIOS_ADD_CODE(ARM_b(0));
+    ref = CodeMiscAddRef(rpn->code_misc2, bin + code_off - 4);
+    ref->patch_uncond_br = ARM_b;
+    rpn->code_misc->addr = bin + code_off;
+    tmp.integer = 1;
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    rpn->code_misc2->addr = bin + code_off;
+    break;
+    break;
+  case IC_XOR_XOR:
+#define BACKEND_LOGICAL_BINOP(op)                                              \
+  next = ICArgN(rpn, 1);                                                       \
+  next2 = ICArgN(rpn, 0);                                                      \
+  if (!SpillsTmpRegs(next2))                                                   \
+    PushTmp(cctrl, next, NULL);                                                \
+  else                                                                         \
+    PushSpilledTmp(cctrl, next);                                               \
+  PushTmp(cctrl, next2, &rpn->res);                                            \
+  code_off = __OptPassFinal(cctrl, next, bin, code_off);                       \
+  code_off = __OptPassFinal(cctrl, next2, bin, code_off);                      \
+  PopTmp(cctrl, next2);                                                        \
+  PopTmp(cctrl, next);                                                         \
+  if (rpn->res.mode == MD_REG) {                                               \
+    into_reg = rpn->res.reg;                                                   \
+  } else                                                                       \
+    into_reg = 0;                                                              \
+  code_off =                                                                   \
+      PutICArgIntoReg(cctrl, &next->res, rpn->raw_type, 2, bin, code_off);     \
+  code_off =                                                                   \
+      PutICArgIntoReg(cctrl, &next2->res, rpn->raw_type, 1, bin, code_off);    \
+  BACKEND_BOOLIFY(2, next->res.reg, next->res.raw_type);                       \
+  BACKEND_BOOLIFY(1, next2->res.reg, next2->res.raw_type);                     \
+  AIWNIOS_ADD_CODE(op(into_reg, 1, 2));                                        \
+  if (rpn->res.mode != MD_REG) {                                               \
+    tmp.raw_type = rpn->raw_type;                                              \
+    tmp.reg = 0;                                                               \
+    tmp.mode = MD_REG;                                                         \
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);                   \
+  }
+    BACKEND_LOGICAL_BINOP(ARM_eorRegX);
+    break;
+  case IC_EQ_EQ:
+#define BACKEND_CMP                                                            \
+  next = ICArgN(rpn, 1);                                                       \
+  next2 = ICArgN(rpn, 0);                                                      \
+  if (!SpillsTmpRegs(next2))                                                   \
+    PushTmp(cctrl, next, NULL);                                                \
+  else                                                                         \
+    PushSpilledTmp(cctrl, next);                                               \
+  PushTmp(cctrl, next2, &rpn->res);                                            \
+  code_off = __OptPassFinal(cctrl, next, bin, code_off);                       \
+  code_off = __OptPassFinal(cctrl, next2, bin, code_off);                      \
+  PopTmp(cctrl, next2);                                                        \
+  PopTmp(cctrl, next);                                                         \
+  code_off =                                                                   \
+      PutICArgIntoReg(cctrl, &next->res, rpn->raw_type, 2, bin, code_off);     \
+  code_off =                                                                   \
+      PutICArgIntoReg(cctrl, &next2->res, rpn->raw_type, 1, bin, code_off);    \
+  if (rpn->raw_type == RT_F64) {                                               \
+    AIWNIOS_ADD_CODE(ARM_fcmp(next->res.reg, next2->res.reg));                 \
+  } else {                                                                     \
+    AIWNIOS_ADD_CODE(ARM_cmpRegX(next->res.reg, next2->res.reg));              \
+  }
+    BACKEND_CMP;
+    if (old_fail_addr && old_pass_addr) {
+      AIWNIOS_ADD_CODE(ARM_bcc(ARM_EQ, 0));
+      if (bin) {
+        ref = CodeMiscAddRef(old_pass_addr, bin + code_off - 4);
+        ref->patch_cond_br = ARM_bcc;
+        ref->user_data1 = ARM_EQ;
       }
-			break;
-		}
-		if (use_flags)
-			return code_off;
-		if (rpn->res.mode == MD_REG) {
-			into_reg = rpn->res.reg;
-		} else
-			into_reg = 0;
-		AIWNIOS_ADD_CODE(ARM_csetX(into_reg, ARM_EQ));
-		if (rpn->res.mode != MD_REG) {
-			tmp.raw_type = rpn->raw_type;
-			tmp.reg = 0;
-			tmp.mode = MD_REG;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		}
-		break;
-	case IC_NE:
-		BACKEND_CMP;
-		if (old_pass_addr && old_fail_addr) {
-			AIWNIOS_ADD_CODE(ARM_bcc(ARM_NE, 0));
-			if (bin) {
-				ref=CodeMiscAddRef(old_pass_addr, bin + code_off - 4);
-        ref->patch_cond_br=ARM_bcc;
-        ref->user_data1=ARM_NE;
+      AIWNIOS_ADD_CODE(ARM_b(0));
+      if (bin) {
+        ref = CodeMiscAddRef(old_fail_addr, bin + code_off - 4);
+        ref->patch_uncond_br = ARM_b;
       }
-			AIWNIOS_ADD_CODE(ARM_b(0));
-			if (bin) {
-				ref=CodeMiscAddRef(old_fail_addr, bin + code_off - 4);
-        ref->patch_uncond_br=ARM_b;
+      break;
+    }
+    if (use_flags)
+      return code_off;
+    if (rpn->res.mode == MD_REG) {
+      into_reg = rpn->res.reg;
+    } else
+      into_reg = 0;
+    AIWNIOS_ADD_CODE(ARM_csetX(into_reg, ARM_EQ));
+    if (rpn->res.mode != MD_REG) {
+      tmp.raw_type = rpn->raw_type;
+      tmp.reg = 0;
+      tmp.mode = MD_REG;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    }
+    break;
+  case IC_NE:
+    BACKEND_CMP;
+    if (old_pass_addr && old_fail_addr) {
+      AIWNIOS_ADD_CODE(ARM_bcc(ARM_NE, 0));
+      if (bin) {
+        ref = CodeMiscAddRef(old_pass_addr, bin + code_off - 4);
+        ref->patch_cond_br = ARM_bcc;
+        ref->user_data1 = ARM_NE;
       }
-			break;
-		}
-		if (use_flags)
-			return code_off;
-		if (rpn->res.mode == MD_REG) {
-			into_reg = rpn->res.reg;
-		} else
-			into_reg = 0;
-		AIWNIOS_ADD_CODE(ARM_csetX(into_reg, ARM_NE));
-		if (rpn->res.mode != MD_REG) {
-			tmp.raw_type = rpn->raw_type;
-			tmp.reg = 0;
-			tmp.mode = MD_REG;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		}
-		break;
-	case IC_LSH:
-		BACKEND_BIT_BINOP(ARM_lslvRegX, 1);
-		break;
-	case IC_RSH:
-		switch (rpn->raw_type) {
-		case RT_U8i:
-		case RT_U16i:
-		case RT_U32i:
-		case RT_U64i:
-			BACKEND_BINOP(ARM_lsrvRegX, ARM_lsrvRegX);
-			break;
-		default:
-			BACKEND_BIT_BINOP(ARM_asrvRegX, 1);
-		}
-		break;
-	case __IC_CALL:
-	case IC_CALL:
-		//
-		// ()_()_()_()
-		// /          \     // When we call a function,all temp registers
-		// | O______O |     // are invalidated,so we can reset the temp register
-		// | \______/ |===> // counts (for the new expressions).
-		// \__________/     //
-		//   \./   \./      // We will restore the temp register counts after the
-		//   call
-		//
-		i = cctrl->backend_user_data2;
-		i2 = cctrl->backend_user_data3;
-		cctrl->backend_user_data2 = 0;
-		cctrl->backend_user_data3 = 0;
-		code_off = __ICFCallTOS(cctrl, rpn, bin, code_off);
-		cctrl->backend_user_data2 = i;
-		cctrl->backend_user_data3 = i2;
-		break;
-	case __IC_VARGS:
-		//  ^^^^^^^^
-		// (        \      ___________________
-		// ( (*) (*)|     /                   \
+      AIWNIOS_ADD_CODE(ARM_b(0));
+      if (bin) {
+        ref = CodeMiscAddRef(old_fail_addr, bin + code_off - 4);
+        ref->patch_uncond_br = ARM_b;
+      }
+      break;
+    }
+    if (use_flags)
+      return code_off;
+    if (rpn->res.mode == MD_REG) {
+      into_reg = rpn->res.reg;
+    } else
+      into_reg = 0;
+    AIWNIOS_ADD_CODE(ARM_csetX(into_reg, ARM_NE));
+    if (rpn->res.mode != MD_REG) {
+      tmp.raw_type = rpn->raw_type;
+      tmp.reg = 0;
+      tmp.mode = MD_REG;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    }
+    break;
+  case IC_LSH:
+    BACKEND_BIT_BINOP(ARM_lslvRegX, 1);
+    break;
+  case IC_RSH:
+    switch (rpn->raw_type) {
+    case RT_U8i:
+    case RT_U16i:
+    case RT_U32i:
+    case RT_U64i:
+      BACKEND_BINOP(ARM_lsrvRegX, ARM_lsrvRegX);
+      break;
+    default:
+      BACKEND_BIT_BINOP(ARM_asrvRegX, 1);
+    }
+    break;
+  case __IC_CALL:
+  case IC_CALL:
+    //
+    // ()_()_()_()
+    // /          \     // When we call a function,all temp registers
+    // | O______O |     // are invalidated,so we can reset the temp register
+    // | \______/ |===> // counts (for the new expressions).
+    // \__________/     //
+    //   \./   \./      // We will restore the temp register counts after the
+    //   call
+    //
+    i = cctrl->backend_user_data2;
+    i2 = cctrl->backend_user_data3;
+    cctrl->backend_user_data2 = 0;
+    cctrl->backend_user_data3 = 0;
+    code_off = __ICFCallTOS(cctrl, rpn, bin, code_off);
+    cctrl->backend_user_data2 = i;
+    cctrl->backend_user_data3 = i2;
+    break;
+  case __IC_VARGS:
+    //  ^^^^^^^^
+    // (        \      ___________________
+    // ( (*) (*)|     /                   \
     //  \   ^   |    |__IFCall            |
-		//   \  <>  | <==| Will unwind for you|
-		//    \    /      \__________________/
-		//      \_/
-		if (ARM_ERR_INV_OFF != ARM_subImmX(ARM_REG_SP, ARM_REG_SP, 8 * rpn->length)) {
-			// Align to 16
-			if (rpn->length & 1)
-				AIWNIOS_ADD_CODE(ARM_subImmX(ARM_REG_SP, ARM_REG_SP, 8 + 8 * rpn->length))
-			else
-				AIWNIOS_ADD_CODE(ARM_subImmX(ARM_REG_SP, ARM_REG_SP, 8 * rpn->length))
-		} else {
-			if (rpn->length & 1) // Align to 16
-				code_off = __ICMoveI64(cctrl, 0, 8 + 8 * rpn->length, bin, code_off);
-			else
-				code_off = __ICMoveI64(cctrl, 0, 8 * rpn->length, bin, code_off);
-			AIWNIOS_ADD_CODE(ARM_subRegX(ARM_REG_SP, ARM_REG_SP, 0));
-		}
-		for (i = 0; i != rpn->length; i++) {
-			next = ICArgN(rpn, rpn->length - i - 1);
-			PushTmp(cctrl, next, &rpn->res);
-			code_off = __OptPassFinal(cctrl, next, bin, code_off);
-			PopTmp(cctrl, next);
-			tmp.reg = ARM_REG_SP;
-			tmp.off = 8 * i;
-			tmp.mode = MD_INDIR_REG;
-			tmp.raw_type = next->raw_type;
-			if (tmp.raw_type < RT_I64i)
-				tmp.raw_type = RT_I64i;
-			code_off = ICMov(cctrl, &tmp, &next->res, bin, code_off);
-		}
-		tmp.reg = ARM_REG_SP;
-		tmp.mode = MD_REG;
-		tmp.raw_type = RT_I64i;
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		break;
-	case IC_ADD_EQ:
-		code_off = __SexyAssignOp(cctrl, rpn, &ARM_addRegX, ARM_addImmX, &ARM_faddReg, bin, code_off);
-		break;
-	case IC_SUB_EQ:
-		code_off = __SexyAssignOp(cctrl, rpn, &ARM_subRegX, ARM_subImmX, &ARM_fsubReg, bin, code_off);
-		break;
-	case IC_MUL_EQ:
-		if (ICArgN(rpn, 1)->raw_type == RT_U64i) {
-			code_off = __SexyAssignOp(cctrl, rpn, &ARM_umullX, NULL, &ARM_fmulReg, bin, code_off);
-			;
-		} else
-			code_off = __SexyAssignOp(cctrl, rpn, &ARM_mulRegX, NULL, &ARM_fmulReg, bin, code_off);
-		break;
-	case IC_DIV_EQ:
-		if (ICArgN(rpn, 1)->raw_type == RT_U64i) {
-			code_off = __SexyAssignOp(cctrl, rpn, &ARM_udivX, NULL, &ARM_fdivReg, bin, code_off);
-			;
-		} else
-			code_off = __SexyAssignOp(cctrl, rpn, &ARM_sdivRegX, NULL, &ARM_fdivReg, bin, code_off);
-		break;
-	case IC_LSH_EQ:
-		if (rpn->raw_type == RT_F64)
-			abort();
-		code_off = __SexyAssignOp(cctrl, rpn, &ARM_lslvRegX, ARM_lslImmX, &ARM_lslvRegX, bin, code_off);
-		break;
-	case IC_RSH_EQ:
-		if (rpn->raw_type == RT_F64)
-			abort();
-		switch (rpn->raw_type) {
-		case RT_U8i:
-		case RT_U16i:
-		case RT_U32i:
-		case RT_U64i:
-			code_off = __SexyAssignOp(cctrl, rpn, &ARM_lsrvRegX, ARM_lsrImmX, &ARM_lsrvRegX, bin,
-				code_off);
-			break;
-		default:
-			code_off = __SexyAssignOp(cctrl, rpn, &ARM_asrvRegX, ARM_asrImmX, &ARM_asrvRegX, bin,
-				code_off);
-		}
-		break;
-	case IC_AND_EQ:
-		if (rpn->raw_type == RT_F64)
-			abort(); // TODO
-		code_off = __SexyAssignOp(cctrl, rpn, &ARM_andRegX, ARM_andImmX, &ARM_andRegX, bin, code_off);
-		break;
-	case IC_OR_EQ:
-		if (rpn->raw_type == RT_F64)
-			abort(); // TODO
-		code_off = __SexyAssignOp(cctrl, rpn, &ARM_orrRegX, ARM_orrImmX, &ARM_orrRegX, bin, code_off);
-		break;
-	case IC_XOR_EQ:
-		if (rpn->raw_type == RT_F64)
-			abort(); // TODO
-		code_off = __SexyAssignOp(cctrl, rpn, &ARM_eorRegX, ARM_eorImmX, &ARM_eorRegX, bin, code_off);
-		break;
-	case IC_ARROW:
-		abort();
-		break;
-	case IC_DOT:
-		abort();
-		break;
-	case IC_MOD_EQ:
-		// Handles IC_MOD_EQ too
-		code_off = __CompileMod(cctrl, rpn, bin, code_off);
-		break;
-	case IC_I64:
-    if(rpn->res.mode!=MD_I64) {
+    //   \  <>  | <==| Will unwind for you|
+    //    \    /      \__________________/
+    //      \_/
+    if (ARM_ERR_INV_OFF !=
+        ARM_subImmX(ARM_REG_SP, ARM_REG_SP, 8 * rpn->length)) {
+      // Align to 16
+      if (rpn->length & 1)
+        AIWNIOS_ADD_CODE(
+            ARM_subImmX(ARM_REG_SP, ARM_REG_SP, 8 + 8 * rpn->length))
+      else
+        AIWNIOS_ADD_CODE(ARM_subImmX(ARM_REG_SP, ARM_REG_SP, 8 * rpn->length))
+    } else {
+      if (rpn->length & 1) // Align to 16
+        code_off = __ICMoveI64(cctrl, 0, 8 + 8 * rpn->length, bin, code_off);
+      else
+        code_off = __ICMoveI64(cctrl, 0, 8 * rpn->length, bin, code_off);
+      AIWNIOS_ADD_CODE(ARM_subRegX(ARM_REG_SP, ARM_REG_SP, 0));
+    }
+    for (i = 0; i != rpn->length; i++) {
+      next = ICArgN(rpn, rpn->length - i - 1);
+      PushTmp(cctrl, next, &rpn->res);
+      code_off = __OptPassFinal(cctrl, next, bin, code_off);
+      PopTmp(cctrl, next);
+      tmp.reg = ARM_REG_SP;
+      tmp.off = 8 * i;
+      tmp.mode = MD_INDIR_REG;
+      tmp.raw_type = next->raw_type;
+      if (tmp.raw_type < RT_I64i)
+        tmp.raw_type = RT_I64i;
+      code_off = ICMov(cctrl, &tmp, &next->res, bin, code_off);
+    }
+    tmp.reg = ARM_REG_SP;
+    tmp.mode = MD_REG;
+    tmp.raw_type = RT_I64i;
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    break;
+  case IC_ADD_EQ:
+    code_off = __SexyAssignOp(cctrl, rpn, &ARM_addRegX, ARM_addImmX,
+                              &ARM_faddReg, bin, code_off);
+    break;
+  case IC_SUB_EQ:
+    code_off = __SexyAssignOp(cctrl, rpn, &ARM_subRegX, ARM_subImmX,
+                              &ARM_fsubReg, bin, code_off);
+    break;
+  case IC_MUL_EQ:
+    if (ICArgN(rpn, 1)->raw_type == RT_U64i) {
+      code_off = __SexyAssignOp(cctrl, rpn, &ARM_umullX, NULL, &ARM_fmulReg,
+                                bin, code_off);
+      ;
+    } else
+      code_off = __SexyAssignOp(cctrl, rpn, &ARM_mulRegX, NULL, &ARM_fmulReg,
+                                bin, code_off);
+    break;
+  case IC_DIV_EQ:
+    if (ICArgN(rpn, 1)->raw_type == RT_U64i) {
+      code_off = __SexyAssignOp(cctrl, rpn, &ARM_udivX, NULL, &ARM_fdivReg, bin,
+                                code_off);
+      ;
+    } else
+      code_off = __SexyAssignOp(cctrl, rpn, &ARM_sdivRegX, NULL, &ARM_fdivReg,
+                                bin, code_off);
+    break;
+  case IC_LSH_EQ:
+    if (rpn->raw_type == RT_F64)
+      abort();
+    code_off = __SexyAssignOp(cctrl, rpn, &ARM_lslvRegX, ARM_lslImmX,
+                              &ARM_lslvRegX, bin, code_off);
+    break;
+  case IC_RSH_EQ:
+    if (rpn->raw_type == RT_F64)
+      abort();
+    switch (rpn->raw_type) {
+    case RT_U8i:
+    case RT_U16i:
+    case RT_U32i:
+    case RT_U64i:
+      code_off = __SexyAssignOp(cctrl, rpn, &ARM_lsrvRegX, ARM_lsrImmX,
+                                &ARM_lsrvRegX, bin, code_off);
+      break;
+    default:
+      code_off = __SexyAssignOp(cctrl, rpn, &ARM_asrvRegX, ARM_asrImmX,
+                                &ARM_asrvRegX, bin, code_off);
+    }
+    break;
+  case IC_AND_EQ:
+    if (rpn->raw_type == RT_F64)
+      abort(); // TODO
+    code_off = __SexyAssignOp(cctrl, rpn, &ARM_andRegX, ARM_andImmX,
+                              &ARM_andRegX, bin, code_off);
+    break;
+  case IC_OR_EQ:
+    if (rpn->raw_type == RT_F64)
+      abort(); // TODO
+    code_off = __SexyAssignOp(cctrl, rpn, &ARM_orrRegX, ARM_orrImmX,
+                              &ARM_orrRegX, bin, code_off);
+    break;
+  case IC_XOR_EQ:
+    if (rpn->raw_type == RT_F64)
+      abort(); // TODO
+    code_off = __SexyAssignOp(cctrl, rpn, &ARM_eorRegX, ARM_eorImmX,
+                              &ARM_eorRegX, bin, code_off);
+    break;
+  case IC_ARROW:
+    abort();
+    break;
+  case IC_DOT:
+    abort();
+    break;
+  case IC_MOD_EQ:
+    // Handles IC_MOD_EQ too
+    code_off = __CompileMod(cctrl, rpn, bin, code_off);
+    break;
+  case IC_I64:
+    if (rpn->res.mode != MD_I64) {
       tmp.mode = MD_I64;
       tmp.raw_type = RT_I64i;
       tmp.integer = rpn->integer;
@@ -3824,9 +3912,9 @@ static int64_t __OptPassFinal(CCmpCtrl* cctrl, CRPN* rpn, char* bin,
       rpn->res.raw_type = RT_I64i;
       rpn->res.integer = rpn->integer;
     }
-		break;
-	case IC_F64:
-		if(rpn->res.mode!=MD_F64) {
+    break;
+  case IC_F64:
+    if (rpn->res.mode != MD_F64) {
       tmp.mode = MD_F64;
       tmp.raw_type = RT_F64;
       tmp.flt = rpn->flt;
@@ -3837,105 +3925,104 @@ static int64_t __OptPassFinal(CCmpCtrl* cctrl, CRPN* rpn, char* bin,
       rpn->res.flt = rpn->flt;
     }
     break;
-	case IC_ARRAY_ACC:
-		abort();
-		break;
-	case IC_RET:
-		next = ICArgN(rpn, 0);
-		PushTmp(cctrl, next, NULL);
-		code_off = __OptPassFinal(cctrl, next, bin, code_off);
-		PopTmp(cctrl, next);
-		if (cctrl->cur_fun)
-			tmp.raw_type = cctrl->cur_fun->return_class->raw_type;
-		else if (rpn->ic_class) {
-			// No return type so just return what we have
-			tmp.raw_type = rpn->ic_class->raw_type;
-		} else
-			// No return type so just return what we have
-			tmp.raw_type = next->raw_type;
-		tmp.reg = 0; // 0 is return register
-		tmp.mode = MD_REG;
-		code_off = ICMov(cctrl, &tmp, &next->res, bin, code_off);
-		// TempleOS will always store F64 result in RAX(integer register)
-		// Let's merge the two togheter
-		if (tmp.raw_type == RT_F64) {
-			AIWNIOS_ADD_CODE(ARM_fmovI64F64(0, 0));
-		} else {
-			// Vise versa
-			AIWNIOS_ADD_CODE(ARM_fmovF64I64(0, 0));
-		}
-		// TODO  jump to return area,not generate epilog for each poo poo
-		if (cctrl->code_ctrl->final_pass) {
-			AIWNIOS_ADD_CODE(ARM_b(0));
-			ref=CodeMiscAddRef(cctrl->epilog_label, bin + code_off - 4);
-      ref->patch_uncond_br=ARM_b;
-		} else
-			AIWNIOS_ADD_CODE(ARM_b(0));
-		break;
-	case IC_BASE_PTR:
-		tmp.raw_type = rpn->raw_type;
-    tmp.off=rpn->integer;
-		tmp.mode = MD_FRAME;
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		break;
-	case IC_STATIC:
-		tmp.raw_type = rpn->raw_type;
-		tmp.off = rpn->integer;
-		tmp.mode = MD_PTR;
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		break;
-	case IC_IREG:
-		tmp.raw_type = RT_I64i;
-		tmp.reg = rpn->integer;
-		tmp.mode = MD_REG;
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		break;
-	case IC_FREG:
-		tmp.raw_type = RT_F64;
-		tmp.reg = rpn->integer;
-		tmp.mode = MD_REG;
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		break;
-	case IC_LOAD:
-		abort();
-		break;
-	case IC_STORE:
-		abort();
-		break;
-	case __IC_STATIC_REF:
-		if (cctrl->code_ctrl->final_pass) {
-			tmp.raw_type = rpn->raw_type;
-			tmp.off = rpn->integer;
-			tmp.mode = MD_STATIC;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		} else
-			AIWNIOS_ADD_CODE(0);
-		break;
-	case __IC_SET_STATIC_DATA:
-		break; //TODO
-	}
-	//Call the Kool-Aid man because Oh-Yeah,Trump gonna be president hopefully
-	if (old_fail_addr && old_pass_addr && !IsBranchableInst(rpn)) {
-		ARM_TEST(rpn);
-		AIWNIOS_ADD_CODE(ARM_bcc(ARM_EQ, 0));
-		if (bin) {
-			ref=CodeMiscAddRef(old_fail_addr, bin + code_off - 4);
-      ref->patch_cond_br=ARM_bcc;
-      ref->user_data1=ARM_EQ;
+  case IC_ARRAY_ACC:
+    abort();
+    break;
+  case IC_RET:
+    next = ICArgN(rpn, 0);
+    PushTmp(cctrl, next, NULL);
+    code_off = __OptPassFinal(cctrl, next, bin, code_off);
+    PopTmp(cctrl, next);
+    if (cctrl->cur_fun)
+      tmp.raw_type = cctrl->cur_fun->return_class->raw_type;
+    else if (rpn->ic_class) {
+      // No return type so just return what we have
+      tmp.raw_type = rpn->ic_class->raw_type;
+    } else
+      // No return type so just return what we have
+      tmp.raw_type = next->raw_type;
+    tmp.reg = 0; // 0 is return register
+    tmp.mode = MD_REG;
+    code_off = ICMov(cctrl, &tmp, &next->res, bin, code_off);
+    // TempleOS will always store F64 result in RAX(integer register)
+    // Let's merge the two togheter
+    if (tmp.raw_type == RT_F64) {
+      AIWNIOS_ADD_CODE(ARM_fmovI64F64(0, 0));
+    } else {
+      // Vise versa
+      AIWNIOS_ADD_CODE(ARM_fmovF64I64(0, 0));
     }
-		AIWNIOS_ADD_CODE(ARM_b(0));
-		if (bin) {
-			ref=CodeMiscAddRef(old_pass_addr, bin + code_off - 4);
-      ref->patch_uncond_br=ARM_b;
+    // TODO  jump to return area,not generate epilog for each poo poo
+    if (cctrl->code_ctrl->final_pass) {
+      AIWNIOS_ADD_CODE(ARM_b(0));
+      ref = CodeMiscAddRef(cctrl->epilog_label, bin + code_off - 4);
+      ref->patch_uncond_br = ARM_b;
+    } else
+      AIWNIOS_ADD_CODE(ARM_b(0));
+    break;
+  case IC_BASE_PTR:
+    tmp.raw_type = rpn->raw_type;
+    tmp.off = rpn->integer;
+    tmp.mode = MD_FRAME;
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    break;
+  case IC_STATIC:
+    tmp.raw_type = rpn->raw_type;
+    tmp.off = rpn->integer;
+    tmp.mode = MD_PTR;
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    break;
+  case IC_IREG:
+    tmp.raw_type = RT_I64i;
+    tmp.reg = rpn->integer;
+    tmp.mode = MD_REG;
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    break;
+  case IC_FREG:
+    tmp.raw_type = RT_F64;
+    tmp.reg = rpn->integer;
+    tmp.mode = MD_REG;
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    break;
+  case IC_LOAD:
+    abort();
+    break;
+  case IC_STORE:
+    abort();
+    break;
+  case __IC_STATIC_REF:
+    if (cctrl->code_ctrl->final_pass) {
+      tmp.raw_type = rpn->raw_type;
+      tmp.off = rpn->integer;
+      tmp.mode = MD_STATIC;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    } else
+      AIWNIOS_ADD_CODE(0);
+    break;
+  case __IC_SET_STATIC_DATA:
+    break; // TODO
+  }
+  // Call the Kool-Aid man because Oh-Yeah,Trump gonna be president hopefully
+  if (old_fail_addr && old_pass_addr && !IsBranchableInst(rpn)) {
+    ARM_TEST(rpn);
+    AIWNIOS_ADD_CODE(ARM_bcc(ARM_EQ, 0));
+    if (bin) {
+      ref = CodeMiscAddRef(old_fail_addr, bin + code_off - 4);
+      ref->patch_cond_br = ARM_bcc;
+      ref->user_data1 = ARM_EQ;
     }
-	}
-  cctrl->backend_user_data5=old_fail_addr;
-  cctrl->backend_user_data6=old_pass_addr;
-	return code_off;
+    AIWNIOS_ADD_CODE(ARM_b(0));
+    if (bin) {
+      ref = CodeMiscAddRef(old_pass_addr, bin + code_off - 4);
+      ref->patch_uncond_br = ARM_b;
+    }
+  }
+  cctrl->backend_user_data5 = old_fail_addr;
+  cctrl->backend_user_data6 = old_pass_addr;
+  return code_off;
 }
 
-static void DoNothing()
-{
+static void DoNothing() {
 }
 
 // This dude calls __OptPassFinal 2 times.
@@ -3944,209 +4031,217 @@ static void DoNothing()
 //    This pass  will also asign CRPN->res with tmp registers/FRAME offsets
 // 2. Fill in function body
 //
-char* OptPassFinal(CCmpCtrl* cctrl, int64_t* res_sz, char** dbg_info)
-{
-	int64_t code_off, run, idx, cnt = 0, cnt2, final_size, is_terminal;
-	int64_t min_ln = 0, max_ln = 0, statics_sz = 0;
-	char* bin = NULL;
-	char* ptr;
-	CCodeMisc* misc;
-	CHashImport* import;
-  CCodeMiscRef *cm_ref,*cm_ref_tmp;
-	CRPN* r;
-	cctrl->epilog_label = CodeMiscNew(cctrl, CMT_LABEL);
-	cctrl->statics_label = CodeMiscNew(cctrl, CMT_LABEL);
-	for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code; r = r->base.next) {
-		if (r->ic_line) {
-			if (!min_ln)
-				min_ln = r->ic_line;
-			min_ln = (min_ln < r->ic_line) ? min_ln : r->ic_line;
-			if (!max_ln)
-				max_ln = r->ic_line;
-			max_ln = (max_ln > r->ic_line) ? max_ln : r->ic_line;
-		}
-		// Move all frame offsets over by 16(for FP/LR) area on the frame
-		if (r->type == IC_BASE_PTR) {
-			r->integer += 16;
-		} else if (r->type == __IC_STATICS_SIZE)
-			statics_sz = r->integer;
-	}
-	for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code; r = ICFwd(r)) {
-		cnt++;
-	}
-	if (dbg_info) {
-		// Dont allocate on cctrl->hc heap ctrl as we want to share our datqa
-		cctrl->code_ctrl->dbg_info = dbg_info;
-		cctrl->code_ctrl->min_ln = min_ln;
-	}
-	CRPN* forwards[cnt2 = cnt];
-	cnt = 0;
-	for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code; r = ICFwd(r)) {
-		forwards[cnt2 - ++cnt] = r;
-	}
-	// We DONT reset the wiggle room
-	cctrl->backend_user_data0 = 0;
-	// 0 get maximum code size,
-	// 1 final pass
-	for (run = 0; run != 2; run++) {
-		cctrl->code_ctrl->final_pass = run;
-		cctrl->backend_user_data1 = 0;
-		cctrl->backend_user_data2 = 0;
-		cctrl->backend_user_data3 = 0;
-		if (run == 0) {
-			code_off = 0;
-			bin = NULL;
-		} else if (run == 1) {
-			// Dont allocate on cctrl->hc heap ctrl as we want to share our data
-			bin = A_MALLOC(code_off, NULL);
-			code_off = 0;
-		}
-		code_off = FuncProlog(cctrl, bin, code_off);
-		for (cnt = 0; cnt < cnt2; cnt++) {
-		enter:
-			r = forwards[cnt];
-      r->res.mode=MD_NULL;
-			code_off = __OptPassFinal(cctrl, r, bin, code_off);
-			if (IsTerminalInst(r)) {
-				cnt++;
-				for (; cnt < cnt2; cnt++) {
-					if (forwards[cnt]->type == IC_LABEL)
-						goto enter;
-				}
-			}
-		}
-		cctrl->epilog_label->addr = code_off + bin;
-		code_off = FuncEpilog(cctrl, bin, code_off);
-		for (misc = cctrl->code_ctrl->code_misc->next;
-			 misc != cctrl->code_ctrl->code_misc; misc = misc->base.next) {
-			switch (misc->type) {
-				break;
-			case CMT_INT_CONST:
-				if (code_off % 8)
-					code_off += 8 - code_off % 8;
-				misc->addr = bin + code_off;
-				if (bin)
-					*(int64_t*)(bin + code_off) = misc->integer;
-fill_in_refs:
-#define FILL_IN_REFS \
-				for (cm_ref = misc->refs; cm_ref; cm_ref = cm_ref_tmp) { \
-					cm_ref_tmp = cm_ref->next; \
-					if (run) { \
-            if(cm_ref->patch_cond_br) \
-              *(int32_t*)cm_ref->add_to=cm_ref->patch_cond_br(cm_ref->user_data1,(char*)misc->addr-(char*)cm_ref->add_to+cm_ref->offset); \
-            if(cm_ref->patch_uncond_br) \
-              *(int32_t*)cm_ref->add_to=cm_ref->patch_uncond_br((char*)misc->addr-(char*)cm_ref->add_to+cm_ref->offset); \
-          } \
-					A_FREE(cm_ref); \
-				} \
-        misc->refs = NULL;
-				FILL_IN_REFS;
-				code_off += 8;
-				break;
-			case CMT_FLOAT_CONST:
-				if (code_off % 8)
-					code_off += 8 - code_off % 8;
-				misc->addr = bin + code_off;
-				if (bin)
-					*(double*)(bin + code_off) = misc->flt;
-				code_off += 8;
+char *OptPassFinal(CCmpCtrl *cctrl, int64_t *res_sz, char **dbg_info) {
+  int64_t code_off, run, idx, cnt = 0, cnt2, final_size, is_terminal;
+  int64_t min_ln = 0, max_ln = 0, statics_sz = 0;
+  char *bin = NULL;
+  char *ptr;
+  CCodeMisc *misc;
+  CHashImport *import;
+  CCodeMiscRef *cm_ref, *cm_ref_tmp;
+  CRPN *r;
+  cctrl->epilog_label = CodeMiscNew(cctrl, CMT_LABEL);
+  cctrl->statics_label = CodeMiscNew(cctrl, CMT_LABEL);
+  for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code;
+       r = r->base.next) {
+    if (r->ic_line) {
+      if (!min_ln)
+        min_ln = r->ic_line;
+      min_ln = (min_ln < r->ic_line) ? min_ln : r->ic_line;
+      if (!max_ln)
+        max_ln = r->ic_line;
+      max_ln = (max_ln > r->ic_line) ? max_ln : r->ic_line;
+    }
+    // Move all frame offsets over by 16(for FP/LR) area on the frame
+    if (r->type == IC_BASE_PTR) {
+      r->integer += 16;
+    } else if (r->type == __IC_STATICS_SIZE)
+      statics_sz = r->integer;
+  }
+  for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code;
+       r = ICFwd(r)) {
+    cnt++;
+  }
+  if (dbg_info) {
+    // Dont allocate on cctrl->hc heap ctrl as we want to share our datqa
+    cctrl->code_ctrl->dbg_info = dbg_info;
+    cctrl->code_ctrl->min_ln = min_ln;
+  }
+  CRPN *forwards[cnt2 = cnt];
+  cnt = 0;
+  for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code;
+       r = ICFwd(r)) {
+    forwards[cnt2 - ++cnt] = r;
+  }
+  // We DONT reset the wiggle room
+  cctrl->backend_user_data0 = 0;
+  // 0 get maximum code size,
+  // 1 final pass
+  for (run = 0; run != 2; run++) {
+    cctrl->code_ctrl->final_pass = run;
+    cctrl->backend_user_data1 = 0;
+    cctrl->backend_user_data2 = 0;
+    cctrl->backend_user_data3 = 0;
+    if (run == 0) {
+      code_off = 0;
+      bin = NULL;
+    } else if (run == 1) {
+      // Dont allocate on cctrl->hc heap ctrl as we want to share our data
+      bin = A_MALLOC(code_off, NULL);
+      code_off = 0;
+    }
+    code_off = FuncProlog(cctrl, bin, code_off);
+    for (cnt = 0; cnt < cnt2; cnt++) {
+    enter:
+      r = forwards[cnt];
+      r->res.mode = MD_NULL;
+      code_off = __OptPassFinal(cctrl, r, bin, code_off);
+      if (IsTerminalInst(r)) {
+        cnt++;
+        for (; cnt < cnt2; cnt++) {
+          if (forwards[cnt]->type == IC_LABEL)
+            goto enter;
+        }
+      }
+    }
+    cctrl->epilog_label->addr = code_off + bin;
+    code_off = FuncEpilog(cctrl, bin, code_off);
+    for (misc = cctrl->code_ctrl->code_misc->next;
+         misc != cctrl->code_ctrl->code_misc; misc = misc->base.next) {
+      switch (misc->type) {
+        break;
+      case CMT_INT_CONST:
+        if (code_off % 8)
+          code_off += 8 - code_off % 8;
+        misc->addr = bin + code_off;
+        if (bin)
+          *(int64_t *)(bin + code_off) = misc->integer;
+      fill_in_refs:
+#define FILL_IN_REFS                                                           \
+  for (cm_ref = misc->refs; cm_ref; cm_ref = cm_ref_tmp) {                     \
+    cm_ref_tmp = cm_ref->next;                                                 \
+    if (run) {                                                                 \
+      if (cm_ref->patch_cond_br)                                               \
+        *(int32_t *)cm_ref->add_to = cm_ref->patch_cond_br(                    \
+            cm_ref->user_data1,                                                \
+            (char *)misc->addr - (char *)cm_ref->add_to + cm_ref->offset);     \
+      if (cm_ref->patch_uncond_br)                                             \
+        *(int32_t *)cm_ref->add_to = cm_ref->patch_uncond_br(                  \
+            (char *)misc->addr - (char *)cm_ref->add_to + cm_ref->offset);     \
+    }                                                                          \
+    A_FREE(cm_ref);                                                            \
+  }                                                                            \
+  misc->refs = NULL;
+        FILL_IN_REFS;
+        code_off += 8;
+        break;
+      case CMT_FLOAT_CONST:
+        if (code_off % 8)
+          code_off += 8 - code_off % 8;
+        misc->addr = bin + code_off;
+        if (bin)
+          *(double *)(bin + code_off) = misc->flt;
+        code_off += 8;
         goto fill_in_refs;
-				break;
-			case CMT_JMP_TAB:
-				if (code_off % 8)
-					code_off += 8 - code_off % 8;
-				misc->addr = bin + code_off;
-        if(misc->patch_addr) *misc->patch_addr=misc->addr;
-				if (bin) {
+        break;
+      case CMT_JMP_TAB:
+        if (code_off % 8)
+          code_off += 8 - code_off % 8;
+        misc->addr = bin + code_off;
+        if (misc->patch_addr)
+          *misc->patch_addr = misc->addr;
+        if (bin) {
           for (idx = 0; idx <= misc->hi - misc->lo; idx++)
-						*(void**)(bin + code_off + idx * 8) = (char*)misc->jmp_tab[idx]->addr;
-				}
-				code_off += (misc->hi - misc->lo + 1) * 8;
+            *(void **)(bin + code_off + idx * 8) =
+                (char *)misc->jmp_tab[idx]->addr;
+        }
+        code_off += (misc->hi - misc->lo + 1) * 8;
         goto fill_in_refs;
-			case CMT_LABEL:
-        if(misc!=cctrl->statics_label) //Filled in later
+      case CMT_LABEL:
+        if (misc != cctrl->statics_label) // Filled in later
           goto fill_in_refs;
-				break;
-			case CMT_SHORT_ADDR:
-				if (run && misc->patch_addr) {
-					*misc->patch_addr = misc->addr;
-				}
-				break;
-			case CMT_RELOC_U64:
-				// No need to make room for an unued misc
-				if (run && !misc->use_cnt&&misc->patch_addr) {
-					*misc->patch_addr = INVALID_PTR;
-					break;
-				}
-				if (code_off % 8)
-					code_off += 8 - code_off % 8;
-				misc->addr = bin + code_off;
-				if (bin)
-					*(int64_t*)(bin + code_off) = &DoNothing;
-				code_off += 8;
-				//
-				// 1 is the final run,we add the relocation to the hash table
-				//
-				if (run) {
-					import = A_CALLOC(sizeof(CHashImport), NULL);
-					import->base.type = HTT_IMPORT_SYS_SYM;
-					import->base.str = A_STRDUP(misc->str, NULL);
-					import->address = misc->addr;
-					HashAdd(import, Fs->hash_table);
-				}
-				if (run && misc->patch_addr) {
-					*misc->patch_addr = misc->addr;
-				}
+        break;
+      case CMT_SHORT_ADDR:
+        if (run && misc->patch_addr) {
+          *misc->patch_addr = misc->addr;
+        }
+        break;
+      case CMT_RELOC_U64:
+        // No need to make room for an unued misc
+        if (run && !misc->use_cnt && misc->patch_addr) {
+          *misc->patch_addr = INVALID_PTR;
+          break;
+        }
+        if (code_off % 8)
+          code_off += 8 - code_off % 8;
+        misc->addr = bin + code_off;
+        if (bin)
+          *(int64_t *)(bin + code_off) = &DoNothing;
+        code_off += 8;
+        //
+        // 1 is the final run,we add the relocation to the hash table
+        //
+        if (run) {
+          import = A_CALLOC(sizeof(CHashImport), NULL);
+          import->base.type = HTT_IMPORT_SYS_SYM;
+          import->base.str = A_STRDUP(misc->str, NULL);
+          import->address = misc->addr;
+          HashAdd(import, Fs->hash_table);
+        }
+        if (run && misc->patch_addr) {
+          *misc->patch_addr = misc->addr;
+        }
         goto fill_in_refs;
-				break;
-			case CMT_STRING:
-				if (!(cctrl->flags & CCF_STRINGS_ON_HEAP)) {
-					if (code_off % 8)
-						code_off += 8 - code_off % 8;
-					misc->addr = bin + code_off;
-					if (bin)
-						memcpy(bin + code_off, misc->str, misc->str_len);
-					code_off += misc->str_len;
+        break;
+      case CMT_STRING:
+        if (!(cctrl->flags & CCF_STRINGS_ON_HEAP)) {
+          if (code_off % 8)
+            code_off += 8 - code_off % 8;
+          misc->addr = bin + code_off;
+          if (bin)
+            memcpy(bin + code_off, misc->str, misc->str_len);
+          code_off += misc->str_len;
           goto fill_in_refs;
-				} else {
-					if (run) {
-						// See IC_STR: We "steal" the ->str because it's already on the heap.
-						//  IC_STR steals the ->str point so we dont want to Free it
-						misc->str = NULL;
-					}
-				}
-			}
-		}
-		if (run) {
-			if (code_off % 8) // Align to 8
-				code_off += 8 - code_off % 8;
-			cctrl->statics_label->addr = code_off + bin;
-			if (statics_sz)
-				code_off += statics_sz + 8;
-			if (run)
-				final_size = code_off;
-      misc=cctrl->statics_label;
+        } else {
+          if (run) {
+            // See IC_STR: We "steal" the ->str because it's already on the
+            // heap.
+            //  IC_STR steals the ->str point so we dont want to Free it
+            misc->str = NULL;
+          }
+        }
+      }
+    }
+    if (run) {
+      if (code_off % 8) // Align to 8
+        code_off += 8 - code_off % 8;
+      cctrl->statics_label->addr = code_off + bin;
+      if (statics_sz)
+        code_off += statics_sz + 8;
+      if (run)
+        final_size = code_off;
+      misc = cctrl->statics_label;
       FILL_IN_REFS;
-		}
-	}
-	__builtin___clear_cache(bin, bin + MSize(bin));
-	if (dbg_info) {
-		cnt = MSize(dbg_info) / 8;
-		ptr = dbg_info[0] = bin;
-		for (idx = 1; idx < cnt; idx++) {
-			if (!dbg_info[idx]) {
-				dbg_info[idx] = NULL;
-				continue;
-			}
-			if (ptr > dbg_info[idx]) {
-				// No backwards jumps
-				dbg_info[idx] = NULL;
-				continue;
-			}
-			ptr = dbg_info[idx];
-		}
-	}
-	if (res_sz)
-		*res_sz = final_size;
-	return bin;
+    }
+  }
+  __builtin___clear_cache(bin, bin + MSize(bin));
+  if (dbg_info) {
+    cnt = MSize(dbg_info) / 8;
+    ptr = dbg_info[0] = bin;
+    for (idx = 1; idx < cnt; idx++) {
+      if (!dbg_info[idx]) {
+        dbg_info[idx] = NULL;
+        continue;
+      }
+      if (ptr > dbg_info[idx]) {
+        // No backwards jumps
+        dbg_info[idx] = NULL;
+        continue;
+      }
+      ptr = dbg_info[idx];
+    }
+  }
+  if (res_sz)
+    *res_sz = final_size;
+  return bin;
 }

--- a/arm_loader.c
+++ b/arm_loader.c
@@ -1,9 +1,9 @@
 #include "aiwn.h"
 #include <string.h>
 typedef struct _CHashImport {
-	CHash base;
-	char* module_base;
-	char* module_header_entry;
+  CHash base;
+  char *module_base;
+  char *module_header_entry;
 } _CHashImport;
 
 #define IET_END 0
@@ -25,281 +25,272 @@ typedef struct _CHashImport {
 #define IET_REL64_EXPORT 18 // Not implemented
 #define IET_IMM64_EXPORT 19 // Not implemented
 #define IET_ABS_ADDR 20
-#define IET_CODE_HEAP 21 // Not really used
+#define IET_CODE_HEAP 21        // Not really used
 #define IET_ZEROED_CODE_HEAP 22 // Not really used
 #define IET_DATA_HEAP 23
 #define IET_ZEROED_DATA_HEAP 24 // Not really used
 #define IET_MAIN 25
 
-static void LoadOneImport(char** _src, char* module_base, int64_t ld_flags)
-{
-	char *src = *_src, *ptr2, *st_ptr;
-	int64_t i, etype;
-	CHashExport* tmpex = NULL;
-	_CHashImport* tmpiss;
-	int64_t first = 1;
+static void LoadOneImport(char **_src, char *module_base, int64_t ld_flags) {
+  char *src = *_src, *ptr2, *st_ptr;
+  int64_t i, etype;
+  CHashExport *tmpex = NULL;
+  _CHashImport *tmpiss;
+  int64_t first = 1;
 
-	while (etype = *src++) {
-		i = *(int32_t*)src;
-		src += 4;
-		st_ptr = src;
-		src += strlen(st_ptr) + 1;
-		if (*st_ptr) {
-			if (!first) {
-				*_src = st_ptr - 5;
-				return;
-			} else {
-				first = 0;
-				if (!(tmpex = HashFind(st_ptr,
-						  Fs->hash_table, HTT_FUN | HTT_GLBL_VAR | HTT_EXPORT_SYS_SYM, 1))) {
-					printf("Unresolved Reference:%s\n", st_ptr);
-					tmpiss = A_CALLOC(sizeof(_CHashImport), NULL);
-					tmpiss->base.str = A_STRDUP(st_ptr, NULL);
-					tmpiss->base.type = HTT_IMPORT_SYS_SYM2;
-					tmpiss->module_header_entry = st_ptr - 5;
-					tmpiss->module_base = module_base;
-					HashAdd(tmpiss, Fs->hash_table);
-				}
-			}
-		}
-		if (tmpex) {
-			ptr2 = module_base + i;
-			if (tmpex->base.type & HTT_FUN)
-				i = ((CHashFun*)tmpex)->fun_ptr;
-			else if (tmpex->base.type & HTT_GLBL_VAR)
-				i = ((CHashGlblVar*)tmpex)->data_addr;
-			else
-				i = tmpex->val;
-			switch (etype) {
-			case IET_REL_I8:
-				*(char*)ptr2 = i - (int64_t)ptr2 - 1;
-				break;
-			case IET_IMM_U8:
-				*(char*)ptr2 = i;
-				break;
-			case IET_REL_I16:
-				*(int16_t*)ptr2 = i - (int64_t)ptr2 - 2;
-				break;
-			case IET_IMM_U16:
-				*(int16_t*)ptr2 = i;
-				break;
-			case IET_REL_I32:
-				*(int32_t*)ptr2 = i - (int64_t)ptr2 - 4;
-				break;
-			case IET_IMM_U32:
-				*(int32_t*)ptr2 = i;
-				break;
-			case IET_REL_I64:
-				*(int64_t*)ptr2 = i - (int64_t)ptr2 - 8;
-				break;
-			case IET_IMM_I64:
-				*(int64_t*)ptr2 = i;
-				break;
-			}
-		}
-	}
-	*_src = src - 1;
+  while (etype = *src++) {
+    i = *(int32_t *)src;
+    src += 4;
+    st_ptr = src;
+    src += strlen(st_ptr) + 1;
+    if (*st_ptr) {
+      if (!first) {
+        *_src = st_ptr - 5;
+        return;
+      } else {
+        first = 0;
+        if (!(tmpex =
+                  HashFind(st_ptr, Fs->hash_table,
+                           HTT_FUN | HTT_GLBL_VAR | HTT_EXPORT_SYS_SYM, 1))) {
+          printf("Unresolved Reference:%s\n", st_ptr);
+          tmpiss = A_CALLOC(sizeof(_CHashImport), NULL);
+          tmpiss->base.str = A_STRDUP(st_ptr, NULL);
+          tmpiss->base.type = HTT_IMPORT_SYS_SYM2;
+          tmpiss->module_header_entry = st_ptr - 5;
+          tmpiss->module_base = module_base;
+          HashAdd(tmpiss, Fs->hash_table);
+        }
+      }
+    }
+    if (tmpex) {
+      ptr2 = module_base + i;
+      if (tmpex->base.type & HTT_FUN)
+        i = ((CHashFun *)tmpex)->fun_ptr;
+      else if (tmpex->base.type & HTT_GLBL_VAR)
+        i = ((CHashGlblVar *)tmpex)->data_addr;
+      else
+        i = tmpex->val;
+      switch (etype) {
+      case IET_REL_I8:
+        *(char *)ptr2 = i - (int64_t)ptr2 - 1;
+        break;
+      case IET_IMM_U8:
+        *(char *)ptr2 = i;
+        break;
+      case IET_REL_I16:
+        *(int16_t *)ptr2 = i - (int64_t)ptr2 - 2;
+        break;
+      case IET_IMM_U16:
+        *(int16_t *)ptr2 = i;
+        break;
+      case IET_REL_I32:
+        *(int32_t *)ptr2 = i - (int64_t)ptr2 - 4;
+        break;
+      case IET_IMM_U32:
+        *(int32_t *)ptr2 = i;
+        break;
+      case IET_REL_I64:
+        *(int64_t *)ptr2 = i - (int64_t)ptr2 - 8;
+        break;
+      case IET_IMM_I64:
+        *(int64_t *)ptr2 = i;
+        break;
+      }
+    }
+  }
+  *_src = src - 1;
 }
 
-static void SysSymImportsResolve2(char* st_ptr, int64_t ld_flags)
-{
-	_CHashImport* tmpiss;
-	char* ptr;
-	while (tmpiss = HashSingleTableFind(st_ptr,
-			   Fs->hash_table, HTT_IMPORT_SYS_SYM2, 1)) {
-		ptr = tmpiss->module_header_entry;
-		LoadOneImport(&ptr, tmpiss->module_base, ld_flags);
-		tmpiss->base.type = HTT_INVALID;
-	}
+static void SysSymImportsResolve2(char *st_ptr, int64_t ld_flags) {
+  _CHashImport *tmpiss;
+  char *ptr;
+  while (tmpiss = HashSingleTableFind(st_ptr, Fs->hash_table,
+                                      HTT_IMPORT_SYS_SYM2, 1)) {
+    ptr = tmpiss->module_header_entry;
+    LoadOneImport(&ptr, tmpiss->module_base, ld_flags);
+    tmpiss->base.type = HTT_INVALID;
+  }
 }
 
-static void LoadPass1(char* src, char* module_base, int64_t ld_flags)
-{
-	char *ptr2, *ptr3, *st_ptr;
-	int64_t i, j, cnt, etype;
-	CHashExport* tmpex = NULL;
-	while (etype = *src++) {
-		i = *(int32_t*)src;
-		src += 4;
-		st_ptr = src;
-		src += strlen(st_ptr) + 1;
-		switch (etype) {
-		case IET_REL32_EXPORT:
-		case IET_IMM32_EXPORT:
-		case IET_REL64_EXPORT:
-		case IET_IMM64_EXPORT:
-			tmpex = A_CALLOC(sizeof(CHashExport), NULL);
-			tmpex->base.str = A_STRDUP(st_ptr, NULL);
-			tmpex->base.type = HTT_EXPORT_SYS_SYM;
-			if (etype == IET_IMM32_EXPORT || etype == IET_IMM64_EXPORT)
-				tmpex->val = i;
-			else
-				tmpex->val = i + module_base;
-			HashAdd(tmpex, Fs->hash_table);
-			SysSymImportsResolve2(st_ptr, ld_flags);
-			break;
-		case IET_REL_I0 ... IET_IMM_I64:
-			src = st_ptr - 5;
-			LoadOneImport(&src, module_base, ld_flags);
-			break;
-		case IET_ABS_ADDR:
-			if (0)
-				src += i * sizeof(int32_t);
-			else {
-				cnt = i;
-				for (j = 0; j < cnt; j++) {
-					ptr2 = module_base + *(int32_t*)src;
-					src += 4;
-					// Changed to 64bit by nroot
-					*(int64_t*)ptr2 += module_base;
-				}
-			}
-			break;
+static void LoadPass1(char *src, char *module_base, int64_t ld_flags) {
+  char *ptr2, *ptr3, *st_ptr;
+  int64_t i, j, cnt, etype;
+  CHashExport *tmpex = NULL;
+  while (etype = *src++) {
+    i = *(int32_t *)src;
+    src += 4;
+    st_ptr = src;
+    src += strlen(st_ptr) + 1;
+    switch (etype) {
+    case IET_REL32_EXPORT:
+    case IET_IMM32_EXPORT:
+    case IET_REL64_EXPORT:
+    case IET_IMM64_EXPORT:
+      tmpex = A_CALLOC(sizeof(CHashExport), NULL);
+      tmpex->base.str = A_STRDUP(st_ptr, NULL);
+      tmpex->base.type = HTT_EXPORT_SYS_SYM;
+      if (etype == IET_IMM32_EXPORT || etype == IET_IMM64_EXPORT)
+        tmpex->val = i;
+      else
+        tmpex->val = i + module_base;
+      HashAdd(tmpex, Fs->hash_table);
+      SysSymImportsResolve2(st_ptr, ld_flags);
+      break;
+    case IET_REL_I0 ... IET_IMM_I64:
+      src = st_ptr - 5;
+      LoadOneImport(&src, module_base, ld_flags);
+      break;
+    case IET_ABS_ADDR:
+      if (0)
+        src += i * sizeof(int32_t);
+      else {
+        cnt = i;
+        for (j = 0; j < cnt; j++) {
+          ptr2 = module_base + *(int32_t *)src;
+          src += 4;
+          // Changed to 64bit by nroot
+          *(int64_t *)ptr2 += module_base;
+        }
+      }
+      break;
 
-		case IET_CODE_HEAP:
-			ptr3 = A_MALLOC(*(int32_t*)src, NULL);
-			src += 4;
-			goto end;
-		case IET_ZEROED_CODE_HEAP:
-			ptr3 = A_MALLOC(*(int32_t*)src, NULL);
-			src += 4;
-		end:
-			if (*st_ptr) {
-				tmpex = A_CALLOC(sizeof(CHashExport), NULL);
-				tmpex->base.str = A_STRDUP(st_ptr, NULL);
-				tmpex->base.type = HTT_EXPORT_SYS_SYM;
-				tmpex->val = ptr3;
-				HashAdd(tmpex, Fs->hash_table);
-			}
-			cnt = i;
-			for (j = 0; j < cnt; j++) {
-				ptr2 = module_base + *(int32_t*)src;
-				src += 4;
-				*(int32_t*)ptr2 += ptr3;
-			}
-			break;
+    case IET_CODE_HEAP:
+      ptr3 = A_MALLOC(*(int32_t *)src, NULL);
+      src += 4;
+      goto end;
+    case IET_ZEROED_CODE_HEAP:
+      ptr3 = A_MALLOC(*(int32_t *)src, NULL);
+      src += 4;
+    end:
+      if (*st_ptr) {
+        tmpex = A_CALLOC(sizeof(CHashExport), NULL);
+        tmpex->base.str = A_STRDUP(st_ptr, NULL);
+        tmpex->base.type = HTT_EXPORT_SYS_SYM;
+        tmpex->val = ptr3;
+        HashAdd(tmpex, Fs->hash_table);
+      }
+      cnt = i;
+      for (j = 0; j < cnt; j++) {
+        ptr2 = module_base + *(int32_t *)src;
+        src += 4;
+        *(int32_t *)ptr2 += ptr3;
+      }
+      break;
 
-		case IET_DATA_HEAP:
-			ptr3 = A_MALLOC(*(int64_t*)src, NULL);
-			src += 8;
-			goto end;
-		case IET_ZEROED_DATA_HEAP:
-			ptr3 = A_CALLOC(*(int64_t*)src, NULL);
-			src += 8;
-			goto end;
-		end2:
-			if (*st_ptr) {
-				tmpex = A_CALLOC(sizeof(CHashExport), NULL);
-				tmpex->base.str = A_STRDUP(st_ptr, NULL);
-				tmpex->base.type = HTT_EXPORT_SYS_SYM;
-				tmpex->val = ptr3;
-				HashAdd(tmpex, Fs->hash_table);
-			}
-			cnt = i;
-			for (j = 0; j < cnt; j++) {
-				ptr2 = module_base + *(int32_t*)src;
-				src += 4;
-				*(int64_t*)ptr2 += ptr3;
-			}
-			break;
-		}
-	}
+    case IET_DATA_HEAP:
+      ptr3 = A_MALLOC(*(int64_t *)src, NULL);
+      src += 8;
+      goto end;
+    case IET_ZEROED_DATA_HEAP:
+      ptr3 = A_CALLOC(*(int64_t *)src, NULL);
+      src += 8;
+      goto end;
+    end2:
+      if (*st_ptr) {
+        tmpex = A_CALLOC(sizeof(CHashExport), NULL);
+        tmpex->base.str = A_STRDUP(st_ptr, NULL);
+        tmpex->base.type = HTT_EXPORT_SYS_SYM;
+        tmpex->val = ptr3;
+        HashAdd(tmpex, Fs->hash_table);
+      }
+      cnt = i;
+      for (j = 0; j < cnt; j++) {
+        ptr2 = module_base + *(int32_t *)src;
+        src += 4;
+        *(int64_t *)ptr2 += ptr3;
+      }
+      break;
+    }
+  }
 }
 
-static void LoadPass2(char* src, char* module_base)
-{
-	char* st_ptr;
-	int64_t i, etype;
-	void (*fptr)();
-	while (etype = *src++) {
-		i = *(int32_t*)src;
-		src += 4;
-		st_ptr = src;
-		src += strlen(st_ptr) + 1;
-		switch (etype) {
-		case IET_MAIN:
-			fptr = (i + module_base);
+static void LoadPass2(char *src, char *module_base) {
+  char *st_ptr;
+  int64_t i, etype;
+  void (*fptr)();
+  while (etype = *src++) {
+    i = *(int32_t *)src;
+    src += 4;
+    st_ptr = src;
+    src += strlen(st_ptr) + 1;
+    switch (etype) {
+    case IET_MAIN:
+      fptr = (i + module_base);
 #ifdef USE_TEMPLEOS_ABI
-			FFI_CALL_TOS_0(fptr);
+      FFI_CALL_TOS_0(fptr);
 #else
-			(*fptr)();
+      (*fptr)();
 #endif
-			break;
-		case IET_ABS_ADDR:
-			src += sizeof(int32_t) * i;
-			break;
-		case IET_CODE_HEAP:
-		case IET_ZEROED_CODE_HEAP:
-			src += 4 + sizeof(int32_t) * i;
-			break;
-		case IET_DATA_HEAP:
-		case IET_ZEROED_DATA_HEAP:
-			src += 8 + sizeof(int32_t) * i;
-			break;
-		}
-	}
+      break;
+    case IET_ABS_ADDR:
+      src += sizeof(int32_t) * i;
+      break;
+    case IET_CODE_HEAP:
+    case IET_ZEROED_CODE_HEAP:
+      src += 4 + sizeof(int32_t) * i;
+      break;
+    case IET_DATA_HEAP:
+    case IET_ZEROED_DATA_HEAP:
+      src += 8 + sizeof(int32_t) * i;
+      break;
+    }
+  }
 }
 
 /*
 class CBinFile
-{//$LK,"Bin File Header Generation",A="FF:::/Compiler/CMain.HC,16 ALIGN"$ by compiler.
-  U16	jmp;
-  U8	module_align_bits,
-	reserved;
-  U32	bin_signature;
-  I64	org,
-	patch_table_offset, //$LK,"Patch Table Generation",A="FF:::/Compiler/CMain.HC,IET_ABS_ADDR"$
-	file_size;
+{//$LK,"Bin File Header Generation",A="FF:::/Compiler/CMain.HC,16 ALIGN"$ by
+compiler. U16	jmp; U8	module_align_bits, reserved; U32	bin_signature; I64	org,
+  patch_table_offset, //$LK,"Patch Table
+Generation",A="FF:::/Compiler/CMain.HC,IET_ABS_ADDR"$ file_size;
 };
  */
 typedef struct CBinFile {
-	uint16_t jmp;
-	int8_t module_align_bits, reserved;
-	char bin_signature[4];
-	int64_t org, patch_table_offset, file_size;
+  uint16_t jmp;
+  int8_t module_align_bits, reserved;
+  char bin_signature[4];
+  int64_t org, patch_table_offset, file_size;
 } CBinFile;
-char* Load(char* filename)
-{ // Load a .BIN file module into memory.
-	// bfh_addr==INVALID_PTR means don't care what load addr.
-	char *fbuf = filename, *module_base, *absname;
-	int64_t size, module_align, misalignment;
-	CBinFile* bfh;
-	CBinFile* bfh_addr;
+char *Load(char *filename) { // Load a .BIN file module into memory.
+  // bfh_addr==INVALID_PTR means don't care what load addr.
+  char *fbuf = filename, *module_base, *absname;
+  int64_t size, module_align, misalignment;
+  CBinFile *bfh;
+  CBinFile *bfh_addr;
 
-	if (!(bfh = FileRead(fbuf, &size))) {
-		return NULL;
-	}
+  if (!(bfh = FileRead(fbuf, &size))) {
+    return NULL;
+  }
 
-	// See $LK,"Patch Table Generation",A="FF:::/Compiler/CMain.HC,IET_ABS_ADDR"$
-	module_align = 1 << bfh->module_align_bits;
-	if (!module_align /*|| bfh->bin_signature != BIN_SIGNATURE_VAL*/) {
-		A_FREE(bfh);
-		throw(*(int32_t*)"BINM");
-	}
+  // See $LK,"Patch Table Generation",A="FF:::/Compiler/CMain.HC,IET_ABS_ADDR"$
+  module_align = 1 << bfh->module_align_bits;
+  if (!module_align /*|| bfh->bin_signature != BIN_SIGNATURE_VAL*/) {
+    A_FREE(bfh);
+    throw(*(int32_t *)"BINM");
+  }
 
-	bfh_addr = bfh;
+  bfh_addr = bfh;
 
 lo_skip:
-	module_base = (char*)bfh_addr + sizeof(CBinFile);
+  module_base = (char *)bfh_addr + sizeof(CBinFile);
 
-	LoadPass1((char*)bfh_addr + bfh_addr->patch_table_offset, module_base, 0);
-	LoadPass2((char*)bfh_addr + bfh_addr->patch_table_offset, module_base);
-	return bfh_addr;
+  LoadPass1((char *)bfh_addr + bfh_addr->patch_table_offset, module_base, 0);
+  LoadPass2((char *)bfh_addr + bfh_addr->patch_table_offset, module_base);
+  return bfh_addr;
 }
 
-void ImportSymbolsToHolyC(void (*cb)(char* name, void* addr))
-{
-	int64_t idx = 0;
-	CHashExport* h;
-	for (idx = 0; idx <= Fs->hash_table->mask; idx++) {
-		for (h = Fs->hash_table->body[idx]; h; h = h->base.next) {
-			if (h->base.type & HTT_EXPORT_SYS_SYM) {
+void ImportSymbolsToHolyC(void (*cb)(char *name, void *addr)) {
+  int64_t idx = 0;
+  CHashExport *h;
+  for (idx = 0; idx <= Fs->hash_table->mask; idx++) {
+    for (h = Fs->hash_table->body[idx]; h; h = h->base.next) {
+      if (h->base.type & HTT_EXPORT_SYS_SYM) {
 #ifdef USE_TEMPLEOS_ABI
-				FFI_CALL_TOS_2(cb, h->base.str, h->val);
+        FFI_CALL_TOS_2(cb, h->base.str, h->val);
 #else
-				cb(h->base.str, h->val);
+        cb(h->base.str, h->val);
 #endif
-			}
-		}
-	}
+      }
+    }
+  }
 }

--- a/bungis.c
+++ b/bungis.c
@@ -10,28 +10,28 @@
 //
 struct CHeapCtrl;
 struct CHashTable;
-__thread struct CTask* Fs;
-__thread struct CTask* HolyFs;
-void TaskExit()
-{
-	// TODO implement me
-	exit(0);
+__thread struct CTask *Fs;
+__thread struct CTask *HolyFs;
+void TaskExit() {
+  // TODO implement me
+  exit(0);
 }
 
-void TaskInit(CTask* task, void* addr, int64_t stk_sz)
-{
-	if (!stk_sz)
-		stk_sz = 512 * (1 << 9);
-	CExcept* except;
-	memset(task, 0, sizeof(CTask));
-	task->heap = HeapCtrlInit(NULL, task,1);
-	task->except = A_MALLOC(sizeof(CQue), task);
-	task->stack = A_MALLOC(stk_sz, task);
-	QueInit(task->except);
-	except = A_MALLOC(sizeof(CExcept), task);
-	AIWNIOS_makecontext(&task->ctx, addr, (void*)(-0x10 & (int64_t)(task->stack + MSize(task->stack))));
-	QueIns(except, task->except);
-	task->hash_table = HashTableNew(1 << 10, task);
-	if (Fs && Fs != task)
-		task->hash_table->next = Fs->hash_table;
+void TaskInit(CTask *task, void *addr, int64_t stk_sz) {
+  if (!stk_sz)
+    stk_sz = 512 * (1 << 9);
+  CExcept *except;
+  memset(task, 0, sizeof(CTask));
+  task->heap = HeapCtrlInit(NULL, task, 1);
+  task->except = A_MALLOC(sizeof(CQue), task);
+  task->stack = A_MALLOC(stk_sz, task);
+  QueInit(task->except);
+  except = A_MALLOC(sizeof(CExcept), task);
+  AIWNIOS_makecontext(
+      &task->ctx, addr,
+      (void *)(-0x10 & (int64_t)(task->stack + MSize(task->stack))));
+  QueIns(except, task->except);
+  task->hash_table = HashTableNew(1 << 10, task);
+  if (Fs && Fs != task)
+    task->hash_table->next = Fs->hash_table;
 }

--- a/cque.c
+++ b/cque.c
@@ -2,40 +2,38 @@
 #include "aiwn.h"
 #include <stdint.h>
 #define INTERFACE 0
-void QueInit(CQue* i) { i->next = i, i->last = i; }
-
-void QueIns(CQue* a, CQue* to)
-{
-	a->next = to->next;
-	a->last = to;
-	a->last->next = a;
-	a->next->last = a;
+void QueInit(CQue *i) {
+  i->next = i, i->last = i;
 }
 
-void QueRem(CQue* a)
-{
-	CQue *next = a->next, *last = a->last;
-	next->last = last;
-	last->next = next;
-	QueInit(a);
+void QueIns(CQue *a, CQue *to) {
+  a->next = to->next;
+  a->last = to;
+  a->last->next = a;
+  a->next->last = a;
 }
 
-int64_t QueCnt(CQue* head)
-{
-	int64_t r = 0;
-	CQue* q;
-	for (q = head->next; q != head; q = q->next)
-		r++;
-	return r;
+void QueRem(CQue *a) {
+  CQue *next = a->next, *last = a->last;
+  next->last = last;
+  last->next = next;
+  QueInit(a);
 }
 
-void QueDel(CQue* f)
-{
-	CQue *next = f->next, *next2;
-	while (next != f) {
-		next2 = next->next;
-		A_FREE(next);
-		next = next2;
-	}
-	A_FREE(f);
+int64_t QueCnt(CQue *head) {
+  int64_t r = 0;
+  CQue *q;
+  for (q = head->next; q != head; q = q->next)
+    r++;
+  return r;
+}
+
+void QueDel(CQue *f) {
+  CQue *next = f->next, *next2;
+  while (next != f) {
+    next2 = next->next;
+    A_FREE(next);
+    next = next2;
+  }
+  A_FREE(f);
 }

--- a/dbg.c
+++ b/dbg.c
@@ -1,180 +1,178 @@
 #include "aiwn.h"
 #include <signal.h>
-//Look at your vendor's ucontext.h
-#define __USE_GNU 
+// Look at your vendor's ucontext.h
+#define __USE_GNU
 #if defined(__linux__) || defined(__FreeBSD__)
-#include <ucontext.h>
+  #include <ucontext.h>
 #endif
-static void UnblockSignals()
-{
+static void UnblockSignals() {
 #if defined(__linux__) || defined(__FreeBSD__)
-	sigset_t set;
-	sigemptyset(&set);
-	sigaddset(&set, SIGSEGV);
-	sigaddset(&set, SIGBUS);
-	sigaddset(&set, SIGTRAP);
-	sigaddset(&set, SIGFPE);
-	sigprocmask(SIG_UNBLOCK, &set, NULL);
+  sigset_t set;
+  sigemptyset(&set);
+  sigaddset(&set, SIGSEGV);
+  sigaddset(&set, SIGBUS);
+  sigaddset(&set, SIGTRAP);
+  sigaddset(&set, SIGFPE);
+  sigprocmask(SIG_UNBLOCK, &set, NULL);
 #endif
 }
 #if defined(__linux__) || defined(__FreeBSD__)
-static void SigHandler(int64_t sig, siginfo_t* info, ucontext_t* _ctx)
-{
-#if defined(__x86_64__)
-	#if defined(__linux__)
-	//See /usr/include/x86_64-linux-gnu/sys/ucontext.h
-enum
-{
-  REG_R8 = 0,
-  REG_R9,
-  REG_R10,
-  REG_R11,
-  REG_R12,
-  REG_R13,
-  REG_R14,
-  REG_R15,
-  REG_RDI,
-  REG_RSI,
-  REG_RBP,
-  REG_RBX,
-  REG_RDX,
-  REG_RAX,
-  REG_RCX,
-  REG_RSP,
-  REG_RIP,
-};
-	UnblockSignals();
-	mcontext_t* ctx = &_ctx->uc_mcontext;
-	int64_t actx[32];
-	actx[0]=ctx->gregs[REG_RIP];
-	actx[1]=ctx->gregs[REG_RSP];
-	actx[2]=ctx->gregs[REG_RBP];
-	actx[3]=ctx->gregs[REG_RBX];
-	actx[4]=ctx->gregs[REG_R12];
-	actx[5]=ctx->gregs[REG_R13];
-	actx[6]=ctx->gregs[REG_R14];
-	actx[7]=ctx->gregs[REG_R15];
-	CHashExport* exp;
-	if (exp = HashFind("AiwniosDbgCB", Fs->hash_table, HTT_EXPORT_SYS_SYM, 1)) {
-		FFI_CALL_TOS_2(exp->val,sig, actx);
-	} else if (exp = HashFind("Exit", Fs->hash_table, HTT_EXPORT_SYS_SYM, 1)) {
-		ctx->gregs[0] = exp->val;
-	} else
-		abort();
-	setcontext(_ctx);
-	#elif defined(__FreeBSD__)
-	UnblockSignals();
-	mcontext_t* ctx = &_ctx->uc_mcontext;
-	int64_t actx[32];
-	actx[0]=ctx->mc_rip;
-	actx[1]=ctx->mc_rsp;
-	actx[2]=ctx->mc_rbp;
-	actx[3]=ctx->mc_rbx;
-	actx[4]=ctx->mc_r12;
-	actx[5]=ctx->mc_r13;
-	actx[6]=ctx->mc_r14;
-	actx[7]=ctx->mc_r15;
-	CHashExport* exp;
-	if (exp = HashFind("AiwniosDbgCB", Fs->hash_table, HTT_EXPORT_SYS_SYM, 1)) {
-		FFI_CALL_TOS_2(exp->val,sig, actx);
-	} else if (exp = HashFind("Exit", Fs->hash_table, HTT_EXPORT_SYS_SYM, 1)) {
-		ctx->mc_rip = exp->val;
-	} else
-		abort();
-	setcontext(_ctx);
-	#endif
-#elif defined(__aarch64__) || defined(_M_ARM64)
-	mcontext_t* ctx = &_ctx->uc_mcontext;
-	CHashExport* exp;
-	int64_t is_single_step;
-	// See swapctxAARCH64.s
-	//  I have a secret,im only filling in saved registers as they are used
-	//  for vairables in Aiwnios. I dont have plans on adding tmp registers
-	//  in here anytime soon
-	int64_t (*fp)(int64_t sig, int64_t * ctx), (*fp2)();
-	int64_t actx[(30 - 18 + 1) + (15 - 8 + 1) + 1];
-	int64_t i, i2, sz, fp_idx;
-	UnblockSignals();
-	for (i = 18; i <= 30; i++)
-		if (i - 18 != 12) // the 12th one is the return register
-#if defined (__linux__)
-			actx[i - 18] = ctx->regs[i];
-#elif defined(__FreeBSD__)
-			actx[i - 18] = ctx->mc_gpregs.gp_x[i];
-#endif 
-#if defined (__linux__)
-	// We will look for FPSIMD_MAGIC(0x46508001)
-	// From https://github.com/torvalds/linux/blob/master/arch/arm64/include/uapi/asm/sigcontext.h
-	for (i = 0; i < 4096;) {
-		sz = ((uint32_t*)(&ctx->__reserved[i]))[1];
-		if (((uint32_t*)(&ctx->__reserved[i]))[0] == 0x46508001) {
-			i += 4 + 4 + 4 + 4;
-			fp_idx = i;
-			for (i2 = 8; i2 <= 15; i2++)
-				actx[(30 - 18 + 1) + i2 - 8] = *(int64_t*)(&ctx->__reserved[fp_idx + 16 * i2]);
-			break;
-		} else if (!sz)
-			break;
-		else
-			i += sz;
-	}
-#elif defined (__FreeBSD__)
-	for (i2 = 8; i2 <= 15; i2++)
-		actx[(30 - 18 + 1) + i2 - 8] = *(int64_t*)(&ctx->mc_fpregs.fp_q[16 * i2]);
-#endif
-#if defined(__linux__)
-	actx[21] = ctx->sp;
-#elif defined(__FreeBSD__)
-	actx[21] = ctx->mc_gpregs.gp_sp;
-#endif
-	// AiwniosDbgCB will return 1 for singlestep
-	if (exp = HashFind("AiwniosDbgCB", Fs->hash_table, HTT_EXPORT_SYS_SYM, 1)) {
-		fp = exp->val;
-		if(FFI_CALL_TOS_2(fp,sig,actx)) { //Returns 1 for single step
-#if defined (__x86_64__)
-#if defined(__FreeBSD__)
-			ctx->mc_rip=actx[0];
-			ctx->mc_rsp=actx[1];
-			ctx->mc_rbp=actx[2];
-			ctx->mc_rbx=actx[3];
-			ctx->mc_r12=actx[4];
-			ctx->mc_r13=actx[5];
-			ctx->mc_r14=actx[6];
-			ctx->mc_r15=actx[7];
-			ctx->mc_eflags|=1<<8;
-#elif defined(__linux__)
-			ctx->gregs[REG_RIP]=actx[0];
-			ctx->gregs[REG_RSP]=actx[1];
-			ctx->gregs[REG_RBP]=actx[2];
-			ctx->gregs[REG_RBX]=actx[3];
-			ctx->gregs[REG_R12]=actx[4];
-			ctx->gregs[REG_R13]=actx[5];
-			ctx->gregs[REG_R14]=actx[6];
-			ctx->gregs[REG_R15]=actx[7];
-#endif
-#endif
-		}
-	} else if (exp = HashFind("Exit", Fs->hash_table, HTT_EXPORT_SYS_SYM, 1)) {
-call_exit:
-		fp2 = exp->val;
-		FFI_CALL_TOS_0(fp2);
-	} else
-		abort();
-	goto call_exit; 
-#endif
+static void SigHandler(int64_t sig, siginfo_t *info, ucontext_t *_ctx) {
+  #if defined(__x86_64__)
+    #if defined(__linux__)
+  // See /usr/include/x86_64-linux-gnu/sys/ucontext.h
+  enum {
+    REG_R8 = 0,
+    REG_R9,
+    REG_R10,
+    REG_R11,
+    REG_R12,
+    REG_R13,
+    REG_R14,
+    REG_R15,
+    REG_RDI,
+    REG_RSI,
+    REG_RBP,
+    REG_RBX,
+    REG_RDX,
+    REG_RAX,
+    REG_RCX,
+    REG_RSP,
+    REG_RIP,
+  };
+  UnblockSignals();
+  mcontext_t *ctx = &_ctx->uc_mcontext;
+  int64_t actx[32];
+  actx[0] = ctx->gregs[REG_RIP];
+  actx[1] = ctx->gregs[REG_RSP];
+  actx[2] = ctx->gregs[REG_RBP];
+  actx[3] = ctx->gregs[REG_RBX];
+  actx[4] = ctx->gregs[REG_R12];
+  actx[5] = ctx->gregs[REG_R13];
+  actx[6] = ctx->gregs[REG_R14];
+  actx[7] = ctx->gregs[REG_R15];
+  CHashExport *exp;
+  if (exp = HashFind("AiwniosDbgCB", Fs->hash_table, HTT_EXPORT_SYS_SYM, 1)) {
+    FFI_CALL_TOS_2(exp->val, sig, actx);
+  } else if (exp = HashFind("Exit", Fs->hash_table, HTT_EXPORT_SYS_SYM, 1)) {
+    ctx->gregs[0] = exp->val;
+  } else
+    abort();
+  setcontext(_ctx);
+    #elif defined(__FreeBSD__)
+  UnblockSignals();
+  mcontext_t *ctx = &_ctx->uc_mcontext;
+  int64_t actx[32];
+  actx[0] = ctx->mc_rip;
+  actx[1] = ctx->mc_rsp;
+  actx[2] = ctx->mc_rbp;
+  actx[3] = ctx->mc_rbx;
+  actx[4] = ctx->mc_r12;
+  actx[5] = ctx->mc_r13;
+  actx[6] = ctx->mc_r14;
+  actx[7] = ctx->mc_r15;
+  CHashExport *exp;
+  if (exp = HashFind("AiwniosDbgCB", Fs->hash_table, HTT_EXPORT_SYS_SYM, 1)) {
+    FFI_CALL_TOS_2(exp->val, sig, actx);
+  } else if (exp = HashFind("Exit", Fs->hash_table, HTT_EXPORT_SYS_SYM, 1)) {
+    ctx->mc_rip = exp->val;
+  } else
+    abort();
+  setcontext(_ctx);
+    #endif
+  #elif defined(__aarch64__) || defined(_M_ARM64)
+  mcontext_t *ctx = &_ctx->uc_mcontext;
+  CHashExport *exp;
+  int64_t is_single_step;
+  // See swapctxAARCH64.s
+  //  I have a secret,im only filling in saved registers as they are used
+  //  for vairables in Aiwnios. I dont have plans on adding tmp registers
+  //  in here anytime soon
+  int64_t (*fp)(int64_t sig, int64_t * ctx), (*fp2)();
+  int64_t actx[(30 - 18 + 1) + (15 - 8 + 1) + 1];
+  int64_t i, i2, sz, fp_idx;
+  UnblockSignals();
+  for (i = 18; i <= 30; i++)
+    if (i - 18 != 12) // the 12th one is the return register
+    #if defined(__linux__)
+      actx[i - 18] = ctx->regs[i];
+    #elif defined(__FreeBSD__)
+      actx[i - 18] = ctx->mc_gpregs.gp_x[i];
+    #endif
+    #if defined(__linux__)
+  // We will look for FPSIMD_MAGIC(0x46508001)
+  // From
+  // https://github.com/torvalds/linux/blob/master/arch/arm64/include/uapi/asm/sigcontext.h
+  for (i = 0; i < 4096;) {
+    sz = ((uint32_t *)(&ctx->__reserved[i]))[1];
+    if (((uint32_t *)(&ctx->__reserved[i]))[0] == 0x46508001) {
+      i += 4 + 4 + 4 + 4;
+      fp_idx = i;
+      for (i2 = 8; i2 <= 15; i2++)
+        actx[(30 - 18 + 1) + i2 - 8] =
+            *(int64_t *)(&ctx->__reserved[fp_idx + 16 * i2]);
+      break;
+    } else if (!sz)
+      break;
+    else
+      i += sz;
+  }
+    #elif defined(__FreeBSD__)
+  for (i2 = 8; i2 <= 15; i2++)
+    actx[(30 - 18 + 1) + i2 - 8] = *(int64_t *)(&ctx->mc_fpregs.fp_q[16 * i2]);
+    #endif
+    #if defined(__linux__)
+  actx[21] = ctx->sp;
+    #elif defined(__FreeBSD__)
+  actx[21] = ctx->mc_gpregs.gp_sp;
+    #endif
+  // AiwniosDbgCB will return 1 for singlestep
+  if (exp = HashFind("AiwniosDbgCB", Fs->hash_table, HTT_EXPORT_SYS_SYM, 1)) {
+    fp = exp->val;
+    if (FFI_CALL_TOS_2(fp, sig, actx)) { // Returns 1 for single step
+    #if defined(__x86_64__)
+      #if defined(__FreeBSD__)
+      ctx->mc_rip = actx[0];
+      ctx->mc_rsp = actx[1];
+      ctx->mc_rbp = actx[2];
+      ctx->mc_rbx = actx[3];
+      ctx->mc_r12 = actx[4];
+      ctx->mc_r13 = actx[5];
+      ctx->mc_r14 = actx[6];
+      ctx->mc_r15 = actx[7];
+      ctx->mc_eflags |= 1 << 8;
+      #elif defined(__linux__)
+      ctx->gregs[REG_RIP] = actx[0];
+      ctx->gregs[REG_RSP] = actx[1];
+      ctx->gregs[REG_RBP] = actx[2];
+      ctx->gregs[REG_RBX] = actx[3];
+      ctx->gregs[REG_R12] = actx[4];
+      ctx->gregs[REG_R13] = actx[5];
+      ctx->gregs[REG_R14] = actx[6];
+      ctx->gregs[REG_R15] = actx[7];
+      #endif
+    #endif
+    }
+  } else if (exp = HashFind("Exit", Fs->hash_table, HTT_EXPORT_SYS_SYM, 1)) {
+  call_exit:
+    fp2 = exp->val;
+    FFI_CALL_TOS_0(fp2);
+  } else
+    abort();
+  goto call_exit;
+  #endif
 }
 #endif
-void InstallDbgSignalsForThread()
-{
-#if defined(__linux__)|| defined(__FreeBSD__)
-	struct sigaction sa;
-	memset(&sa, 0, sizeof(struct sigaction));
-	sa.sa_handler = SIG_IGN;
-	sa.sa_flags = SA_SIGINFO;
-	sa.sa_sigaction = SigHandler;
-	sigaction(SIGSEGV, &sa, NULL);
-	sigaction(SIGBUS, &sa, NULL);
-	sigaction(SIGTRAP, &sa, NULL);
-	sigaction(SIGFPE, &sa, NULL);
+void InstallDbgSignalsForThread() {
+#if defined(__linux__) || defined(__FreeBSD__)
+  struct sigaction sa;
+  memset(&sa, 0, sizeof(struct sigaction));
+  sa.sa_handler = SIG_IGN;
+  sa.sa_flags = SA_SIGINFO;
+  sa.sa_sigaction = SigHandler;
+  sigaction(SIGSEGV, &sa, NULL);
+  sigaction(SIGBUS, &sa, NULL);
+  sigaction(SIGTRAP, &sa, NULL);
+  sigaction(SIGFPE, &sa, NULL);
 #endif
 }

--- a/except.c
+++ b/except.c
@@ -2,42 +2,37 @@
 #include "aiwn.h"
 #include <setjmp.h>
 // See AIWNIOS_enter_try t in except_*.s
-jmp_buf* __enter_try()
-{
-	CExcept* ex = A_MALLOC(sizeof(CExcept), Fs);
-	QueIns(ex, Fs->except->last);
-	Fs->catch_except = 0;
-	return &ex->ctx;
+jmp_buf *__enter_try() {
+  CExcept *ex = A_MALLOC(sizeof(CExcept), Fs);
+  QueIns(ex, Fs->except->last);
+  Fs->catch_except = 0;
+  return &ex->ctx;
 }
-jmp_buf* __throw(uint64_t code)
-{
-	Fs->except_ch = code;
-	CExcept* ex;
-	Fs->catch_except = 0;
-	Fs->except_ch = code;
-	QueRem(ex = Fs->except->last);
-	memcpy(Fs->throw_pad, ex->ctx, sizeof(ex->ctx));
-	A_FREE(ex);
-	return &(Fs->throw_pad);
+jmp_buf *__throw(uint64_t code) {
+  Fs->except_ch = code;
+  CExcept *ex;
+  Fs->catch_except = 0;
+  Fs->except_ch = code;
+  QueRem(ex = Fs->except->last);
+  memcpy(Fs->throw_pad, ex->ctx, sizeof(ex->ctx));
+  A_FREE(ex);
+  return &(Fs->throw_pad);
 }
-void AIWNIOS_ExitCatch()
-{
-	if (Fs->catch_except) {
-		Fs->catch_except = 0;
-	} else
-		throw(Fs->except_ch);
+void AIWNIOS_ExitCatch() {
+  if (Fs->catch_except) {
+    Fs->catch_except = 0;
+  } else
+    throw(Fs->except_ch);
 }
 
-int64_t AIWNIOS_enter_try()
-{
-	return !setjmp(*__enter_try());
+int64_t AIWNIOS_enter_try() {
+  return !setjmp(*__enter_try());
 }
 
-void AIWNIOS_throw(uint64_t c)
-{
-	CHashExport *exp;
-	if(exp=HashFind("throw",Fs->hash_table,HTT_EXPORT_SYS_SYM,1)) {
-		FFI_CALL_TOS_1(exp->val,c);
-	}
-	abort();
+void AIWNIOS_throw(uint64_t c) {
+  CHashExport *exp;
+  if (exp = HashFind("throw", Fs->hash_table, HTT_EXPORT_SYS_SYM, 1)) {
+    FFI_CALL_TOS_1(exp->val, c);
+  }
+  abort();
 }

--- a/ffi_call_tos.s
+++ b/ffi_call_tos.s
@@ -1,61 +1,63 @@
-SECTION .text
-GLOBAL FFI_CALL_TOS_0
+.intel_syntax noprefix
+
+.global FFI_CALL_TOS_0
+.global FFI_CALL_TOS_1
+.global FFI_CALL_TOS_2
+.global FFI_CALL_TOS_3
+.global FFI_CALL_TOS_4
+
 FFI_CALL_TOS_0:
-PUSH RBP
-MOV RBP,RSP
-PUSH RBX
-CALL RDI
-POP RBX
-LEAVE
-RET
+  push rbp
+  mov rbp,rsp
+  push rbx
+  call rdi
+  pop rbx
+  leave
+  ret
 
 
-GLOBAL FFI_CALL_TOS_1
 FFI_CALL_TOS_1:
-PUSH RBP
-MOV RBP,RSP
-PUSH RBX
-PUSH RSI
-CALL RDI
-POP RBX
-LEAVE
-RET
+  push rbp
+  mov rbp,rsp
+  push rbx
+  push rsi
+  call rdi
+  pop rbx
+  leave
+  ret
 
-GLOBAL FFI_CALL_TOS_2
 FFI_CALL_TOS_2:
-PUSH RBP
-MOV RBP,RSP
-PUSH RBX
-PUSH RDX
-PUSH RSI
-CALL RDI
-POP RBX
-LEAVE
-RET
+  push rbp
+  mov rbp,rsp
+  push rbx
+  push rdx
+  push rsi
+  call rdi
+  pop rbx
+  leave
+  ret
 
-GLOBAL FFI_CALL_TOS_3
 FFI_CALL_TOS_3:
-PUSH RBP
-MOV RBP,RSP
-PUSH RBX
-PUSH RCX
-PUSH RDX
-PUSH RSI
-CALL RDI
-POP RBX
-LEAVE
-RET
+  push rbp
+  mov rbp,rsp
+  push rbx
+  push rcx
+  push rdx
+  push rsi
+  call rdi
+  pop rbx
+  leave
+  ret
 
-GLOBAL FFI_CALL_TOS_4
 FFI_CALL_TOS_4:
-PUSH RBP
-MOV RBP,RSP
-PUSH RBX
-PUSH R8
-PUSH RCX
-PUSH RDX
-PUSH RSI
-CALL RDI
-POP RBX
-LEAVE
-RET
+  push rbp
+  mov rbp,rsp
+  push rbx
+  push r8
+  push rcx
+  push rdx
+  push rsi
+  call rdi
+  pop rbx
+  leave
+  ret

--- a/ffi_call_tos_WIN.s
+++ b/ffi_call_tos_WIN.s
@@ -1,75 +1,75 @@
-SECTION .text
-;Poo Poo FFI for Windows64 to TempleOS
-GLOBAL FFI_CALL_TOS_0
+.intel_syntax noprefix
+.global FFI_CALL_TOS_0
+.global FFI_CALL_TOS_1
+.global FFI_CALL_TOS_2
+.global FFI_CALL_TOS_3
+.global FFI_CALL_TOS_4
+# Poo Poo FFI for Windows64 to TempleOS
+
 FFI_CALL_TOS_0:
-PUSH RBP
-MOV RBP,RSP
-AND RSP,-0x10
-PUSH RBX
-CALL RCX
-POP RBX
-LEAVE
-RET
+  push rbp
+  mov rbp,rsp
+  and rsp,-0x10
+  push rbx
+  call rcx
+  pop rbx
+  leave
+  ret
 
-GLOBAL FFI_CALL_TOS_1
 FFI_CALL_TOS_1:
-PUSH RBP
-MOV RBP,RSP
-AND RSP,-0x10
-; Ditto
-PUSH RBX
-PUSH RDX
-CALL RCX
-POP RBX 
-LEAVE
-RET
+  push rbp
+  mov rbp,rsp
+  and rsp,-0x10
+  push rbx
+  push rdx
+  call rcx
+  pop rbx 
+  leave
+  ret
 
-GLOBAL FFI_CALL_TOS_2
 FFI_CALL_TOS_2:
-PUSH RBP
-MOV RBP,RSP
-AND RSP,-0x10
-PUSH RBX
-PUSH R8
-PUSH RDX
-CALL RCX
-POP RBX
-LEAVE
-RET
+  push rbp
+  mov rbp,rsp
+  and rsp,-0x10
+  push rbx
+  push r8
+  push rdx
+  call rcx
+  pop rbx
+  leave
+  ret
 
-GLOBAL FFI_CALL_TOS_3
 FFI_CALL_TOS_3:
-PUSH RBP
-MOV RBP,RSP
-AND RSP,-0x10
-PUSH RBX
-PUSH R9
-PUSH R8
-PUSH RDX
-CALL RCX
-POP RBX
-LEAVE
-RET
+  push rbp
+  mov rbp,rsp
+  and rsp,-0x10
+  push rbx
+  push r9
+  push r8
+  push rdx
+  call rcx
+  pop rbx
+  leave
+  ret
 
-; https://docs.microsoft.com/en-us/cpp/build/stack-usage?view=msvc-170
-; Fist stack arg:0x30
-; R9 HOME+0x28 
-; R8 HOME+0x20
-; RDX HOME+0x18
-; RCX HOME+0x10
-; RET ADDR+8
-; RBP
-GLOBAL FFI_CALL_TOS_4
+# https://docs.microsoft.com/en-us/cpp/build/stack-usage?view=msvc-170
+# Fist stack arg:0x30
+# R9 HOME+0x28 
+# R8 HOME+0x20
+# RDX HOME+0x18
+# RCX HOME+0x10
+# RET ADDR+8
+# RBP
 FFI_CALL_TOS_4:
-PUSH RBP
-MOV RBP,RSP
-AND RSP,-0x10
-PUSH RBX
-PUSH QWORD [RBP+0x30]
-PUSH R9
-PUSH R8
-PUSH RDX
-CALL RCX
-POP RBX
-LEAVE
-RET
+  push rbp
+  mov rbp,rsp
+  and rsp,-0x10
+  push rbx
+  push qword ptr [rbp+0x30]
+  push r9
+  push r8
+  push rdx
+  call rcx
+  pop rbx
+  leave
+  ret

--- a/ffi_gen.c
+++ b/ffi_gen.c
@@ -1,57 +1,58 @@
 #include "aiwn.h"
 #if defined(_WIN32) || defined(WIN32)
-void* GenFFIBinding(void* fptr, int64_t arity)
-{
-#ifdef USE_TEMPLEOS_ABI
-/*
-0:  55                      push   rbp
-1:  48 89 e5                mov    rbp,rsp
-4:  48 83 e4 f0             and    rsp,0xfffffffffffffff0
-8:  41 52                   push   r10
-a:  41 53                   push   r11
-c:  48 83 ec 20             sub    rsp,0x20
-10: 48 b8 55 44 33 22 11    movabs rax,0x1122334455
-17: 00 00 00
-1a: 48 8d 4d 10             lea    rcx,[rbp+0x10]
-1e: ff d0                   call   rax
-20: 48 83 c4 20             add    rsp,0x20
-24: 41 5b                   pop    r11
-26: 41 5a                   pop    r10
-28: c9                      leave
-29: c2 34 12                ret    0x1234 */
-	char* ffi_binding = "\x55\x48\x89\xE5\x48\x83\xE4\xF0\x41\x52\x41\x53\x48\x83\xEC\x20\x48\xB8\x55\x44\x33\x22\x11\x00\x00\x00\x48\x8D\x4D\x10\xFF\xD0\x48\x83\xC4\x20\x41\x5B\x41\x5A\xC9\xC2\x34\x12";
-	char* ret = A_MALLOC(0x2c, NULL);
-	memcpy(ret, ffi_binding, 0x2c);
-	*(int64_t*)(ret + 0x12) = fptr;
-	*(int16_t*)(ret + 0x2a) = arity*8;
-	return ret;
-#else
-	return fptr;
-#endif
+void *GenFFIBinding(void *fptr, int64_t arity) {
+  #ifdef USE_TEMPLEOS_ABI
+  /*
+  0:  55                      push   rbp
+  1:  48 89 e5                mov    rbp,rsp
+  4:  48 83 e4 f0             and    rsp,0xfffffffffffffff0
+  8:  41 52                   push   r10
+  a:  41 53                   push   r11
+  c:  48 83 ec 20             sub    rsp,0x20
+  10: 48 b8 55 44 33 22 11    movabs rax,0x1122334455
+  17: 00 00 00
+  1a: 48 8d 4d 10             lea    rcx,[rbp+0x10]
+  1e: ff d0                   call   rax
+  20: 48 83 c4 20             add    rsp,0x20
+  24: 41 5b                   pop    r11
+  26: 41 5a                   pop    r10
+  28: c9                      leave
+  29: c2 34 12                ret    0x1234 */
+  char *ffi_binding =
+      "\x55\x48\x89\xE5\x48\x83\xE4\xF0\x41\x52\x41\x53\x48\x83\xEC\x20\x48\xB8"
+      "\x55\x44\x33\x22\x11\x00\x00\x00\x48\x8D\x4D\x10\xFF\xD0\x48\x83\xC4\x20"
+      "\x41\x5B\x41\x5A\xC9\xC2\x34\x12";
+  char *ret = A_MALLOC(0x2c, NULL);
+  memcpy(ret, ffi_binding, 0x2c);
+  *(int64_t *)(ret + 0x12) = fptr;
+  *(int16_t *)(ret + 0x2a) = arity * 8;
+  return ret;
+  #else
+  return fptr;
+  #endif
 }
-void* GenFFIBindingNaked(void* fptr, int64_t arity)
-{
-	/*
-	0:  \x48\x8D\x4C\x24\x08          lea    rcx,[rsp+0x8]
-	5:  48 b8 55 44 33 22 11    movabs rax,0x1122334455
-	c:  00 00 00
-	f:  ff e0 					jmp rax
-	*/
-	const char* ffi_binding = "\x48\x8D\x4C\x24\x08\x48\xB8\x55\x44\x33\x22\x11\x00\x00\x00\xFF\xe0";
-#ifdef USE_TEMPLEOS_ABI
-	char* ret = A_MALLOC(0x12, NULL);
-	memcpy(ret, ffi_binding, 0x12);
-	*(int64_t*)(ret + 0x7) = fptr;
-	return ret;
-#else
-	return fptr;
-#endif
+void *GenFFIBindingNaked(void *fptr, int64_t arity) {
+  /*
+  0:  \x48\x8D\x4C\x24\x08          lea    rcx,[rsp+0x8]
+  5:  48 b8 55 44 33 22 11    movabs rax,0x1122334455
+  c:  00 00 00
+  f:  ff e0 					jmp rax
+  */
+  const char *ffi_binding =
+      "\x48\x8D\x4C\x24\x08\x48\xB8\x55\x44\x33\x22\x11\x00\x00\x00\xFF\xe0";
+  #ifdef USE_TEMPLEOS_ABI
+  char *ret = A_MALLOC(0x12, NULL);
+  memcpy(ret, ffi_binding, 0x12);
+  *(int64_t *)(ret + 0x7) = fptr;
+  return ret;
+  #else
+  return fptr;
+  #endif
 }
-#elif (defined (__linux__) ||defined (__FreeBSD__)) && defined (__x86_64__)
-void* GenFFIBinding(void* fptr, int64_t arity)
-{
-#ifdef USE_TEMPLEOS_ABI
-	/*
+#elif (defined(__linux__) || defined(__FreeBSD__)) && defined(__x86_64__)
+void *GenFFIBinding(void *fptr, int64_t arity) {
+  #ifdef USE_TEMPLEOS_ABI
+  /*
 0:  55                      push   rbp
 1:  48 89 e5                mov    rbp,rsp
 4:  48 83 e4 f0             and    rsp,0xfffffffffffffff0
@@ -90,64 +91,74 @@ a2: f2 44 0f 10 74 24 50    movsd  xmm14,QWORD PTR [rsp+0x50]
 a9: f2 44 0f 10 7c 24 58    movsd  xmm15,QWORD PTR [rsp+0x58]
 b0: 66 48 0f 6e c0          movq   xmm0,rax
 b5: c9                      leave
-b6: c2 22 11                ret    0x1122 
+b6: c2 22 11                ret    0x1122
 */
-	// Look at the silly sauce at https://defuse.ca/online-x86-assembler.htm#disassembly
-	// Is 0x22 bytes long
-	const char* ffi_binding = "\x55\x48\x89\xE5\x48\x83\xE4\xF0\x48\x83\xEC\x60\xF2\x0F\x11\x74\x24\x08\xF2\x0F\x11\x7C\x24\x10\xF2\x44\x0F\x11\x44\x24\x18\xF2\x44\x0F\x11\x4C\x24\x20\xF2\x44\x0F\x11\x54\x24\x28\xF2\x44\x0F\x11\x5C\x24\x30\xF2\x44\x0F\x11\x64\x24\x38\xF2\x44\x0F\x11\x6C\x24\x40\xF2\x44\x0F\x11\x74\x24\x50\xF2\x44\x0F\x11\x7C\x24\x58\x56\x57\x41\x52\x41\x53\x48\x8D\x7D\x10\x48\xB8\x55\x44\x33\x22\x11\x00\x00\x00\xFF\xD0\x41\x5B\x41\x5A\x5F\x5E\xF2\x0F\x10\x74\x24\x08\xF2\x0F\x10\x7C\x24\x10\xF2\x44\x0F\x10\x44\x24\x18\xF2\x44\x0F\x10\x4C\x24\x20\xF2\x44\x0F\x10\x54\x24\x28\xF2\x44\x0F\x10\x5C\x24\x30\xF2\x44\x0F\x10\x64\x24\x38\xF2\x44\x0F\x10\x6C\x24\x40\xF2\x44\x0F\x10\x74\x24\x50\xF2\x44\x0F\x10\x7C\x24\x58\x66\x48\x0F\x6E\xC0\xC9\xC2\x22\x11";
-	char* ret = A_MALLOC(0xb9, NULL);
-	memcpy(ret, ffi_binding, 0xb9);
-	*(int64_t*)(ret + 0x5c) = fptr;
-	*(int16_t*)(ret + 0xb7) = arity*8;
-	return ret;
-#else
-	return fptr;
-#endif
+  // Look at the silly sauce at
+  // https://defuse.ca/online-x86-assembler.htm#disassembly Is 0x22 bytes long
+  const char *ffi_binding =
+      "\x55\x48\x89\xE5\x48\x83\xE4\xF0\x48\x83\xEC\x60\xF2\x0F\x11\x74\x24\x08"
+      "\xF2\x0F\x11\x7C\x24\x10\xF2\x44\x0F\x11\x44\x24\x18\xF2\x44\x0F\x11\x4C"
+      "\x24\x20\xF2\x44\x0F\x11\x54\x24\x28\xF2\x44\x0F\x11\x5C\x24\x30\xF2\x44"
+      "\x0F\x11\x64\x24\x38\xF2\x44\x0F\x11\x6C\x24\x40\xF2\x44\x0F\x11\x74\x24"
+      "\x50\xF2\x44\x0F\x11\x7C\x24\x58\x56\x57\x41\x52\x41\x53\x48\x8D\x7D\x10"
+      "\x48\xB8\x55\x44\x33\x22\x11\x00\x00\x00\xFF\xD0\x41\x5B\x41\x5A\x5F\x5E"
+      "\xF2\x0F\x10\x74\x24\x08\xF2\x0F\x10\x7C\x24\x10\xF2\x44\x0F\x10\x44\x24"
+      "\x18\xF2\x44\x0F\x10\x4C\x24\x20\xF2\x44\x0F\x10\x54\x24\x28\xF2\x44\x0F"
+      "\x10\x5C\x24\x30\xF2\x44\x0F\x10\x64\x24\x38\xF2\x44\x0F\x10\x6C\x24\x40"
+      "\xF2\x44\x0F\x10\x74\x24\x50\xF2\x44\x0F\x10\x7C\x24\x58\x66\x48\x0F\x6E"
+      "\xC0\xC9\xC2\x22\x11";
+  char *ret = A_MALLOC(0xb9, NULL);
+  memcpy(ret, ffi_binding, 0xb9);
+  *(int64_t *)(ret + 0x5c) = fptr;
+  *(int16_t *)(ret + 0xb7) = arity * 8;
+  return ret;
+  #else
+  return fptr;
+  #endif
 }
-void* GenFFIBindingNaked(void* fptr, int64_t arity)
-{
-	/*
-	0:  48 b8 55 44 33 22 11    movabs rax,0x1122334455
-	7:  00 00 00
-	a:  ff e0 					jmp rax
-	*/
-	const char* ffi_binding = "\x48\xB8\x55\x44\x33\x22\x11\x00\x00\x00\xFF\xe0";
-#ifdef USE_TEMPLEOS_ABI
-	char* ret = A_MALLOC(0xd, NULL);
-	memcpy(ret, ffi_binding, 0xd);
-	*(int64_t*)(ret + 0x2) = fptr;
-	return ret;
-#else
-	return fptr;
-#endif
+void *GenFFIBindingNaked(void *fptr, int64_t arity) {
+  /*
+  0:  48 b8 55 44 33 22 11    movabs rax,0x1122334455
+  7:  00 00 00
+  a:  ff e0 					jmp rax
+  */
+  const char *ffi_binding = "\x48\xB8\x55\x44\x33\x22\x11\x00\x00\x00\xFF\xe0";
+  #ifdef USE_TEMPLEOS_ABI
+  char *ret = A_MALLOC(0xd, NULL);
+  memcpy(ret, ffi_binding, 0xd);
+  *(int64_t *)(ret + 0x2) = fptr;
+  return ret;
+  #else
+  return fptr;
+  #endif
 }
 #endif
 
 #if defined(__aarch64__) || defined(_M_ARM64)
-void* GenFFIBinding(void* fptr, int64_t arity) {
+void *GenFFIBinding(void *fptr, int64_t arity) {
   #ifdef USE_TEMPLEOS_ABI
-  //0:  stp x29,x30[sp,-16]!
-  //4:  add x0,sp,16
-  //8:  ldr x1,label
-  //c:  blr x1
-  //10: ldp x29,x30[sp],16
-  //14: ret
-  //18: label: fptr
-  int32_t *blob=A_MALLOC(0x18+8,NULL);
-  blob[0]=ARM_stpPreImmX(29,30,31,-16);
-  blob[1]=ARM_addImmX(0,31,16);
-  blob[2]=ARM_ldrLabelX(1,0x18-0x8);
-  blob[3]=ARM_blr(1);
-  blob[4]=ARM_ldpPostImmX(29,30,31,16);
-  blob[5]=ARM_ret();
-  *(void**)(blob+6)=fptr;
+  // 0:  stp x29,x30[sp,-16]!
+  // 4:  add x0,sp,16
+  // 8:  ldr x1,label
+  // c:  blr x1
+  // 10: ldp x29,x30[sp],16
+  // 14: ret
+  // 18: label: fptr
+  int32_t *blob = A_MALLOC(0x18 + 8, NULL);
+  blob[0] = ARM_stpPreImmX(29, 30, 31, -16);
+  blob[1] = ARM_addImmX(0, 31, 16);
+  blob[2] = ARM_ldrLabelX(1, 0x18 - 0x8);
+  blob[3] = ARM_blr(1);
+  blob[4] = ARM_ldpPostImmX(29, 30, 31, 16);
+  blob[5] = ARM_ret();
+  *(void **)(blob + 6) = fptr;
   return blob;
   #else
   return fptr;
   #endif
 }
-void* GenFFIBindingNaked(void* fptr, int64_t arity) {
-  //TODO
+void *GenFFIBindingNaked(void *fptr, int64_t arity) {
+  // TODO
   return fptr;
 }
 #endif

--- a/fs.c
+++ b/fs.c
@@ -4,466 +4,435 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #if defined(_WIN32) || defined(WIN32)
-#include <processthreadsapi.h>
-#include <synchapi.h>
-#include <windows.h>
-static void MakePathSane(char* ptr)
-{
-	char* ptr2 = ptr;
+  #include <processthreadsapi.h>
+  #include <synchapi.h>
+  #include <windows.h>
+static void MakePathSane(char *ptr) {
+  char *ptr2 = ptr;
 enter:
-	while (*ptr) {
-		if (*ptr == '/' && ptr[1] == '/') {
-			*ptr2++ = *ptr++;
-			while (*ptr == '/')
-				ptr++;
-			goto enter;
-		}
-		if (ptr != ptr2)
-			*ptr2++ = *ptr;
-		else
-			ptr2++;
-		if (*ptr)
-			ptr++;
-	}
-	*ptr2 = 0;
+  while (*ptr) {
+    if (*ptr == '/' && ptr[1] == '/') {
+      *ptr2++ = *ptr++;
+      while (*ptr == '/')
+        ptr++;
+      goto enter;
+    }
+    if (ptr != ptr2)
+      *ptr2++ = *ptr;
+    else
+      ptr2++;
+    if (*ptr)
+      ptr++;
+  }
+  *ptr2 = 0;
 }
 #endif
-static int __FExists(char* path)
-{
-	return access(path, F_OK) == 0;
+static int __FExists(char *path) {
+  return access(path, F_OK) == 0;
 }
-static int __FIsDir(char* path)
-{
+static int __FIsDir(char *path) {
 #if defined(_WIN32) || defined(WIN32)
-	return PathIsDirectoryA(path);
+  return PathIsDirectoryA(path);
 #else
-	struct stat s;
-	stat(path, &s);
-	return (s.st_mode & S_IFMT) == S_IFDIR;
+  struct stat s;
+  stat(path, &s);
+  return (s.st_mode & S_IFMT) == S_IFDIR;
 #endif
 }
 
-int64_t FileExists(char* name) { return access(name, F_OK) == 0; }
-void FileWrite(char* fn, char* data, int64_t sz)
-{
-	FILE* f = fopen(fn, "wb");
-	if (!f)
-		return;
-	fwrite(data, sz, 1, f);
-	fclose(f);
+int64_t FileExists(char *name) {
+  return access(name, F_OK) == 0;
 }
-char* FileRead(char* fn, int64_t* sz)
-{
-	int64_t s, e;
-	FILE* f = fopen(fn, "rb");
-	char* ret;
-	if (!f)
-		return NULL;
-	fseek(f, 0, SEEK_END);
-	e = ftell(f);
-	fseek(f, 0, SEEK_SET);
-	s = e - ftell(f);
-	ret = A_MALLOC(s + 1, NULL);
-	fread(ret, 1, s, f);
-	ret[s] = 0;
-	fclose(f);
-	if (sz)
-		*sz = s;
-	return ret;
+void FileWrite(char *fn, char *data, int64_t sz) {
+  FILE *f = fopen(fn, "wb");
+  if (!f)
+    return;
+  fwrite(data, sz, 1, f);
+  fclose(f);
+}
+char *FileRead(char *fn, int64_t *sz) {
+  int64_t s, e;
+  FILE *f = fopen(fn, "rb");
+  char *ret;
+  if (!f)
+    return NULL;
+  fseek(f, 0, SEEK_END);
+  e = ftell(f);
+  fseek(f, 0, SEEK_SET);
+  s = e - ftell(f);
+  ret = A_MALLOC(s + 1, NULL);
+  fread(ret, 1, s, f);
+  ret[s] = 0;
+  fclose(f);
+  if (sz)
+    *sz = s;
+  return ret;
 }
 
 // From 3Days(also by nroot)
 __thread char thrd_pwd[1024];
 __thread char thrd_drv;
-void VFsThrdInit()
-{
-	strcpy(thrd_pwd, "/");
-	thrd_drv = 'T';
+void VFsThrdInit() {
+  strcpy(thrd_pwd, "/");
+  thrd_drv = 'T';
 }
-void VFsSetDrv(char d)
-{
-	if (!isalpha(d))
-		return;
-	thrd_drv = toupper(d);
+void VFsSetDrv(char d) {
+  if (!isalpha(d))
+    return;
+  thrd_drv = toupper(d);
 }
-int VFsCd(char* to, int make)
-{
-	to = __VFsFileNameAbs(to);
-	if (__FExists(to) && __FIsDir(to)) {
-		A_FREE(to);
-		return 1;
-	} else if (make) {
+int VFsCd(char *to, int make) {
+  to = __VFsFileNameAbs(to);
+  if (__FExists(to) && __FIsDir(to)) {
+    A_FREE(to);
+    return 1;
+  } else if (make) {
 #if defined(_WIN32) || defined(WIN32)
-		mkdir(to);
+    mkdir(to);
 #else
-		mkdir(to, 0700);
+    mkdir(to, 0700);
 #endif
-		A_FREE(to);
-		return 1;
-	}
-	return 0;
+    A_FREE(to);
+    return 1;
+  }
+  return 0;
 }
-static void DelDir(char* p)
-{
-	DIR* d = opendir(p);
-	struct dirent* d2;
-	char od[2048];
-	while (d2 = readdir(d)) {
-		if (!strcmp(".", d2->d_name) || !strcmp("..", d2->d_name))
-			continue;
-		strcpy(od, p);
-		strcat(od, "/");
-		strcat(od, d2->d_name);
-		if (__FIsDir(od)) {
-			DelDir(od);
-		} else {
-			remove(od);
-		}
-	}
-	closedir(d);
-	rmdir(p);
-}
-
-int64_t VFsDel(char* p)
-{
-	int r;
-	p = __VFsFileNameAbs(p);
-	if (!__FExists(p)) {
-		A_FREE(p);
-		return 0;
-	}
-	if (__FIsDir(p)) {
-		DelDir(p);
-	} else
-		remove(p);
-	r = !__FExists(p);
-	A_FREE(p);
-	return r;
+static void DelDir(char *p) {
+  DIR *d = opendir(p);
+  struct dirent *d2;
+  char od[2048];
+  while (d2 = readdir(d)) {
+    if (!strcmp(".", d2->d_name) || !strcmp("..", d2->d_name))
+      continue;
+    strcpy(od, p);
+    strcat(od, "/");
+    strcat(od, d2->d_name);
+    if (__FIsDir(od)) {
+      DelDir(od);
+    } else {
+      remove(od);
+    }
+  }
+  closedir(d);
+  rmdir(p);
 }
 
-static char* mount_points['z' - 'a' + 1];
-char* __VFsFileNameAbs(char* name)
-{
-	char computed[1024];
-	strcpy(computed, mount_points[toupper(thrd_drv) - 'A']);
-	computed[strlen(computed) + 1] = 0;
-	computed[strlen(computed)] = '/';
-	strcat(computed, thrd_pwd);
-	computed[strlen(computed) + 1] = 0;
-	if (!name)
-		return A_STRDUP(computed, NULL);
-	if (strlen(name)) {
-		computed[strlen(computed)] = '/';
-		strcat(computed, name);
-	}
-	return A_STRDUP(computed, NULL);
+int64_t VFsDel(char *p) {
+  int r;
+  p = __VFsFileNameAbs(p);
+  if (!__FExists(p)) {
+    A_FREE(p);
+    return 0;
+  }
+  if (__FIsDir(p)) {
+    DelDir(p);
+  } else
+    remove(p);
+  r = !__FExists(p);
+  A_FREE(p);
+  return r;
+}
+
+static char *mount_points['z' - 'a' + 1];
+char *__VFsFileNameAbs(char *name) {
+  char computed[1024];
+  strcpy(computed, mount_points[toupper(thrd_drv) - 'A']);
+  computed[strlen(computed) + 1] = 0;
+  computed[strlen(computed)] = '/';
+  strcat(computed, thrd_pwd);
+  computed[strlen(computed) + 1] = 0;
+  if (!name)
+    return A_STRDUP(computed, NULL);
+  if (strlen(name)) {
+    computed[strlen(computed)] = '/';
+    strcat(computed, name);
+  }
+  return A_STRDUP(computed, NULL);
 }
 #if defined(_WIN32) || defined(WIN32)
-static int64_t FILETIME2Unix(FILETIME* t)
-{
-	// https://www.frenk.com/2009/12/convert-filetime-to-unix-timestamp/
-	int64_t time = t->dwLowDateTime | ((int64_t)t->dwHighDateTime << 32), adj;
-	adj = 10000 * (int64_t)11644473600000ll;
-	time -= adj;
-	return time / 10000000ll;
+static int64_t FILETIME2Unix(FILETIME *t) {
+  // https://www.frenk.com/2009/12/convert-filetime-to-unix-timestamp/
+  int64_t time = t->dwLowDateTime | ((int64_t)t->dwHighDateTime << 32), adj;
+  adj = 10000 * (int64_t)11644473600000ll;
+  time -= adj;
+  return time / 10000000ll;
 }
-int64_t VFsUnixTime(char* name)
-{
-	char* fn = __VFsFileNameAbs(name);
-	FILETIME t;
-	if (!fn)
-		return 0;
-	if (!__FExists(fn))
-		return 0;
-	HANDLE fh = CreateFileA(fn, GENERIC_READ, FILE_SHARE_READ, NULL,
-		OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
-	GetFileTime(fh, NULL, NULL, &t);
-	A_FREE(fn);
-	CloseHandle(fh);
-	return FILETIME2Unix(&t);
+int64_t VFsUnixTime(char *name) {
+  char *fn = __VFsFileNameAbs(name);
+  FILETIME t;
+  if (!fn)
+    return 0;
+  if (!__FExists(fn))
+    return 0;
+  HANDLE fh = CreateFileA(fn, GENERIC_READ, FILE_SHARE_READ, NULL,
+                          OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
+  GetFileTime(fh, NULL, NULL, &t);
+  A_FREE(fn);
+  CloseHandle(fh);
+  return FILETIME2Unix(&t);
 }
 
-int64_t VFsFSize(char* name)
-{
-	char *fn = __VFsFileNameAbs(name), *delim;
-	int64_t s64;
-	int32_t h32;
-	if (!fn)
-		return 0;
-	if (!__FExists(fn)) {
-		A_FREE(fn);
-		return 0;
-	}
-	if (__FIsDir(fn)) {
-		WIN32_FIND_DATAA data;
-		HANDLE dh;
-		char buffer[strlen(fn) + 4];
-		strcpy(buffer, fn);
-		strcat(buffer, "/*");
-		MakePathSane(buffer);
-		while (delim = strchr(buffer, '/'))
-			*delim = '\\';
-		s64 = 0;
-		dh = FindFirstFileA(buffer, &data);
-		while (FindNextFileA(dh, &data))
-			s64++;
-		A_FREE(fn);
-		// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findfirstfilea
-		if (dh != INVALID_HANDLE_VALUE)
-			FindClose(dh);
-		return s64;
-	}
-	HANDLE fh = CreateFileA(fn, GENERIC_READ, 0, NULL, OPEN_EXISTING,
-		FILE_FLAG_BACKUP_SEMANTICS, NULL);
-	s64 = GetFileSize(fh, &h32);
-	s64 |= (int64_t)h32 << 32;
-	A_FREE(fn);
-	CloseHandle(fh);
-	return s64;
+int64_t VFsFSize(char *name) {
+  char *fn = __VFsFileNameAbs(name), *delim;
+  int64_t s64;
+  int32_t h32;
+  if (!fn)
+    return 0;
+  if (!__FExists(fn)) {
+    A_FREE(fn);
+    return 0;
+  }
+  if (__FIsDir(fn)) {
+    WIN32_FIND_DATAA data;
+    HANDLE dh;
+    char buffer[strlen(fn) + 4];
+    strcpy(buffer, fn);
+    strcat(buffer, "/*");
+    MakePathSane(buffer);
+    while (delim = strchr(buffer, '/'))
+      *delim = '\\';
+    s64 = 0;
+    dh = FindFirstFileA(buffer, &data);
+    while (FindNextFileA(dh, &data))
+      s64++;
+    A_FREE(fn);
+    // https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findfirstfilea
+    if (dh != INVALID_HANDLE_VALUE)
+      FindClose(dh);
+    return s64;
+  }
+  HANDLE fh = CreateFileA(fn, GENERIC_READ, 0, NULL, OPEN_EXISTING,
+                          FILE_FLAG_BACKUP_SEMANTICS, NULL);
+  s64 = GetFileSize(fh, &h32);
+  s64 |= (int64_t)h32 << 32;
+  A_FREE(fn);
+  CloseHandle(fh);
+  return s64;
 }
 
-char** VFsDir(char* name)
-{
-	char *fn = __VFsFileNameAbs(""), **ret = NULL, *delim;
-	if (!fn)
-		return 0;
-	if (!__FExists(fn) || !__FIsDir(fn)) {
-		A_FREE(fn);
-		return 0;
-	}
-	int64_t sz = VFsFSize("");
-	if (sz) {
-		ret = A_CALLOC((sz + 1) * 8, NULL);
-		WIN32_FIND_DATAA data;
-		HANDLE dh;
-		char buffer[strlen(fn) + 4];
-		strcpy(buffer, fn);
-		strcat(buffer, "/*");
-		MakePathSane(buffer);
-		while (delim = strchr(buffer, '/'))
-			*delim = '\\';
-		int64_t s64 = 0;
-		dh = FindFirstFileA(buffer, &data);
-		while (FindNextFileA(dh, &data))
-			ret[s64++] = A_STRDUP(data.cFileName, NULL);
-		A_FREE(fn);
-		// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findfirstfilea
-		if (dh != INVALID_HANDLE_VALUE)
-			FindClose(dh);
-	}
-	return ret;
+char **VFsDir(char *name) {
+  char *fn = __VFsFileNameAbs(""), **ret = NULL, *delim;
+  if (!fn)
+    return 0;
+  if (!__FExists(fn) || !__FIsDir(fn)) {
+    A_FREE(fn);
+    return 0;
+  }
+  int64_t sz = VFsFSize("");
+  if (sz) {
+    ret = A_CALLOC((sz + 1) * 8, NULL);
+    WIN32_FIND_DATAA data;
+    HANDLE dh;
+    char buffer[strlen(fn) + 4];
+    strcpy(buffer, fn);
+    strcat(buffer, "/*");
+    MakePathSane(buffer);
+    while (delim = strchr(buffer, '/'))
+      *delim = '\\';
+    int64_t s64 = 0;
+    dh = FindFirstFileA(buffer, &data);
+    while (FindNextFileA(dh, &data))
+      ret[s64++] = A_STRDUP(data.cFileName, NULL);
+    A_FREE(fn);
+    // https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findfirstfilea
+    if (dh != INVALID_HANDLE_VALUE)
+      FindClose(dh);
+  }
+  return ret;
 }
 
 #else
 
-char** VFsDir(char* fn)
-{
-	int64_t sz;
-	char** ret;
-	fn = __VFsFileNameAbs("");
-	while (strlen(fn) && fn[strlen(fn) - 1] == '/')
-		fn[strlen(fn) - 1] = 0;
-	DIR* dir = opendir(fn);
-	if (!dir) {
-		A_FREE(fn);
-		return NULL;
-	}
-	struct dirent* ent;
-	sz = 0;
-	while (ent = readdir(dir))
-		sz++;
-	rewinddir(dir);
-	ret = A_MALLOC((sz + 1) * sizeof(char*), NULL);
-	sz = 0;
-	while (ent = readdir(dir)) {
-		// CDIR_FILENAME_LEN  is 38(includes nul terminator)
-		if (strlen(ent->d_name) <= 37)
-			ret[sz++] = A_STRDUP(ent->d_name, NULL);
-	}
-	ret[sz] = 0;
-	A_FREE(fn);
-	closedir(dir);
-	return ret;
+char **VFsDir(char *fn) {
+  int64_t sz;
+  char **ret;
+  fn = __VFsFileNameAbs("");
+  while (strlen(fn) && fn[strlen(fn) - 1] == '/')
+    fn[strlen(fn) - 1] = 0;
+  DIR *dir = opendir(fn);
+  if (!dir) {
+    A_FREE(fn);
+    return NULL;
+  }
+  struct dirent *ent;
+  sz = 0;
+  while (ent = readdir(dir))
+    sz++;
+  rewinddir(dir);
+  ret = A_MALLOC((sz + 1) * sizeof(char *), NULL);
+  sz = 0;
+  while (ent = readdir(dir)) {
+    // CDIR_FILENAME_LEN  is 38(includes nul terminator)
+    if (strlen(ent->d_name) <= 37)
+      ret[sz++] = A_STRDUP(ent->d_name, NULL);
+  }
+  ret[sz] = 0;
+  A_FREE(fn);
+  closedir(dir);
+  return ret;
 }
 
-int64_t VFsUnixTime(char* name)
-{
-	char* fn = __VFsFileNameAbs(name);
-	struct stat s;
-	stat(fn, &s);
-	int64_t r = mktime(localtime(&s.st_ctime));
-	A_FREE(fn);
-	return r;
+int64_t VFsUnixTime(char *name) {
+  char *fn = __VFsFileNameAbs(name);
+  struct stat s;
+  stat(fn, &s);
+  int64_t r = mktime(localtime(&s.st_ctime));
+  A_FREE(fn);
+  return r;
 }
 
-int64_t VFsFSize(char* name)
-{
-	struct stat s;
-	long cnt;
-	DIR* d;
-	char* fn = __VFsFileNameAbs(name);
-	if (!__FExists(fn)) {
-		A_FREE(fn);
-		return -1;
-	} else if (__FIsDir(fn)) {
-		d = opendir(fn);
-		cnt = 0;
-		while (readdir(d))
-			cnt++;
-		closedir(d);
-		A_FREE(fn);
-		return cnt;
-	}
-	stat(fn, &s);
-	A_FREE(fn);
-	return s.st_size;
+int64_t VFsFSize(char *name) {
+  struct stat s;
+  long cnt;
+  DIR *d;
+  char *fn = __VFsFileNameAbs(name);
+  if (!__FExists(fn)) {
+    A_FREE(fn);
+    return -1;
+  } else if (__FIsDir(fn)) {
+    d = opendir(fn);
+    cnt = 0;
+    while (readdir(d))
+      cnt++;
+    closedir(d);
+    A_FREE(fn);
+    return cnt;
+  }
+  stat(fn, &s);
+  A_FREE(fn);
+  return s.st_size;
 }
 #endif
-int64_t VFsFileWrite(char* name, char* data, int64_t len)
-{
-	FILE* f;
-	name = __VFsFileNameAbs(name);
-	if (name) {
-		f = fopen(name, "wb");
-		if (f) {
-			fwrite(data, 1, len, f);
-			fclose(f);
-		}
-	}
-	A_FREE(name);
-	return !!name;
+int64_t VFsFileWrite(char *name, char *data, int64_t len) {
+  FILE *f;
+  name = __VFsFileNameAbs(name);
+  if (name) {
+    f = fopen(name, "wb");
+    if (f) {
+      fwrite(data, 1, len, f);
+      fclose(f);
+    }
+  }
+  A_FREE(name);
+  return !!name;
 }
-int64_t VFsIsDir(char* name)
-{
-	int64_t ret;
-	name = __VFsFileNameAbs(name);
-	if (!name)
-		return 0;
-	ret = __FIsDir(name);
-	A_FREE(name);
-	return ret;
+int64_t VFsIsDir(char *name) {
+  int64_t ret;
+  name = __VFsFileNameAbs(name);
+  if (!name)
+    return 0;
+  ret = __FIsDir(name);
+  A_FREE(name);
+  return ret;
 }
-int64_t VFsFileRead(char* name, int64_t* len)
-{
-	if (len)
-		*len = 0;
-	FILE* f;
-	int64_t s, e;
-	void* data = NULL;
-	name = __VFsFileNameAbs(name);
-	if (!name)
-		return (int64_t)NULL;
-	if (__FExists(name))
-		if (!__FIsDir(name)) {
-			f = fopen(name, "rb");
-			if (!f)
-				goto end;
-			s = ftell(f);
-			fseek(f, 0, SEEK_END);
-			e = ftell(f);
-			fseek(f, 0, SEEK_SET);
-			fread(data = A_MALLOC(e - s + 1, NULL), 1, e - s, f);
-			fclose(f);
-			if (len)
-				*len = e - s;
-			((char*)data)[e - s] = 0;
-		}
+int64_t VFsFileRead(char *name, int64_t *len) {
+  if (len)
+    *len = 0;
+  FILE *f;
+  int64_t s, e;
+  void *data = NULL;
+  name = __VFsFileNameAbs(name);
+  if (!name)
+    return (int64_t)NULL;
+  if (__FExists(name))
+    if (!__FIsDir(name)) {
+      f = fopen(name, "rb");
+      if (!f)
+        goto end;
+      s = ftell(f);
+      fseek(f, 0, SEEK_END);
+      e = ftell(f);
+      fseek(f, 0, SEEK_SET);
+      fread(data = A_MALLOC(e - s + 1, NULL), 1, e - s, f);
+      fclose(f);
+      if (len)
+        *len = e - s;
+      ((char *)data)[e - s] = 0;
+    }
 end:
-	A_FREE(name);
-	return (int64_t)data;
+  A_FREE(name);
+  return (int64_t)data;
 }
-int VFsFileExists(char* path)
-{
-	if (!path)
-		return 0;
-	path = __VFsFileNameAbs(path);
-	int e = __FExists(path);
-	A_FREE(path);
-	return e;
-}
-
-int VFsMountDrive(char let, char* path)
-{
-	int idx = toupper(let) - 'A';
-	if (mount_points[idx])
-		A_FREE(mount_points[idx]);
-	mount_points[idx] = A_MALLOC(strlen(path) + 2, NULL);
-	strcpy(mount_points[idx], path);
-	strcat(mount_points[idx],"/");
-}
-FILE* VFsFOpen(char* path, char* m)
-{
-	path = __VFsFileNameAbs(path);
-	FILE* f = fopen(path, m);
-	A_FREE(path);
-	return f;
+int VFsFileExists(char *path) {
+  if (!path)
+    return 0;
+  path = __VFsFileNameAbs(path);
+  int e = __FExists(path);
+  A_FREE(path);
+  return e;
 }
 
-int64_t VFsFClose(FILE* f)
-{
-	fclose(f);
-	return 0;
+int VFsMountDrive(char let, char *path) {
+  int idx = toupper(let) - 'A';
+  if (mount_points[idx])
+    A_FREE(mount_points[idx]);
+  mount_points[idx] = A_MALLOC(strlen(path) + 2, NULL);
+  strcpy(mount_points[idx], path);
+  strcat(mount_points[idx], "/");
 }
-int64_t VFsFBlkRead(void* d, int64_t n, int64_t sz, FILE* f)
-{
-	return 0 != fread(d, n, sz, f);
-}
-int64_t VFsFBlkWrite(void* d, int64_t n, int64_t sz, FILE* f)
-{
-	return 0 != fwrite(d, n, sz, f);
-}
-int64_t VFsFSeek(int64_t off, FILE* f)
-{
-	fseek(f, off, SEEK_SET);
-	return 0;
+FILE *VFsFOpen(char *path, char *m) {
+  path = __VFsFileNameAbs(path);
+  FILE *f = fopen(path, m);
+  A_FREE(path);
+  return f;
 }
 
-int64_t VFsTrunc(char* fn, int64_t sz)
-{
-	fn = __VFsFileNameAbs(fn);
-	if (fn) {
-		truncate(fn, sz);
-		A_FREE(fn);
-	}
-	return 0;
+int64_t VFsFClose(FILE *f) {
+  fclose(f);
+  return 0;
 }
-void VFsSetPwd(char* pwd)
-{
-	if (!pwd)
-		pwd = "/";
-	strcpy(thrd_pwd, pwd);
+int64_t VFsFBlkRead(void *d, int64_t n, int64_t sz, FILE *f) {
+  return 0 != fread(d, n, sz, f);
 }
-
-FILE* VFsFOpenW(char* f)
-{
-	char* path = __VFsFileNameAbs(f);
-	FILE* r = fopen(path, "wb");
-	A_FREE(path);
-	return r;
+int64_t VFsFBlkWrite(void *d, int64_t n, int64_t sz, FILE *f) {
+  return 0 != fwrite(d, n, sz, f);
+}
+int64_t VFsFSeek(int64_t off, FILE *f) {
+  fseek(f, off, SEEK_SET);
+  return 0;
 }
 
-FILE* VFsFOpenR(char* f)
-{
-	char* path = __VFsFileNameAbs(f);
-	FILE* r = fopen(path, "rb");
-	A_FREE(path);
-	return r;
+int64_t VFsTrunc(char *fn, int64_t sz) {
+  fn = __VFsFileNameAbs(fn);
+  if (fn) {
+    truncate(fn, sz);
+    A_FREE(fn);
+  }
+  return 0;
+}
+void VFsSetPwd(char *pwd) {
+  if (!pwd)
+    pwd = "/";
+  strcpy(thrd_pwd, pwd);
 }
 
-int64_t VFsDirMk(char* f)
-{
-	return VFsCd(f, 1);
+FILE *VFsFOpenW(char *f) {
+  char *path = __VFsFileNameAbs(f);
+  FILE *r = fopen(path, "wb");
+  A_FREE(path);
+  return r;
+}
+
+FILE *VFsFOpenR(char *f) {
+  char *path = __VFsFileNameAbs(f);
+  FILE *r = fopen(path, "rb");
+  A_FREE(path);
+  return r;
+}
+
+int64_t VFsDirMk(char *f) {
+  return VFsCd(f, 1);
 }
 
 // Creates a virtual drive by a template
 static void CopyDir(char *dst, char *src) {
-#if defined(WIN32) || defined (_WIN32)
-	char delim='\\';
+#if defined(WIN32) || defined(_WIN32)
+  char delim = '\\';
 #else
-	char delim='/';
+  char delim = '/';
 #endif
   if (!__FExists(dst)) {
-#if defined (_WIN32) || defined (WIN32)
+#if defined(_WIN32) || defined(WIN32)
     mkdir(dst);
 #else
     mkdir(dst, 0700);
@@ -504,7 +473,7 @@ static void CopyDir(char *dst, char *src) {
 }
 
 static int __FIsNewer(char *fn, char *fn2) {
-#if !(defined (_WIN32)||defined(WIN32))
+#if !(defined(_WIN32) || defined(WIN32))
   struct stat s, s2;
   stat(fn, &s), stat(fn2, &s2);
   int64_t r = mktime(localtime(&s.st_ctime)),
@@ -517,14 +486,10 @@ static int __FIsNewer(char *fn, char *fn2) {
   int32_t h32;
   int64_t s64, s64_2;
   FILETIME t;
-  HANDLE fh = CreateFileA(
-             fn, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING,
-             FILE_FLAG_BACKUP_SEMANTICS, NULL
-         ),
-         fh2 = CreateFileA(
-             fn2, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING,
-             FILE_FLAG_BACKUP_SEMANTICS, NULL
-         );
+  HANDLE fh = CreateFileA(fn, GENERIC_READ, FILE_SHARE_READ, NULL,
+                          OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL),
+         fh2 = CreateFileA(fn2, GENERIC_READ, FILE_SHARE_READ, NULL,
+                           OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
   GetFileTime(fh, NULL, NULL, &t);
   s64 = t.dwLowDateTime | ((int64_t)t.dwHighDateTime << 32);
   GetFileTime(fh2, NULL, NULL, &t);
@@ -536,9 +501,12 @@ static int __FIsNewer(char *fn, char *fn2) {
 
 int CreateTemplateBootDrv(char *to, char *template, int overwrite) {
   char buffer[1024], drvl[16], buffer2[1024];
-  if(!__FExists(template)) {
-	fprintf(AIWNIOS_OSTREAM,"Template directory %s doesn't exist. You probably didnt install Aiwnios",template);
-	return 0;
+  if (!__FExists(template)) {
+    fprintf(AIWNIOS_OSTREAM,
+            "Template directory %s doesn't exist. You probably didnt install "
+            "Aiwnios",
+            template);
+    return 0;
   }
   if (!overwrite)
     if (__FExists(to)) {
@@ -553,10 +521,8 @@ int CreateTemplateBootDrv(char *to, char *template, int overwrite) {
     for (_try = 0; _try != 0x10000; _try++) {
       sprintf(buffer, "%s_BAKCUP.%ld", to, _try);
       if (!__FExists(buffer)) {
-        printf(
-            "Newer Template drive found,backing up old drive to \"%s\".\n",
-            buffer
-        );
+        printf("Newer Template drive found,backing up old drive to \"%s\".\n",
+               buffer);
 // Rename the old boot drive to something else
 #if defined(_WIN32) || defined(WIN32)
         MoveFile(to, buffer);
@@ -568,34 +534,38 @@ int CreateTemplateBootDrv(char *to, char *template, int overwrite) {
     }
     return 0;
   }
-#if defined(_WIN32) || defined (WIN32)
+#if defined(_WIN32) || defined(WIN32)
   strcpy(buffer2, template);
   strcat(buffer2, "\\");
 #else
   strcpy(buffer2, template);
 #endif
   if (!__FExists(buffer2)) {
-    fprintf(AIWNIOS_OSTREAM, "Use \"./aiwnios -t T\" to specify the T drive.\n");
+    fprintf(AIWNIOS_OSTREAM,
+            "Use \"./aiwnios -t T\" to specify the T drive.\n");
     return 0;
   }
   CopyDir(to, buffer2);
   return 1;
 }
 
-const char *ResolveBootDir(char *use,int overwrite,int make_new_dir) {
-	if(__FExists("HCRT2.BIN")) {
-		return ".";
-	}
-	if(__FExists("T/HCRT2.BIN")) {
-		return "T";
-	}
-	if(!make_new_dir) goto fail;
-	if(!CreateTemplateBootDrv(use,AIWNIOS_TEMPLATE_DIR,overwrite)) {
-fail:
-		fprintf(AIWNIOS_OSTREAM,"I don't know where the HCRT2.BIN is!!!\n");
-		fprintf(AIWNIOS_OSTREAM,"Use \"aiwnios -b\" in the root of the source directory to build a boot binary.\n");
-		fprintf(AIWNIOS_OSTREAM,"Or Use \"aiwnios -n\" to make a new boot drive(if installed on your system).\n");
-		exit(-1);
-	}
-	return use;
+const char *ResolveBootDir(char *use, int overwrite, int make_new_dir) {
+  if (__FExists("HCRT2.BIN")) {
+    return ".";
+  }
+  if (__FExists("T/HCRT2.BIN")) {
+    return "T";
+  }
+  if (!make_new_dir)
+    goto fail;
+  if (!CreateTemplateBootDrv(use, AIWNIOS_TEMPLATE_DIR, overwrite)) {
+  fail:
+    fprintf(AIWNIOS_OSTREAM, "I don't know where the HCRT2.BIN is!!!\n");
+    fprintf(AIWNIOS_OSTREAM, "Use \"aiwnios -b\" in the root of the source "
+                             "directory to build a boot binary.\n");
+    fprintf(AIWNIOS_OSTREAM, "Or Use \"aiwnios -n\" to make a new boot "
+                             "drive(if installed on your system).\n");
+    exit(-1);
+  }
+  return use;
 }

--- a/hash.c
+++ b/hash.c
@@ -1,111 +1,101 @@
 #pragma once
 #include "aiwn.h"
 #include <stdint.h>
-int64_t HashStr(char* str)
-{
-	int64_t res = 5381;
-	while (*str)
-		res += (res << 5) + res + *str++;
-	return res;
+int64_t HashStr(char *str) {
+  int64_t res = 5381;
+  while (*str)
+    res += (res << 5) + res + *str++;
+  return res;
 }
 
-void HashDel(CHash* h)
-{
+void HashDel(CHash *h) {
 #ifdef AIWN_BOOTSTRAP
-	// TODO
-	A_FREE(h->str);
-	A_FREE(h);
+  // TODO
+  A_FREE(h->str);
+  A_FREE(h);
 #else
 // TODO
 #endif
 }
 
-CHashTable* HashTableNew(int64_t sz, void* task)
-{
-	CHash** body = A_CALLOC(sz * sizeof(CHash*), task);
-	CHashTable* ret = A_MALLOC(sizeof(CHashTable), task);
-	ret->body = body;
-	ret->mask = sz - 1;
-	return ret;
+CHashTable *HashTableNew(int64_t sz, void *task) {
+  CHash **body = A_CALLOC(sz * sizeof(CHash *), task);
+  CHashTable *ret = A_MALLOC(sizeof(CHashTable), task);
+  ret->body = body;
+  ret->mask = sz - 1;
+  return ret;
 }
 
-CHash* HashFind(char* str, CHashTable* table, int64_t type, int64_t inst)
-{
-	int64_t b = HashStr(str) & table->mask;
-	CHash* h;
-	for (h = table->body[b]; h; h = h->next) {
-		if (!strcmp(str, h->str))
-			if (h->type & type)
-				if (--inst == 0)
-					return h;
-	}
-	if (table->next)
-		return HashFind(str, table->next, type, inst);
-	return NULL;
+CHash *HashFind(char *str, CHashTable *table, int64_t type, int64_t inst) {
+  int64_t b = HashStr(str) & table->mask;
+  CHash *h;
+  for (h = table->body[b]; h; h = h->next) {
+    if (!strcmp(str, h->str))
+      if (h->type & type)
+        if (--inst == 0)
+          return h;
+  }
+  if (table->next)
+    return HashFind(str, table->next, type, inst);
+  return NULL;
 }
 // Doesn't check ->next
-CHash* HashSingleTableFind(char* str, CHashTable* table, int64_t type,
-	int64_t inst)
-{
-	int64_t b = HashStr(str) & table->mask;
-	CHash* h;
-	for (h = table->body[b]; h; h = h->next) {
-		if (!strcmp(str, h->str))
-			if (h->type & type)
-				if (--inst == 0)
-					return h;
-	}
-	return NULL;
+CHash *HashSingleTableFind(char *str, CHashTable *table, int64_t type,
+                           int64_t inst) {
+  int64_t b = HashStr(str) & table->mask;
+  CHash *h;
+  for (h = table->body[b]; h; h = h->next) {
+    if (!strcmp(str, h->str))
+      if (h->type & type)
+        if (--inst == 0)
+          return h;
+  }
+  return NULL;
 }
-CHash** HashBucketFind(char* str, CHashTable* table)
-{
-	int64_t b = HashStr(str) & table->mask;
-	return &table->body[b];
+CHash **HashBucketFind(char *str, CHashTable *table) {
+  int64_t b = HashStr(str) & table->mask;
+  return &table->body[b];
 }
 
-void HashAdd(CHash* h, CHashTable* table)
-{
-	CHash** b = HashBucketFind(h->str, table);
-	h->next = *b;
-	*b = h;
+void HashAdd(CHash *h, CHashTable *table) {
+  CHash **b = HashBucketFind(h->str, table);
+  h->next = *b;
+  *b = h;
 }
 
-static int64_t _HashDelStr(char* str, CHashTable* table, int64_t inst)
-{
-	CHash **b = HashBucketFind(str, table), *h2;
-	CHash* prev = NULL;
-	for (h2 = *b; h2; h2 = h2->next) {
-		if (!strcmp(h2->str, str)) {
-			if (!--inst) {
-				if (prev)
-					prev->next = h2->next;
-				HashDel(h2);
-				return 1;
-			}
-		}
-	next:
-		prev = h2;
-	}
-	return 0;
+static int64_t _HashDelStr(char *str, CHashTable *table, int64_t inst) {
+  CHash **b = HashBucketFind(str, table), *h2;
+  CHash *prev = NULL;
+  for (h2 = *b; h2; h2 = h2->next) {
+    if (!strcmp(h2->str, str)) {
+      if (!--inst) {
+        if (prev)
+          prev->next = h2->next;
+        HashDel(h2);
+        return 1;
+      }
+    }
+  next:
+    prev = h2;
+  }
+  return 0;
 }
 
-int64_t HashRemDel(CHash* h, CHashTable* table, int64_t inst)
-{
-	int64_t res = _HashDelStr(h->str, table, inst);
-	HashAdd(h, table);
-	return res;
+int64_t HashRemDel(CHash *h, CHashTable *table, int64_t inst) {
+  int64_t res = _HashDelStr(h->str, table, inst);
+  HashAdd(h, table);
+  return res;
 }
 
-void HashTableDel(CHashTable* table)
-{
-	int64_t i;
-	CHash *next, *cur;
-	for (i = 0; i != table->mask + 1; i++) {
-		for (cur = table->body[i]; cur; cur = next) {
-			next = cur->next;
-			HashDel(cur);
-		}
-	}
-	A_FREE(table->body);
-	A_FREE(table);
+void HashTableDel(CHashTable *table) {
+  int64_t i;
+  CHash *next, *cur;
+  for (i = 0; i != table->mask + 1; i++) {
+    for (cur = table->body[i]; cur; cur = next) {
+      next = cur->next;
+      HashDel(cur);
+    }
+  }
+  A_FREE(table->body);
+  A_FREE(table);
 }

--- a/lex.c
+++ b/lex.c
@@ -5,1190 +5,1180 @@
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
-char* LexSrcLink(CLexer* lex, void* task)
-{
-	char buf[STR_LEN];
-	if (!lex->file)
-		return NULL;
-	sprintf(buf, "%s:%d:%d", lex->file->filename, lex->file->ln + 1,
-		lex->file->col + 1);
-	return A_STRDUP(buf, task);
+char *LexSrcLink(CLexer *lex, void *task) {
+  char buf[STR_LEN];
+  if (!lex->file)
+    return NULL;
+  sprintf(buf, "%s:%d:%d", lex->file->filename, lex->file->ln + 1,
+          lex->file->col + 1);
+  return A_STRDUP(buf, task);
 }
 
-int64_t LexAdvChr(CLexer* lex)
-{
-	//
-	// We want to simulate going back a charactor some times. Say we get a '.'
-	// It could mean a '.',a '...' or maybe even a TK_F64.so if one of these
-	// fails, we can go back in time and check the next item
-	//
-	if (lex->flags & LEXF_USE_LAST_CHAR) {
-		lex->flags &= ~LEXF_USE_LAST_CHAR;
-		return lex->cur_char;
-	}
+int64_t LexAdvChr(CLexer *lex) {
+  //
+  // We want to simulate going back a charactor some times. Say we get a '.'
+  // It could mean a '.',a '...' or maybe even a TK_F64.so if one of these
+  // fails, we can go back in time and check the next item
+  //
+  if (lex->flags & LEXF_USE_LAST_CHAR) {
+    lex->flags &= ~LEXF_USE_LAST_CHAR;
+    return lex->cur_char;
+  }
 enter:;
-	CLexFile *file = lex->file, *last;
-	int64_t ret;
-	if (!lex->file)
-		return 0;
-	// We terminate the silly sauces with 0 as per ASCII nul character
-	if (ret = lex->file->text[lex->file->pos]) {
-		lex->file->pos++;
-		if (ret == 5 || ret == '\r') // TempleOS cursor charactor
-			goto enter;
-		if (ret == '\n')
-			lex->file->ln++, lex->file->col = 0;
-		else
-			lex->file->col++;
-		return lex->cur_char = ret;
-	} else {
-		// Free all the assets of the previous file
-		last = file->last;
-		A_FREE(file->text);
-		A_FREE(file->dir);
-		A_FREE(file->filename);
-		A_FREE(file);
-		//
-		// last points to the last file we were in
-		// /*Contexts if file.HC */
-		// #include "a.HC" // lex->file->next is NULL
-		//
-		// /*Contexts of a.HC*/
-		// "I like toads"; // lex->file->next is "file.HC"'s CLexFile
-		lex->file = last;
-		goto enter;
-	}
+  CLexFile *file = lex->file, *last;
+  int64_t ret;
+  if (!lex->file)
+    return 0;
+  // We terminate the silly sauces with 0 as per ASCII nul character
+  if (ret = lex->file->text[lex->file->pos]) {
+    lex->file->pos++;
+    if (ret == 5 || ret == '\r') // TempleOS cursor charactor
+      goto enter;
+    if (ret == '\n')
+      lex->file->ln++, lex->file->col = 0;
+    else
+      lex->file->col++;
+    return lex->cur_char = ret;
+  } else {
+    // Free all the assets of the previous file
+    last = file->last;
+    A_FREE(file->text);
+    A_FREE(file->dir);
+    A_FREE(file->filename);
+    A_FREE(file);
+    //
+    // last points to the last file we were in
+    // /*Contexts if file.HC */
+    // #include "a.HC" // lex->file->next is NULL
+    //
+    // /*Contexts of a.HC*/
+    // "I like toads"; // lex->file->next is "file.HC"'s CLexFile
+    lex->file = last;
+    goto enter;
+  }
 }
-static void LexErr(CLexer* lex, char* fmt, ...)
-{
-	va_list lst;
-	char buffer[STR_LEN];
-	va_start(lst, fmt);
-	vsprintf(buffer, fmt, lst);
-	va_end(lst);
-	if (lex->file) {
-		fprintf(AIWNIOS_OSTREAM, "ERR %s:%d:%d %s", lex->file->filename, lex->file->ln + 1,
-			lex->file->col + 1, buffer);
-	} else {
-		fprintf(AIWNIOS_OSTREAM, "ERR ???:?:? %s", buffer);
-	}
-	throw(*(int64_t*)"Lex\0\0\0\0\0");
-}
-
-static void LexWarn(CLexer* lex, char* fmt, ...)
-{
-	va_list lst;
-	char buffer[STR_LEN];
-	va_start(lst, fmt);
-	vsprintf(buffer, fmt, lst);
-	va_end(lst);
-	if (lex->file) {
-		fprintf(AIWNIOS_OSTREAM, "WARN %s:%d:%d %s\n", lex->file->filename,
-			lex->file->ln + 1, lex->file->col + 1, buffer);
-	} else {
-		fprintf(AIWNIOS_OSTREAM, "WARN ???:?:? %s\n", buffer);
-	}
+static void LexErr(CLexer *lex, char *fmt, ...) {
+  va_list lst;
+  char buffer[STR_LEN];
+  va_start(lst, fmt);
+  vsprintf(buffer, fmt, lst);
+  va_end(lst);
+  if (lex->file) {
+    fprintf(AIWNIOS_OSTREAM, "ERR %s:%d:%d %s", lex->file->filename,
+            lex->file->ln + 1, lex->file->col + 1, buffer);
+  } else {
+    fprintf(AIWNIOS_OSTREAM, "ERR ???:?:? %s", buffer);
+  }
+  throw(*(int64_t *)"Lex\0\0\0\0\0");
 }
 
-static int64_t __IsCondDirective(const char* str)
-{
-	if (!strcmp("if", str))
-		return 1;
-	if (!strcmp("ifaot", str))
-		return 1;
-	if (!strcmp("ifjit", str))
-		return 1;
-	if (!strcmp("ifdef", str))
-		return 1;
-	if (!strcmp("ifndef", str))
-		return 1;
-	return 0;
+static void LexWarn(CLexer *lex, char *fmt, ...) {
+  va_list lst;
+  char buffer[STR_LEN];
+  va_start(lst, fmt);
+  vsprintf(buffer, fmt, lst);
+  va_end(lst);
+  if (lex->file) {
+    fprintf(AIWNIOS_OSTREAM, "WARN %s:%d:%d %s\n", lex->file->filename,
+            lex->file->ln + 1, lex->file->col + 1, buffer);
+  } else {
+    fprintf(AIWNIOS_OSTREAM, "WARN ???:?:? %s\n", buffer);
+  }
 }
 
-static int64_t LexSkipTillNewLine(CLexer* lex)
-{
-	int64_t chr;
-	while (chr = LexAdvChr(lex)) {
-		if (chr == ERR)
-			return ERR;
-		if (chr == '\n')
-			return 0;
-	}
-	return 0;
+static int64_t __IsCondDirective(const char *str) {
+  if (!strcmp("if", str))
+    return 1;
+  if (!strcmp("ifaot", str))
+    return 1;
+  if (!strcmp("ifjit", str))
+    return 1;
+  if (!strcmp("ifdef", str))
+    return 1;
+  if (!strcmp("ifndef", str))
+    return 1;
+  return 0;
 }
 
-static int64_t LexSkipMultlineComment(CLexer* lex)
-{
-	int64_t chr;
-	while (chr = LexAdvChr(lex)) {
-		if (chr == ERR)
-			return ERR;
-		else if (chr == '*') {
-			if ('/' == LexAdvChr(lex))
-				return 0;
-			else
-				lex->flags |= LEXF_USE_LAST_CHAR;
-		} else if (chr == '/') {
-			if ('*' == LexAdvChr(lex)) {
-				if (ERR == LexSkipMultlineComment(lex))
-					return ERR;
-			} else
-				lex->flags |= LEXF_USE_LAST_CHAR;
-		}
-	}
-	LexErr(lex, "Expected end of multi-line comment");
-	return ERR;
+static int64_t LexSkipTillNewLine(CLexer *lex) {
+  int64_t chr;
+  while (chr = LexAdvChr(lex)) {
+    if (chr == ERR)
+      return ERR;
+    if (chr == '\n')
+      return 0;
+  }
+  return 0;
 }
 
-static int64_t LexString(CLexer* lex, int64_t till)
-{
-	int64_t idx, chr1, hex;
-	for (idx = 0;;) {
-		switch (chr1 = LexAdvChr(lex)) {
-		case '\\':
-			switch (chr1 = LexAdvChr(lex)) {
-				break;
-			case 'd':
-				chr1 = '$';
-				goto ins;
-				break;
-			case 'n':
-				chr1 = '\n';
-				goto ins;
-				break;
-			case '0':
-				chr1 = '\0';
-				goto ins;
-				break;
-			case 't':
-				chr1 = '\t';
-				goto ins;
-				break;
-			case 'r':
-				chr1 = '\r';
-				goto ins;
-				break;
-			case '\\':
-				chr1 = '\\';
-				goto ins;
-				break;
-			case '\'':
-				chr1 = '\'';
-				goto ins;
-				break;
-			case '\"':
-				chr1 = '"';
-				goto ins;
-				break;
-			case 'x':
-				hex = 0;
-				while (isxdigit(chr1 = LexAdvChr(lex))) {
-					hex *= 16;
-					switch (chr1) {
-					case '0' ... '9':
-						hex += chr1 - '0';
-					case 'A' ... 'F':
-						hex += chr1 - 'A' + 10;
-					case 'a' ... 'f':
-						hex += chr1 - 'a' + 10;
-					}
-				}
-				lex->flags |= LEXF_USE_LAST_CHAR;
-				chr1 = hex;
-				goto ins;
-				break;
-			default:
-				LexWarn(lex, "Invalid escape charactor '%c'.", chr1);
-				goto ins;
-			}
-			break;
-		default:
-		ins:
-			if (idx + 1 >= STR_LEN) {
-				LexErr(lex, "String exceedes STR_LEN chars.");
-				return ERR;
-			}
-			lex->string[idx++] = chr1;
-			break;
-		case '\'':
-		case '"':
-			if (till == chr1)
-				goto fin;
-			goto ins;
-		}
-	}
+static int64_t LexSkipMultlineComment(CLexer *lex) {
+  int64_t chr;
+  while (chr = LexAdvChr(lex)) {
+    if (chr == ERR)
+      return ERR;
+    else if (chr == '*') {
+      if ('/' == LexAdvChr(lex))
+        return 0;
+      else
+        lex->flags |= LEXF_USE_LAST_CHAR;
+    } else if (chr == '/') {
+      if ('*' == LexAdvChr(lex)) {
+        if (ERR == LexSkipMultlineComment(lex))
+          return ERR;
+      } else
+        lex->flags |= LEXF_USE_LAST_CHAR;
+    }
+  }
+  LexErr(lex, "Expected end of multi-line comment");
+  return ERR;
+}
+
+static int64_t LexString(CLexer *lex, int64_t till) {
+  int64_t idx, chr1, hex;
+  for (idx = 0;;) {
+    switch (chr1 = LexAdvChr(lex)) {
+    case '\\':
+      switch (chr1 = LexAdvChr(lex)) {
+        break;
+      case 'd':
+        chr1 = '$';
+        goto ins;
+        break;
+      case 'n':
+        chr1 = '\n';
+        goto ins;
+        break;
+      case '0':
+        chr1 = '\0';
+        goto ins;
+        break;
+      case 't':
+        chr1 = '\t';
+        goto ins;
+        break;
+      case 'r':
+        chr1 = '\r';
+        goto ins;
+        break;
+      case '\\':
+        chr1 = '\\';
+        goto ins;
+        break;
+      case '\'':
+        chr1 = '\'';
+        goto ins;
+        break;
+      case '\"':
+        chr1 = '"';
+        goto ins;
+        break;
+      case 'x':
+        hex = 0;
+        while (isxdigit(chr1 = LexAdvChr(lex))) {
+          hex *= 16;
+          switch (chr1) {
+          case '0' ... '9':
+            hex += chr1 - '0';
+          case 'A' ... 'F':
+            hex += chr1 - 'A' + 10;
+          case 'a' ... 'f':
+            hex += chr1 - 'a' + 10;
+          }
+        }
+        lex->flags |= LEXF_USE_LAST_CHAR;
+        chr1 = hex;
+        goto ins;
+        break;
+      default:
+        LexWarn(lex, "Invalid escape charactor '%c'.", chr1);
+        goto ins;
+      }
+      break;
+    default:
+    ins:
+      if (idx + 1 >= STR_LEN) {
+        LexErr(lex, "String exceedes STR_LEN chars.");
+        return ERR;
+      }
+      lex->string[idx++] = chr1;
+      break;
+    case '\'':
+    case '"':
+      if (till == chr1)
+        goto fin;
+      goto ins;
+    }
+  }
 fin:
-	lex->str_len = idx;
-	lex->string[idx++] = 0;
-	return 0;
+  lex->str_len = idx;
+  lex->string[idx++] = 0;
+  return 0;
 }
 
-static int64_t LexInt(CLexer* lex, int64_t base)
-{
-	int64_t chr1;
-	int64_t ret = 0, digit;
-	while (chr1 = LexAdvChr(lex)) {
-		switch (chr1) {
-			break;
-		case '0' ... '9':
-			digit = chr1 - '0';
-			break;
-		case 'A' ... 'F':
-			digit = chr1 - 'A' + 10;
-			break;
-		case 'a' ... 'f':
-			digit = chr1 - 'a' + 10;
-			break;
-		default:
-		ret:
-			//
-			// We consumed the current charactor,which may not be useful now,
-			// but it may be useful latter.
-			//
-			lex->flags |= LEXF_USE_LAST_CHAR;
-			return ret;
-		}
-		if (digit >= base) {
-			goto ret;
-		}
-		// This when repeated "add"s an empty digit,as each digit is a multipl of
-		// base
-		ret *= base;
-		ret += digit;
-	}
-	return ret;
+static int64_t LexInt(CLexer *lex, int64_t base) {
+  int64_t chr1;
+  int64_t ret = 0, digit;
+  while (chr1 = LexAdvChr(lex)) {
+    switch (chr1) {
+      break;
+    case '0' ... '9':
+      digit = chr1 - '0';
+      break;
+    case 'A' ... 'F':
+      digit = chr1 - 'A' + 10;
+      break;
+    case 'a' ... 'f':
+      digit = chr1 - 'a' + 10;
+      break;
+    default:
+    ret:
+      //
+      // We consumed the current charactor,which may not be useful now,
+      // but it may be useful latter.
+      //
+      lex->flags |= LEXF_USE_LAST_CHAR;
+      return ret;
+    }
+    if (digit >= base) {
+      goto ret;
+    }
+    // This when repeated "add"s an empty digit,as each digit is a multipl of
+    // base
+    ret *= base;
+    ret += digit;
+  }
+  return ret;
 }
-int64_t Lex(CLexer* lex)
-{
+int64_t Lex(CLexer *lex) {
 re_enter:;
-	int64_t chr1 = LexAdvChr(lex), chr2;
-	int64_t has_base = 0, base = 10, integer = 0, decimal = 0, exponet = 0,
-			zeros = 0, idx = 0, old_flags, in_else;
-	FILE* f;
-	char macro_name[STR_LEN];
-	CHashDefineStr* define;
-	CLexFile* new_file,*actual_file;
-	char *dir;
-	switch (chr1) {
-		break;
-	case '`':
-		return lex->cur_tok = '`';
-		break;
-	case ';':
-		return lex->cur_tok = ';';
-		break;
-	case ':':
-		return lex->cur_tok = ':';
-		break;
-	case ',':
-		return lex->cur_tok = ',';
-		break;
-	case ' ':
-	case '\t':
-	case '\n':
-		goto re_enter;
-		break;
-	case '0' ... '9':
-		if (chr1 == '0') {
-			chr2 = LexAdvChr(lex);
-			switch (chr2) {
-				break;
-			case 'x':
-			case 'X':
-				chr1 = LexAdvChr(lex);
-				base = 16;
-				lex->flags |= LEXF_USE_LAST_CHAR;
-				break;
-			case 'b':
-				chr1 = LexAdvChr(lex);
-				base = 2;
-				lex->flags |= LEXF_USE_LAST_CHAR;
-				break;
-			case '0' ... '9':
-				lex->flags |= LEXF_USE_LAST_CHAR;
-				break;
-			default:;
-				lex->flags |= LEXF_USE_LAST_CHAR;
-				// LexErr(lex,"Unexpected charactor after '0'.");
-				// return lex->cur_tok=ERR;
-			}
-			integer = LexInt(lex, base);
-			if (integer == ERR && (lex->flags & LEXF_ERROR))
-				return lex->cur_tok = ERR;
-			switch (LexAdvChr(lex)) {
-				break;
-			case 'E':
-			case 'e':
-				decimal = 0;
-				if (base != 10) {
-					LexErr(lex, "Expected a base 10 number for floating points.");
-					return lex->cur_tok = ERR;
-				}
-			exponet:
-				exponet = 0;
-				base = 1; // This holds the multipler for the exponet
-				if ('+' == (chr1 = LexAdvChr(lex))) {
-				} else if ('-' == chr1) {
-					base = -1;
-				} else if (isdigit(chr1))
-					lex->flags |= LEXF_USE_LAST_CHAR;
-				exponet = LexInt(lex, 10);
-				exponet *= base;
-				lex->flags |= LEXF_USE_LAST_CHAR;
-				if (integer == ERR && (lex->flags & LEXF_ERROR)) {
-					LexErr(lex, "Expected an exponet.");
-					return lex->cur_tok = ERR;
-				}
-			fin_f64:
-				if (decimal) {
-					lex->flt = integer + decimal * pow(10, -zeros - 1 - floor(log10(decimal)));
-				} else
-					lex->flt = integer;
-				lex->flt *= pow(10, exponet);
-				return lex->cur_tok = TK_F64;
-				break;
-			case '.':
-			decimal_chk:
-				switch (chr1 = LexAdvChr(lex)) {
-					break;
-				case '0':
-					zeros++;
-					goto decimal_chk;
-					break;
-				case '1' ... '9':
-					lex->flags |= LEXF_USE_LAST_CHAR;
-					decimal = LexInt(lex, 10);
-					lex->flags |= LEXF_USE_LAST_CHAR;
-					break;
-				default:;
-				}
-				if (lex->cur_char == 'e' || lex->cur_char == 'E') {
-					lex->flags &= ~LEXF_USE_LAST_CHAR;
-					goto exponet;
-				}
-				lex->flags |= LEXF_USE_LAST_CHAR;
-				lex->integer = integer;
-				goto fin_f64;
-				break;
-			default:
-				lex->flags |= LEXF_USE_LAST_CHAR;
-				lex->integer = integer;
-				return lex->cur_tok = TK_I64;
-			}
-		} else
-			//
-			// We checked the first digit and checked for 0.
-			// Use it again in LexInt as we found no use for it here.
-			//
-			lex->flags |= LEXF_USE_LAST_CHAR;
-		integer = LexInt(lex, base);
-		lex->flags |= LEXF_USE_LAST_CHAR;
-		if (integer == ERR && (lex->flags & LEXF_ERROR))
-			return lex->cur_tok = ERR;
-		lex->integer = integer;
-		if (lex->cur_char == '.') {
-			lex->flags &= ~LEXF_USE_LAST_CHAR;
-			goto decimal_chk;
-		}
-		if (lex->cur_char == 'e' || lex->cur_char == 'E') {
-			lex->flags &= ~LEXF_USE_LAST_CHAR;
-			goto exponet;
-		}
-		return lex->cur_tok = TK_I64;
-		break;
-	case '+':
-		switch (chr1 = LexAdvChr(lex)) {
-			break;
-		case '+':
-			return lex->cur_tok = TK_INC_INC;
-			break;
-		case '=':
-			return lex->cur_tok = TK_ADD_EQ;
-			break;
-		default:
-			lex->flags |= LEXF_USE_LAST_CHAR;
-			return lex->cur_tok = '+';
-		}
-		break;
-	case '-':
-		switch (chr1 = LexAdvChr(lex)) {
-			break;
-		case '-':
-			return lex->cur_tok = TK_DEC_DEC;
-			break;
-		case '>':
-			return lex->cur_tok = TK_ARROW;
-			break;
-		case '=':
-			return lex->cur_tok = TK_SUB_EQ;
-			break;
-		default:
-			lex->flags |= LEXF_USE_LAST_CHAR;
-			return lex->cur_tok = '-';
-		}
-		break;
-	case '=':
-		if ('=' == LexAdvChr(lex))
-			return lex->cur_tok = TK_EQ_EQ;
-		lex->flags |= LEXF_USE_LAST_CHAR;
-		return lex->cur_tok = '=';
-		break;
-	case '(':
-		return lex->cur_tok = '(';
-		break;
-	case ')':
-		return lex->cur_tok = ')';
-		break;
-	case '{':
-		return lex->cur_tok = '{';
-		break;
-	case '}':
-		return lex->cur_tok = '}';
-		break;
-	case '[':
-		return lex->cur_tok = '[';
-		break;
-	case ']':
-		return lex->cur_tok = ']';
-		break;
-	case '.':
-		switch (chr1 = LexAdvChr(lex)) {
-		case '.':
-			if ('.' != LexAdvChr(lex)) {
-				LexErr(lex, "Expected 3 dots.");
-				return ERR;
-			}
-			return lex->cur_tok = TK_DOT_DOT_DOT;
-			break;
-		default:
-			lex->flags |= LEXF_USE_LAST_CHAR;
-			return lex->cur_tok = '.';
-		}
-		break;
-	case '!':
-		if ('=' == LexAdvChr(lex))
-			return lex->cur_tok = TK_NE;
-		lex->flags |= LEXF_USE_LAST_CHAR;
-		return lex->cur_tok = '!';
-		break;
-	case '~':
-		return lex->cur_tok = '~';
-		break;
-	case '*':
-		if ('=' == LexAdvChr(lex))
-			return lex->cur_tok = TK_MUL_EQ;
-		lex->flags |= LEXF_USE_LAST_CHAR;
-		return lex->cur_tok = '*';
-		break;
-	case '/':
-		if ('=' == (chr1 = LexAdvChr(lex)))
-			return lex->cur_tok = TK_DIV_EQ;
-		else if (chr1 == '/') {
-			LexSkipTillNewLine(lex);
-			goto re_enter;
-		} else if (chr1 == '*') {
-			LexSkipMultlineComment(lex);
-			goto re_enter;
-		}
-		lex->flags |= LEXF_USE_LAST_CHAR;
-		return lex->cur_tok = '/';
-		break;
-	case '%':
-		if ('=' == LexAdvChr(lex))
-			return lex->cur_tok = TK_MOD_EQ;
-		lex->flags |= LEXF_USE_LAST_CHAR;
-		return lex->cur_tok = '%';
-		break;
-	case '<':
-		switch (chr1 = LexAdvChr(lex)) {
-			break;
-		case '=':
-			return lex->cur_tok = TK_LE;
-			break;
-		case '<':
-			if ('=' == LexAdvChr(lex))
-				return lex->cur_tok = TK_LSH_EQ;
-			lex->flags |= LEXF_USE_LAST_CHAR;
-			return lex->cur_tok = TK_LSH;
-			break;
-		default:
-			lex->flags |= LEXF_USE_LAST_CHAR;
-			return lex->cur_tok = '<';
-		}
-		break;
-	case '>':
-		switch (chr1 = LexAdvChr(lex)) {
-			break;
-		case '=':
-			return lex->cur_tok = TK_GE;
-			break;
-		case '>':
-			if ('=' == LexAdvChr(lex))
-				return lex->cur_tok = TK_RSH_EQ;
-			lex->flags |= LEXF_USE_LAST_CHAR;
-			return lex->cur_tok = TK_RSH;
-			break;
-		default:
-			lex->flags |= LEXF_USE_LAST_CHAR;
-			return lex->cur_tok = '>';
-		}
-		break;
-	case '&':
-		switch (LexAdvChr(lex)) {
-		case '=':
-			return lex->cur_tok = TK_AND_EQ;
-		case '&':
-			return lex->cur_tok = TK_AND_AND;
-		}
-		lex->flags |= LEXF_USE_LAST_CHAR;
-		return lex->cur_tok = '&';
-		break;
-	case '|':
-		switch (LexAdvChr(lex)) {
-		case '=':
-			return lex->cur_tok = TK_OR_EQ;
-		case '|':
-			return lex->cur_tok = TK_OR_OR;
-		}
-		lex->flags |= LEXF_USE_LAST_CHAR;
-		return lex->cur_tok = '|';
-		break;
-	case '^':
-		switch (LexAdvChr(lex)) {
-		case '=':
-			return lex->cur_tok = TK_XOR_EQ;
-		case '^':
-			return lex->cur_tok = TK_XOR_XOR;
-		}
-		lex->flags |= LEXF_USE_LAST_CHAR;
-		return lex->cur_tok = '^';
-		break;
-	case '"':
-		if (ERR == LexString(lex, '"'))
-			return lex->cur_tok = ERR;
-		return lex->cur_tok = TK_STR;
-		break;
-	case '\'':
-		memset(lex->string, 0, 8);
-		if (ERR == LexString(lex, '\''))
-			return ERR;
-		if (strlen(lex->string) > 8) {
-			LexErr(lex, "String constant too long!");
-			return ERR;
-		}
-		lex->integer = *(uint64_t*)lex->string;
-		return lex->cur_tok = TK_CHR;
-		break;
-	case '_':
-	case '@':
-	case 'a' ... 'z':
-	case 'A' ... 'Z':
-		lex->flags |= LEXF_USE_LAST_CHAR;
-		for (;;) {
-			switch (chr1 = LexAdvChr(lex)) {
-				break;
-			case '_':
-			case '@':
-			case 'a' ... 'z':
-			case 'A' ... 'Z':
-			case '0' ... '9':
-				if (idx + 1 >= STR_LEN) {
-					LexErr(lex, "Name is too long.");
-					return lex->cur_tok = ERR;
-				}
-				lex->string[idx++] = chr1;
-				break;
-			default:
-				lex->flags |= LEXF_USE_LAST_CHAR;
-				lex->string[idx++] = 0;
-				if (!(lex->flags & LEXF_NO_EXPAND)) {
-					define = HashFind(lex->string, Fs->hash_table, HTT_DEFINE_STR, 1);
-					if (define) {
-						//
-						// Move the of cursor backwards as we moved forwards when getting the name
-						// NULL+
-						// ---->Cur
-						//   to
-						// --->(at plus)
-						//
-						lex->file->pos--;
-						// We dont want to use the last charactor now that we are in a macro
-						lex->flags &= ~LEXF_USE_LAST_CHAR;
-						//
-						new_file = A_MALLOC(sizeof(CLexFile), NULL);
-						new_file->dir=NULL;
-						new_file->last = lex->file;
-						new_file->filename = A_STRDUP(define->base.str, NULL);
-						new_file->pos = new_file->col = new_file->ln = 0;
-						new_file->text = A_STRDUP(define->data, NULL);
-						lex->file = new_file;
-						goto re_enter;
-					}
-				}
-				lex->str_len = idx;
-				return lex->cur_tok = TK_NAME;
-			}
-		}
-		break;
-	case '#':
-		if (TK_NAME == Lex(lex)) {
-			if (!strcmp(lex->string, "help_file")) {
-				Lex(lex); //Go past string
-				LexWarn(lex, "AIWN ignore's #help_file's ignored by the C side");
-				goto re_enter;
-			} else if (!strcmp(lex->string, "help_index")) {
-				Lex(lex); //Go past string
-				LexWarn(lex, "AIWN ignore's #help_index's ignored by the C side");
-				goto re_enter;
-			} else if (!strcmp(lex->string, "assert")) {
-				LexWarn(lex, "AIWN ignore's #assert's and other JIT shennangins");
-				goto re_enter;
-			} else if (!strcmp(lex->string, "if")) {
-				LexWarn(lex, "AIWN does not handle #if's(will treat it as a 0).");
-				goto if_fail;
-			} else if (!strcmp(lex->string, "ifaot")) {
-				// AIWN will only AOT compile for you,the JIT will be
-				// handled by the newly compiled compiler
-				goto if_pass;
-			} else if (!strcmp(lex->string, "ifjit")) {
-				// AIWN will only AOT compile for you,the JIT will be
-				// handled by the newly compiled compiler
-				goto if_fail;
-			} else if (!strcmp(lex->string, "endif")) {
-				goto re_enter;
-			} else if (!strcmp(lex->string, "else")) {
-				in_else = 1;
-				// You are here are you passed the initial #if statement?
-				// Otherwise you would be searching for an #else
-				goto if_fail;
-			} else if (!strcmp(lex->string, "ifndef")) {
-				old_flags = lex->flags;
-				lex->flags |= LEXF_NO_EXPAND;
-				if (TK_NAME != Lex(lex)) {
-					LexErr(lex, "Expected a name for #ifndef.");
-					return lex->cur_tok = ERR;
-				}
-				lex->flags = old_flags;
-				if (HashFind(lex->string, Fs->hash_table, HTT_DEFINE_STR, 1)) {
-					in_else = 0;
-					goto if_fail;
-				} else
-					goto if_pass;
-			}
-			if (!strcmp(lex->string, "ifdef")) {
-				old_flags = lex->flags;
-				lex->flags |= LEXF_NO_EXPAND;
-				if (TK_NAME != Lex(lex)) {
-					LexErr(lex, "Expected a name for #ifdef.");
-					return lex->cur_tok = ERR;
-				}
-				lex->flags = old_flags;
-				if (!HashFind(lex->string, Fs->hash_table, HTT_DEFINE_STR, 1)) {
-					in_else = 0;
-				if_fail:
-					//
-					// idx is the current nesting level,it increases every time
-					// we encounter a #ifdef(and it's freinds)
-					//
-					// #ifdef A // idx==1
-					// #ifdef B // idx==2
-					// #ifdef C // idx==2
-					// #endif // idx==1
-					// #endif // idx==0
-					//
-					idx = 1;
-				if_fail_loop:
-					while ('#' != (chr1 = LexAdvChr(lex))) {
-						if (chr1 == 0)
-							return lex->cur_tok = 0;
-						if (chr1 == ERR)
-							return lex->cur_tok = ERR;
-					}
-					if (TK_NAME != Lex(lex)) {
-						LexErr(lex, "Stray '#' in program.");
-						return lex->cur_tok = ERR;
-					}
-					if (!in_else && !strcmp(lex->string, "else")) {
-						goto re_enter;
-					} else if (!strcmp(lex->string, "endif")) {
-						if (!--idx)
-							goto re_enter;
-					} else if (__IsCondDirective(lex->string)) {
-						idx++;
-					}
-					goto if_fail_loop;
-				} else {
-				if_pass:;
-				}
-				lex->flags = old_flags;
-				goto re_enter;
-			}
-			if (!strcmp(lex->string, "include")) {
-				if (TK_STR != Lex(lex)) {
-					LexErr(lex, "Expected a string for #include.");
-					return lex->cur_tok = ERR;
-				}
-				actual_file=lex->file;
-				while(actual_file) {
-					if(actual_file->is_file) break;
-					actual_file=actual_file->last;
-				}
-				if(actual_file) {
-					if(actual_file->dir) {
-						int64_t len=snprintf(NULL,0,"%s/%s",actual_file->dir,lex->string);
-						char buf[len+1];
-						sprintf(buf,"%s/%s",actual_file->dir,lex->string);
-						dir=__AIWNIOS_StrDup(buf,NULL);
-						*strrchr(dir,'/')=0;
-						f = fopen(buf, "rb");
-					} else
-						goto normal;
-				} else {
-				  normal:
-				  f = fopen(lex->string, "rb");
-				  if(!strrchr(lex->string,'/')) {
-					  dir=__AIWNIOS_StrDup(".",NULL);
-				  } else {
-					  dir=__AIWNIOS_StrDup(lex->string,NULL);
-					  *strrchr(dir,'/')=0;
-				  }
-				}
-				if (!f) {
-					LexErr(lex, "I can't find file '%s'.", lex->string);
-					return lex->cur_tok = ERR;
-				}
-				
-				fseek(f, 0, SEEK_END);
-				idx = ftell(f);
-				fseek(f, 0, SEEK_SET);
-				idx -= ftell(f);
-				new_file = A_MALLOC(sizeof(CLexFile), NULL);
-				new_file->text = A_MALLOC(idx + 1, NULL);
-				new_file->text[idx] = 0;
-				new_file->dir=dir;
-				fread(new_file->text, 1, idx, f);
-				fclose(f);
-				new_file->is_file=1;
-				new_file->last = lex->file;
-				new_file->filename = A_STRDUP(lex->string, NULL);
-				new_file->pos = new_file->col = new_file->ln = 0;
-				lex->file = new_file;
-				goto re_enter;
-			} else if (!strcmp(lex->string, "define")) {
-				lex->flags |= LEXF_NO_EXPAND;
-				if (TK_NAME != Lex(lex)) {
-					LexErr(lex, "Expected a name for #define.");
-					return lex->cur_tok = ERR;
-				}
-				lex->flags &= ~LEXF_NO_EXPAND;
-				strcpy(macro_name, lex->string);
-				strcpy(lex->string, "");
-				define = A_CALLOC(sizeof(CHashDefineStr), NULL);
-				define->base.str = A_STRDUP(macro_name, NULL);
-				define->base.type = HTT_DEFINE_STR;
-				define->src_link = LexSrcLink(lex, NULL);
-				idx = 0;
-				while (chr1 = LexAdvChr(lex)) {
-					switch (chr1) {
-						break;
-					//
-					// When we get a '/',it could mean a '//',a '/*',or even just a slash
-					// So check for all orf these conditions
-					//
-					case '/':
-						if ('/' == (chr1 = LexAdvChr(lex))) {
-							LexSkipTillNewLine(lex);
-						add_macro:
-							lex->string[idx++] = 0;
-							define->data = A_STRDUP(lex->string, NULL);
-							HashAdd(&define->base, Fs->hash_table);
-							// Lex next item
-							goto re_enter;
-						} else if (chr1 == '*') {
-							LexSkipMultlineComment(lex);
-							goto add_macro;
-						} else {
-							// Is just a '/',but we didnt use the last character so re-use it
-							lex->flags |= LEXF_USE_LAST_CHAR;
-							lex->string[idx++] = '/';
-						}
-						break;
-					case '\\':
-						LexSkipTillNewLine(lex);
-						break;
-					case '\n':
-						lex->string[idx++] = '\n';
-						goto add_macro;
-						break;
-					default:
-						lex->string[idx++] = chr1;
-					}
-				}
-			}
-		} else {
-			LexErr(lex, "Stray '#' in program.");
-			return lex->cur_tok = ERR;
-		}
-		break;
-	case 0:
-		return lex->cur_tok = 0;
-	}
-	LexErr(lex, "Unexpected charactor '%c'.", chr1);
-	return lex->cur_tok = ERR;
+  int64_t chr1 = LexAdvChr(lex), chr2;
+  int64_t has_base = 0, base = 10, integer = 0, decimal = 0, exponet = 0,
+          zeros = 0, idx = 0, old_flags, in_else;
+  FILE *f;
+  char macro_name[STR_LEN];
+  CHashDefineStr *define;
+  CLexFile *new_file, *actual_file;
+  char *dir;
+  switch (chr1) {
+    break;
+  case '`':
+    return lex->cur_tok = '`';
+    break;
+  case ';':
+    return lex->cur_tok = ';';
+    break;
+  case ':':
+    return lex->cur_tok = ':';
+    break;
+  case ',':
+    return lex->cur_tok = ',';
+    break;
+  case ' ':
+  case '\t':
+  case '\n':
+    goto re_enter;
+    break;
+  case '0' ... '9':
+    if (chr1 == '0') {
+      chr2 = LexAdvChr(lex);
+      switch (chr2) {
+        break;
+      case 'x':
+      case 'X':
+        chr1 = LexAdvChr(lex);
+        base = 16;
+        lex->flags |= LEXF_USE_LAST_CHAR;
+        break;
+      case 'b':
+        chr1 = LexAdvChr(lex);
+        base = 2;
+        lex->flags |= LEXF_USE_LAST_CHAR;
+        break;
+      case '0' ... '9':
+        lex->flags |= LEXF_USE_LAST_CHAR;
+        break;
+      default:;
+        lex->flags |= LEXF_USE_LAST_CHAR;
+        // LexErr(lex,"Unexpected charactor after '0'.");
+        // return lex->cur_tok=ERR;
+      }
+      integer = LexInt(lex, base);
+      if (integer == ERR && (lex->flags & LEXF_ERROR))
+        return lex->cur_tok = ERR;
+      switch (LexAdvChr(lex)) {
+        break;
+      case 'E':
+      case 'e':
+        decimal = 0;
+        if (base != 10) {
+          LexErr(lex, "Expected a base 10 number for floating points.");
+          return lex->cur_tok = ERR;
+        }
+      exponet:
+        exponet = 0;
+        base = 1; // This holds the multipler for the exponet
+        if ('+' == (chr1 = LexAdvChr(lex))) {
+        } else if ('-' == chr1) {
+          base = -1;
+        } else if (isdigit(chr1))
+          lex->flags |= LEXF_USE_LAST_CHAR;
+        exponet = LexInt(lex, 10);
+        exponet *= base;
+        lex->flags |= LEXF_USE_LAST_CHAR;
+        if (integer == ERR && (lex->flags & LEXF_ERROR)) {
+          LexErr(lex, "Expected an exponet.");
+          return lex->cur_tok = ERR;
+        }
+      fin_f64:
+        if (decimal) {
+          lex->flt =
+              integer + decimal * pow(10, -zeros - 1 - floor(log10(decimal)));
+        } else
+          lex->flt = integer;
+        lex->flt *= pow(10, exponet);
+        return lex->cur_tok = TK_F64;
+        break;
+      case '.':
+      decimal_chk:
+        switch (chr1 = LexAdvChr(lex)) {
+          break;
+        case '0':
+          zeros++;
+          goto decimal_chk;
+          break;
+        case '1' ... '9':
+          lex->flags |= LEXF_USE_LAST_CHAR;
+          decimal = LexInt(lex, 10);
+          lex->flags |= LEXF_USE_LAST_CHAR;
+          break;
+        default:;
+        }
+        if (lex->cur_char == 'e' || lex->cur_char == 'E') {
+          lex->flags &= ~LEXF_USE_LAST_CHAR;
+          goto exponet;
+        }
+        lex->flags |= LEXF_USE_LAST_CHAR;
+        lex->integer = integer;
+        goto fin_f64;
+        break;
+      default:
+        lex->flags |= LEXF_USE_LAST_CHAR;
+        lex->integer = integer;
+        return lex->cur_tok = TK_I64;
+      }
+    } else
+      //
+      // We checked the first digit and checked for 0.
+      // Use it again in LexInt as we found no use for it here.
+      //
+      lex->flags |= LEXF_USE_LAST_CHAR;
+    integer = LexInt(lex, base);
+    lex->flags |= LEXF_USE_LAST_CHAR;
+    if (integer == ERR && (lex->flags & LEXF_ERROR))
+      return lex->cur_tok = ERR;
+    lex->integer = integer;
+    if (lex->cur_char == '.') {
+      lex->flags &= ~LEXF_USE_LAST_CHAR;
+      goto decimal_chk;
+    }
+    if (lex->cur_char == 'e' || lex->cur_char == 'E') {
+      lex->flags &= ~LEXF_USE_LAST_CHAR;
+      goto exponet;
+    }
+    return lex->cur_tok = TK_I64;
+    break;
+  case '+':
+    switch (chr1 = LexAdvChr(lex)) {
+      break;
+    case '+':
+      return lex->cur_tok = TK_INC_INC;
+      break;
+    case '=':
+      return lex->cur_tok = TK_ADD_EQ;
+      break;
+    default:
+      lex->flags |= LEXF_USE_LAST_CHAR;
+      return lex->cur_tok = '+';
+    }
+    break;
+  case '-':
+    switch (chr1 = LexAdvChr(lex)) {
+      break;
+    case '-':
+      return lex->cur_tok = TK_DEC_DEC;
+      break;
+    case '>':
+      return lex->cur_tok = TK_ARROW;
+      break;
+    case '=':
+      return lex->cur_tok = TK_SUB_EQ;
+      break;
+    default:
+      lex->flags |= LEXF_USE_LAST_CHAR;
+      return lex->cur_tok = '-';
+    }
+    break;
+  case '=':
+    if ('=' == LexAdvChr(lex))
+      return lex->cur_tok = TK_EQ_EQ;
+    lex->flags |= LEXF_USE_LAST_CHAR;
+    return lex->cur_tok = '=';
+    break;
+  case '(':
+    return lex->cur_tok = '(';
+    break;
+  case ')':
+    return lex->cur_tok = ')';
+    break;
+  case '{':
+    return lex->cur_tok = '{';
+    break;
+  case '}':
+    return lex->cur_tok = '}';
+    break;
+  case '[':
+    return lex->cur_tok = '[';
+    break;
+  case ']':
+    return lex->cur_tok = ']';
+    break;
+  case '.':
+    switch (chr1 = LexAdvChr(lex)) {
+    case '.':
+      if ('.' != LexAdvChr(lex)) {
+        LexErr(lex, "Expected 3 dots.");
+        return ERR;
+      }
+      return lex->cur_tok = TK_DOT_DOT_DOT;
+      break;
+    default:
+      lex->flags |= LEXF_USE_LAST_CHAR;
+      return lex->cur_tok = '.';
+    }
+    break;
+  case '!':
+    if ('=' == LexAdvChr(lex))
+      return lex->cur_tok = TK_NE;
+    lex->flags |= LEXF_USE_LAST_CHAR;
+    return lex->cur_tok = '!';
+    break;
+  case '~':
+    return lex->cur_tok = '~';
+    break;
+  case '*':
+    if ('=' == LexAdvChr(lex))
+      return lex->cur_tok = TK_MUL_EQ;
+    lex->flags |= LEXF_USE_LAST_CHAR;
+    return lex->cur_tok = '*';
+    break;
+  case '/':
+    if ('=' == (chr1 = LexAdvChr(lex)))
+      return lex->cur_tok = TK_DIV_EQ;
+    else if (chr1 == '/') {
+      LexSkipTillNewLine(lex);
+      goto re_enter;
+    } else if (chr1 == '*') {
+      LexSkipMultlineComment(lex);
+      goto re_enter;
+    }
+    lex->flags |= LEXF_USE_LAST_CHAR;
+    return lex->cur_tok = '/';
+    break;
+  case '%':
+    if ('=' == LexAdvChr(lex))
+      return lex->cur_tok = TK_MOD_EQ;
+    lex->flags |= LEXF_USE_LAST_CHAR;
+    return lex->cur_tok = '%';
+    break;
+  case '<':
+    switch (chr1 = LexAdvChr(lex)) {
+      break;
+    case '=':
+      return lex->cur_tok = TK_LE;
+      break;
+    case '<':
+      if ('=' == LexAdvChr(lex))
+        return lex->cur_tok = TK_LSH_EQ;
+      lex->flags |= LEXF_USE_LAST_CHAR;
+      return lex->cur_tok = TK_LSH;
+      break;
+    default:
+      lex->flags |= LEXF_USE_LAST_CHAR;
+      return lex->cur_tok = '<';
+    }
+    break;
+  case '>':
+    switch (chr1 = LexAdvChr(lex)) {
+      break;
+    case '=':
+      return lex->cur_tok = TK_GE;
+      break;
+    case '>':
+      if ('=' == LexAdvChr(lex))
+        return lex->cur_tok = TK_RSH_EQ;
+      lex->flags |= LEXF_USE_LAST_CHAR;
+      return lex->cur_tok = TK_RSH;
+      break;
+    default:
+      lex->flags |= LEXF_USE_LAST_CHAR;
+      return lex->cur_tok = '>';
+    }
+    break;
+  case '&':
+    switch (LexAdvChr(lex)) {
+    case '=':
+      return lex->cur_tok = TK_AND_EQ;
+    case '&':
+      return lex->cur_tok = TK_AND_AND;
+    }
+    lex->flags |= LEXF_USE_LAST_CHAR;
+    return lex->cur_tok = '&';
+    break;
+  case '|':
+    switch (LexAdvChr(lex)) {
+    case '=':
+      return lex->cur_tok = TK_OR_EQ;
+    case '|':
+      return lex->cur_tok = TK_OR_OR;
+    }
+    lex->flags |= LEXF_USE_LAST_CHAR;
+    return lex->cur_tok = '|';
+    break;
+  case '^':
+    switch (LexAdvChr(lex)) {
+    case '=':
+      return lex->cur_tok = TK_XOR_EQ;
+    case '^':
+      return lex->cur_tok = TK_XOR_XOR;
+    }
+    lex->flags |= LEXF_USE_LAST_CHAR;
+    return lex->cur_tok = '^';
+    break;
+  case '"':
+    if (ERR == LexString(lex, '"'))
+      return lex->cur_tok = ERR;
+    return lex->cur_tok = TK_STR;
+    break;
+  case '\'':
+    memset(lex->string, 0, 8);
+    if (ERR == LexString(lex, '\''))
+      return ERR;
+    if (strlen(lex->string) > 8) {
+      LexErr(lex, "String constant too long!");
+      return ERR;
+    }
+    lex->integer = *(uint64_t *)lex->string;
+    return lex->cur_tok = TK_CHR;
+    break;
+  case '_':
+  case '@':
+  case 'a' ... 'z':
+  case 'A' ... 'Z':
+    lex->flags |= LEXF_USE_LAST_CHAR;
+    for (;;) {
+      switch (chr1 = LexAdvChr(lex)) {
+        break;
+      case '_':
+      case '@':
+      case 'a' ... 'z':
+      case 'A' ... 'Z':
+      case '0' ... '9':
+        if (idx + 1 >= STR_LEN) {
+          LexErr(lex, "Name is too long.");
+          return lex->cur_tok = ERR;
+        }
+        lex->string[idx++] = chr1;
+        break;
+      default:
+        lex->flags |= LEXF_USE_LAST_CHAR;
+        lex->string[idx++] = 0;
+        if (!(lex->flags & LEXF_NO_EXPAND)) {
+          define = HashFind(lex->string, Fs->hash_table, HTT_DEFINE_STR, 1);
+          if (define) {
+            //
+            // Move the of cursor backwards as we moved forwards when getting
+            // the name NULL+
+            // ---->Cur
+            //   to
+            // --->(at plus)
+            //
+            lex->file->pos--;
+            // We dont want to use the last charactor now that we are in a macro
+            lex->flags &= ~LEXF_USE_LAST_CHAR;
+            //
+            new_file = A_MALLOC(sizeof(CLexFile), NULL);
+            new_file->dir = NULL;
+            new_file->last = lex->file;
+            new_file->filename = A_STRDUP(define->base.str, NULL);
+            new_file->pos = new_file->col = new_file->ln = 0;
+            new_file->text = A_STRDUP(define->data, NULL);
+            lex->file = new_file;
+            goto re_enter;
+          }
+        }
+        lex->str_len = idx;
+        return lex->cur_tok = TK_NAME;
+      }
+    }
+    break;
+  case '#':
+    if (TK_NAME == Lex(lex)) {
+      if (!strcmp(lex->string, "help_file")) {
+        Lex(lex); // Go past string
+        LexWarn(lex, "AIWN ignore's #help_file's ignored by the C side");
+        goto re_enter;
+      } else if (!strcmp(lex->string, "help_index")) {
+        Lex(lex); // Go past string
+        LexWarn(lex, "AIWN ignore's #help_index's ignored by the C side");
+        goto re_enter;
+      } else if (!strcmp(lex->string, "assert")) {
+        LexWarn(lex, "AIWN ignore's #assert's and other JIT shennangins");
+        goto re_enter;
+      } else if (!strcmp(lex->string, "if")) {
+        LexWarn(lex, "AIWN does not handle #if's(will treat it as a 0).");
+        goto if_fail;
+      } else if (!strcmp(lex->string, "ifaot")) {
+        // AIWN will only AOT compile for you,the JIT will be
+        // handled by the newly compiled compiler
+        goto if_pass;
+      } else if (!strcmp(lex->string, "ifjit")) {
+        // AIWN will only AOT compile for you,the JIT will be
+        // handled by the newly compiled compiler
+        goto if_fail;
+      } else if (!strcmp(lex->string, "endif")) {
+        goto re_enter;
+      } else if (!strcmp(lex->string, "else")) {
+        in_else = 1;
+        // You are here are you passed the initial #if statement?
+        // Otherwise you would be searching for an #else
+        goto if_fail;
+      } else if (!strcmp(lex->string, "ifndef")) {
+        old_flags = lex->flags;
+        lex->flags |= LEXF_NO_EXPAND;
+        if (TK_NAME != Lex(lex)) {
+          LexErr(lex, "Expected a name for #ifndef.");
+          return lex->cur_tok = ERR;
+        }
+        lex->flags = old_flags;
+        if (HashFind(lex->string, Fs->hash_table, HTT_DEFINE_STR, 1)) {
+          in_else = 0;
+          goto if_fail;
+        } else
+          goto if_pass;
+      }
+      if (!strcmp(lex->string, "ifdef")) {
+        old_flags = lex->flags;
+        lex->flags |= LEXF_NO_EXPAND;
+        if (TK_NAME != Lex(lex)) {
+          LexErr(lex, "Expected a name for #ifdef.");
+          return lex->cur_tok = ERR;
+        }
+        lex->flags = old_flags;
+        if (!HashFind(lex->string, Fs->hash_table, HTT_DEFINE_STR, 1)) {
+          in_else = 0;
+        if_fail:
+          //
+          // idx is the current nesting level,it increases every time
+          // we encounter a #ifdef(and it's freinds)
+          //
+          // #ifdef A // idx==1
+          // #ifdef B // idx==2
+          // #ifdef C // idx==2
+          // #endif // idx==1
+          // #endif // idx==0
+          //
+          idx = 1;
+        if_fail_loop:
+          while ('#' != (chr1 = LexAdvChr(lex))) {
+            if (chr1 == 0)
+              return lex->cur_tok = 0;
+            if (chr1 == ERR)
+              return lex->cur_tok = ERR;
+          }
+          if (TK_NAME != Lex(lex)) {
+            LexErr(lex, "Stray '#' in program.");
+            return lex->cur_tok = ERR;
+          }
+          if (!in_else && !strcmp(lex->string, "else")) {
+            goto re_enter;
+          } else if (!strcmp(lex->string, "endif")) {
+            if (!--idx)
+              goto re_enter;
+          } else if (__IsCondDirective(lex->string)) {
+            idx++;
+          }
+          goto if_fail_loop;
+        } else {
+        if_pass:;
+        }
+        lex->flags = old_flags;
+        goto re_enter;
+      }
+      if (!strcmp(lex->string, "include")) {
+        if (TK_STR != Lex(lex)) {
+          LexErr(lex, "Expected a string for #include.");
+          return lex->cur_tok = ERR;
+        }
+        actual_file = lex->file;
+        while (actual_file) {
+          if (actual_file->is_file)
+            break;
+          actual_file = actual_file->last;
+        }
+        if (actual_file) {
+          if (actual_file->dir) {
+            int64_t len =
+                snprintf(NULL, 0, "%s/%s", actual_file->dir, lex->string);
+            char buf[len + 1];
+            sprintf(buf, "%s/%s", actual_file->dir, lex->string);
+            dir = __AIWNIOS_StrDup(buf, NULL);
+            *strrchr(dir, '/') = 0;
+            f = fopen(buf, "rb");
+          } else
+            goto normal;
+        } else {
+        normal:
+          f = fopen(lex->string, "rb");
+          if (!strrchr(lex->string, '/')) {
+            dir = __AIWNIOS_StrDup(".", NULL);
+          } else {
+            dir = __AIWNIOS_StrDup(lex->string, NULL);
+            *strrchr(dir, '/') = 0;
+          }
+        }
+        if (!f) {
+          LexErr(lex, "I can't find file '%s'.", lex->string);
+          return lex->cur_tok = ERR;
+        }
+
+        fseek(f, 0, SEEK_END);
+        idx = ftell(f);
+        fseek(f, 0, SEEK_SET);
+        idx -= ftell(f);
+        new_file = A_MALLOC(sizeof(CLexFile), NULL);
+        new_file->text = A_MALLOC(idx + 1, NULL);
+        new_file->text[idx] = 0;
+        new_file->dir = dir;
+        fread(new_file->text, 1, idx, f);
+        fclose(f);
+        new_file->is_file = 1;
+        new_file->last = lex->file;
+        new_file->filename = A_STRDUP(lex->string, NULL);
+        new_file->pos = new_file->col = new_file->ln = 0;
+        lex->file = new_file;
+        goto re_enter;
+      } else if (!strcmp(lex->string, "define")) {
+        lex->flags |= LEXF_NO_EXPAND;
+        if (TK_NAME != Lex(lex)) {
+          LexErr(lex, "Expected a name for #define.");
+          return lex->cur_tok = ERR;
+        }
+        lex->flags &= ~LEXF_NO_EXPAND;
+        strcpy(macro_name, lex->string);
+        strcpy(lex->string, "");
+        define = A_CALLOC(sizeof(CHashDefineStr), NULL);
+        define->base.str = A_STRDUP(macro_name, NULL);
+        define->base.type = HTT_DEFINE_STR;
+        define->src_link = LexSrcLink(lex, NULL);
+        idx = 0;
+        while (chr1 = LexAdvChr(lex)) {
+          switch (chr1) {
+            break;
+          //
+          // When we get a '/',it could mean a '//',a '/*',or even just a slash
+          // So check for all orf these conditions
+          //
+          case '/':
+            if ('/' == (chr1 = LexAdvChr(lex))) {
+              LexSkipTillNewLine(lex);
+            add_macro:
+              lex->string[idx++] = 0;
+              define->data = A_STRDUP(lex->string, NULL);
+              HashAdd(&define->base, Fs->hash_table);
+              // Lex next item
+              goto re_enter;
+            } else if (chr1 == '*') {
+              LexSkipMultlineComment(lex);
+              goto add_macro;
+            } else {
+              // Is just a '/',but we didnt use the last character so re-use it
+              lex->flags |= LEXF_USE_LAST_CHAR;
+              lex->string[idx++] = '/';
+            }
+            break;
+          case '\\':
+            LexSkipTillNewLine(lex);
+            break;
+          case '\n':
+            lex->string[idx++] = '\n';
+            goto add_macro;
+            break;
+          default:
+            lex->string[idx++] = chr1;
+          }
+        }
+      }
+    } else {
+      LexErr(lex, "Stray '#' in program.");
+      return lex->cur_tok = ERR;
+    }
+    break;
+  case 0:
+    return lex->cur_tok = 0;
+  }
+  LexErr(lex, "Unexpected charactor '%c'.", chr1);
+  return lex->cur_tok = ERR;
 }
 
-CLexer* LexerNew(char* filename, char* text)
-{
-	CLexFile* file = A_CALLOC(sizeof(CLexFile), NULL);
-	file->filename = A_STRDUP(filename, NULL);
-	file->text = A_STRDUP(text, NULL);
-	CLexer* new = A_CALLOC(sizeof(CLexer), NULL);
-	new->file = file;
-	struct {
-		char* name;
-		int64_t tok;
-	} kws[] = {
-		//{"include",TK_KW_INCLUDE},
-		//{"define",TK_KW_DEFINE},
-		{ "union", TK_KW_UNION },
-		{ "catch", TK_KW_CATCH },
-		{ "class", TK_KW_CLASS },
-		{ "try", TK_KW_TRY },
-		{ "if", TK_KW_IF },
-		{ "else", TK_KW_ELSE },
-		{ "for", TK_KW_FOR },
-		{ "while", TK_KW_WHILE },
-		{ "extern", TK_KW_EXTERN },
-		{ "_extern", TK_KW__EXTERN },
-		{ "return", TK_KW_RETURN },
-		{ "sizeof", TK_KW_SIZEOF },
-		{ "_intern", TK_KW__INTERN },
-		{ "do", TK_KW_DO },
-		{ "asm", TK_KW_ASM },
-		{ "goto", TK_KW_GOTO },
-		//{"exe",TK_KW_EXE},
-		{ "break", TK_KW_BREAK },
-		{ "switch", TK_KW_SWITCH },
-		{ "start", TK_KW_START },
-		{ "end", TK_KW_END },
-		{ "case", TK_KW_CASE },
-		{ "default", TK_KW_DEFUALT },
-		{ "public", TK_KW_PUBLIC },
-		{ "offset", TK_KW_OFFSET },
-		{ "import", TK_KW_IMPORT },
-		{ "_import", TK_KW__IMPORT },
-		//{"ifdef",TK_KW_IFDEF},
-		//{"ifndef",TK_KW_IFNDEF},
-		//{"ifaot",TK_KW_IFAOT},
-		//{"ifjit",TK_KW_IFJIT},
-		//{"endif",TK_KW_ENDIF},
-		//{"assert",TK_KW_ASSERT},
-		{ "reg", TK_KW_REG },
-		{ "noreg", TK_KW_NOREG },
-		{ "lastclass", TK_KW_LASTCLASS },
-		{ "no_warn", TK_KW_NOWARN },
-		//{"help_index",TK_KW_HELP_INDEX},
-		//{"help_file",TK_KW_HELP_FILE},
-		{ "static", TK_KW_STATIC },
-		{ "lock", TK_KW_LOCK },
-		{ "defined", TK_KW_DEFINED },
-		{ "interrupt", TK_KW_INTERRUPT },
-		{ "haserrcode", TK_KW_HASERRCODE },
-		{ "argpop", TK_KW_ARGPOP },
-		{ "noargpop", TK_KW_NOARGPOP },
-	};
-	int64_t i;
-	CHashKeyword* kw;
-	for (i = 0; i != sizeof(kws) / sizeof(*kws); i++) {
-		kw = A_CALLOC(sizeof(CHashKeyword), NULL);
-		kw->base.type = HTT_KEYWORD;
-		kw->base.str = A_STRDUP(kws[i].name, NULL);
-		kw->tk = kws[i].tok;
-		HashAdd(kw, Fs->hash_table);
-	}
-	return new;
+CLexer *LexerNew(char *filename, char *text) {
+  CLexFile *file = A_CALLOC(sizeof(CLexFile), NULL);
+  file->filename = A_STRDUP(filename, NULL);
+  file->text = A_STRDUP(text, NULL);
+  CLexer *new = A_CALLOC(sizeof(CLexer), NULL);
+  new->file = file;
+  struct {
+    char *name;
+    int64_t tok;
+  } kws[] = {
+      //{"include",TK_KW_INCLUDE},
+      //{"define",TK_KW_DEFINE},
+      {"union", TK_KW_UNION},
+      {"catch", TK_KW_CATCH},
+      {"class", TK_KW_CLASS},
+      {"try", TK_KW_TRY},
+      {"if", TK_KW_IF},
+      {"else", TK_KW_ELSE},
+      {"for", TK_KW_FOR},
+      {"while", TK_KW_WHILE},
+      {"extern", TK_KW_EXTERN},
+      {"_extern", TK_KW__EXTERN},
+      {"return", TK_KW_RETURN},
+      {"sizeof", TK_KW_SIZEOF},
+      {"_intern", TK_KW__INTERN},
+      {"do", TK_KW_DO},
+      {"asm", TK_KW_ASM},
+      {"goto", TK_KW_GOTO},
+      //{"exe",TK_KW_EXE},
+      {"break", TK_KW_BREAK},
+      {"switch", TK_KW_SWITCH},
+      {"start", TK_KW_START},
+      {"end", TK_KW_END},
+      {"case", TK_KW_CASE},
+      {"default", TK_KW_DEFUALT},
+      {"public", TK_KW_PUBLIC},
+      {"offset", TK_KW_OFFSET},
+      {"import", TK_KW_IMPORT},
+      {"_import", TK_KW__IMPORT},
+      //{"ifdef",TK_KW_IFDEF},
+      //{"ifndef",TK_KW_IFNDEF},
+      //{"ifaot",TK_KW_IFAOT},
+      //{"ifjit",TK_KW_IFJIT},
+      //{"endif",TK_KW_ENDIF},
+      //{"assert",TK_KW_ASSERT},
+      {"reg", TK_KW_REG},
+      {"noreg", TK_KW_NOREG},
+      {"lastclass", TK_KW_LASTCLASS},
+      {"no_warn", TK_KW_NOWARN},
+      //{"help_index",TK_KW_HELP_INDEX},
+      //{"help_file",TK_KW_HELP_FILE},
+      {"static", TK_KW_STATIC},
+      {"lock", TK_KW_LOCK},
+      {"defined", TK_KW_DEFINED},
+      {"interrupt", TK_KW_INTERRUPT},
+      {"haserrcode", TK_KW_HASERRCODE},
+      {"argpop", TK_KW_ARGPOP},
+      {"noargpop", TK_KW_NOARGPOP},
+  };
+  int64_t i;
+  CHashKeyword *kw;
+  for (i = 0; i != sizeof(kws) / sizeof(*kws); i++) {
+    kw = A_CALLOC(sizeof(CHashKeyword), NULL);
+    kw->base.type = HTT_KEYWORD;
+    kw->base.str = A_STRDUP(kws[i].name, NULL);
+    kw->tk = kws[i].tok;
+    HashAdd(kw, Fs->hash_table);
+  }
+  return new;
 }
 
-void LexerDump(CLexer* lex)
-{
-	int64_t tok;
-	while (tok = Lex(lex)) {
-		printf("TOK:");
-		switch (tok) {
-			break;
-		case ERR:
-			printf("ERR");
-			break;
-		case TK_I64:
-			printf("I64:%ld", lex->integer);
-			break;
-		case TK_F64:
-			printf("F64:%n", lex->flt);
-			break;
-		case TK_NAME:
-			printf("NAME:%s", lex->string);
-			break;
-		case TK_STR:
-			printf("STRING:%s", lex->string);
-			break;
-		case TK_CHR:
-			lex->string[8] = 0;
-			printf("CHR:%s", &lex->integer);
-			break;
-		case TK_ERR:
-			printf("ERR");
-			return;
-			break;
-		case TK_INC_INC:
-			printf("++");
-			break;
-		case TK_DEC_DEC:
-			printf("--");
-			break;
-		case TK_AND_AND:
-			printf("&&");
-			break;
-		case TK_XOR_XOR:
-			printf("^^");
-			break;
-		case TK_OR_OR:
-			printf("||");
-			break;
-		case TK_EQ_EQ:
-			printf("==");
-			break;
-		case TK_NE:
-			printf("!=");
-			break;
-		case TK_LE:
-			printf("<=");
-			break;
-		case TK_GE:
-			printf(">=");
-			break;
-		case TK_LSH:
-			printf("<<");
-			break;
-		case TK_RSH:
-			printf(">>");
-			break;
-		case TK_ADD_EQ:
-			printf("+=");
-			break;
-		case TK_SUB_EQ:
-			printf("-=");
-			break;
-		case TK_MUL_EQ:
-			printf("*=");
-			break;
-		case TK_DIV_EQ:
-			printf("/=");
-			break;
-		case TK_LSH_EQ:
-			printf("<<=");
-			break;
-		case TK_RSH_EQ:
-			printf(">>=");
-			break;
-		case TK_AND_EQ:
-			printf("&=");
-			break;
-		case TK_OR_EQ:
-			printf("|=");
-			break;
-		case TK_XOR_EQ:
-			printf("^=");
-			break;
-		case TK_ARROW:
-			printf("->");
-			break;
-		case TK_DOT_DOT_DOT:
-			printf("...");
-			break;
-		case TK_MOD_EQ:
-			printf("%=");
-			break;
-		default:
-			if (tok < 0x100)
-				printf("%c", tok);
-		}
-		printf("\n");
-	}
+void LexerDump(CLexer *lex) {
+  int64_t tok;
+  while (tok = Lex(lex)) {
+    printf("TOK:");
+    switch (tok) {
+      break;
+    case ERR:
+      printf("ERR");
+      break;
+    case TK_I64:
+      printf("I64:%ld", lex->integer);
+      break;
+    case TK_F64:
+      printf("F64:%n", lex->flt);
+      break;
+    case TK_NAME:
+      printf("NAME:%s", lex->string);
+      break;
+    case TK_STR:
+      printf("STRING:%s", lex->string);
+      break;
+    case TK_CHR:
+      lex->string[8] = 0;
+      printf("CHR:%s", &lex->integer);
+      break;
+    case TK_ERR:
+      printf("ERR");
+      return;
+      break;
+    case TK_INC_INC:
+      printf("++");
+      break;
+    case TK_DEC_DEC:
+      printf("--");
+      break;
+    case TK_AND_AND:
+      printf("&&");
+      break;
+    case TK_XOR_XOR:
+      printf("^^");
+      break;
+    case TK_OR_OR:
+      printf("||");
+      break;
+    case TK_EQ_EQ:
+      printf("==");
+      break;
+    case TK_NE:
+      printf("!=");
+      break;
+    case TK_LE:
+      printf("<=");
+      break;
+    case TK_GE:
+      printf(">=");
+      break;
+    case TK_LSH:
+      printf("<<");
+      break;
+    case TK_RSH:
+      printf(">>");
+      break;
+    case TK_ADD_EQ:
+      printf("+=");
+      break;
+    case TK_SUB_EQ:
+      printf("-=");
+      break;
+    case TK_MUL_EQ:
+      printf("*=");
+      break;
+    case TK_DIV_EQ:
+      printf("/=");
+      break;
+    case TK_LSH_EQ:
+      printf("<<=");
+      break;
+    case TK_RSH_EQ:
+      printf(">>=");
+      break;
+    case TK_AND_EQ:
+      printf("&=");
+      break;
+    case TK_OR_EQ:
+      printf("|=");
+      break;
+    case TK_XOR_EQ:
+      printf("^=");
+      break;
+    case TK_ARROW:
+      printf("->");
+      break;
+    case TK_DOT_DOT_DOT:
+      printf("...");
+      break;
+    case TK_MOD_EQ:
+      printf("%=");
+      break;
+    default:
+      if (tok < 0x100)
+        printf("%c", tok);
+    }
+    printf("\n");
+  }
 }
 #ifdef AIWNIOS_TESTS
-#include <assert.h>
-void LexTests()
-{
-	char tmpf[TMP_MAX];
-	tmpnam(tmpf);
-	CLexer* lex = LexerNew("None", "if poodle\n"
-								   "0 123 0b11 0xfeF0\n"
-								   "'abcd1234'\n"
-								   "\"ab\\\"c\"\n"
-								   "++\n"
-								   "--\n"
-								   "&&^^||\n"
-								   "== !=\n"
-								   "<= >= <>\n"
-								   "<<\n"
-								   ">>\n"
-								   "+=\n"
-								   "-=\n"
-								   "*=\n"
-								   "/=\n"
-								   "<<=\n"
-								   ">>=\n"
-								   "&=\n"
-								   "|=\n"
-								   "^=\n"
-								   "->\n"
-								   "...\n"
-								   "%=\n"
-								   "#define onion o \n"
-								   "onion\n"
-								   "#ifdef onion\n"
-								   "1\n"
-								   "#endif\n"
-								   "#ifndef onion\n"
-								   "0\n"
-								   "#endif\n"
-								   "#ifdef onion2\n"
-								   "0\n"
-								   "#endif\n"
-								   "#ifndef onion2\n"
-								   "11\n"
-								   "#endif\n"
-								   "#ifdef onion\n"
-								   "111\n"
-								   "#else\n"
-								   "0\n"
-								   "#endif\n"
-								   "#ifndef onion\n"
-								   "0\n"
-								   "#else\n"
-								   "1111\n"
-								   "#endif\n"
-								   "#ifndef onion2\n"
-								   "11111\n"
-								   "#else\n"
-								   "0\n"
-								   "#endif\n"
-								   // Nested #if test
-								   "#ifdef onion\n"
-								   "#ifdef onion2\n"
-								   "#else\n"
-								   "#ifdef onion2\n"
-								   "#else\n"
-								   "111111\n"
-								   "#endif\n"
-								   "#endif\n"
-								   "#endif\n"
-								   "123.\n"
-								   "123.000456\n"
-								   "123e10\n"
-								   "123e+10\n"
-								   "123e-10\n"
-								   "123.456e+10\n"
-								   "// 123 \n"
-								   "1234\n"
-								   "/*\n"
-								   "1\n"
-								   "2\n"
-								   "*/\n"
-								   "12345\n"
-								   "#define onion 123456 //poop \n"
-								   "onion onion\n"
-								   "#define onion 1234567 /*poop */\n"
-								   "onion onion\n"
-								   "#define onion 1 \\ \n"
-								   "2 \\ \n"
-								   "3 \n"
-								   "onion\n");
-	assert(TK_NAME == Lex(lex));
-	assert(HashFind("if", Fs->hash_table, HTT_KEYWORD, 1));
-	assert(TK_NAME == Lex(lex));
-	assert(!strcmp(lex->string, "poodle"));
-	assert(TK_I64 == Lex(lex));
-	assert(lex->integer == 0);
-	assert(TK_I64 == Lex(lex));
-	assert(lex->integer == 123);
-	assert(TK_I64 == Lex(lex));
-	assert(lex->integer == 0b11);
-	assert(TK_I64 == Lex(lex));
-	assert(lex->integer == 0xfef0);
-	assert(TK_CHR == Lex(lex));
-	assert(lex->integer == *(int64_t*)"abcd1234");
-	assert(TK_STR == Lex(lex));
-	assert(!strcmp(lex->string, "ab\"c"));
-	assert(TK_INC_INC == Lex(lex));
-	assert(TK_DEC_DEC == Lex(lex));
-	assert(TK_AND_AND == Lex(lex));
-	assert(TK_XOR_XOR == Lex(lex));
-	assert(TK_OR_OR == Lex(lex));
-	assert(TK_EQ_EQ == Lex(lex));
-	assert(TK_NE == Lex(lex));
-	assert(TK_LE == Lex(lex));
-	assert(TK_GE == Lex(lex));
-	assert('<' == Lex(lex));
-	assert('>' == Lex(lex));
-	assert(TK_LSH == Lex(lex));
-	assert(TK_RSH == Lex(lex));
-	assert(TK_ADD_EQ == Lex(lex));
-	assert(TK_SUB_EQ == Lex(lex));
-	assert(TK_MUL_EQ == Lex(lex));
-	assert(TK_DIV_EQ == Lex(lex));
-	assert(TK_LSH_EQ == Lex(lex));
-	assert(TK_RSH_EQ == Lex(lex));
-	assert(TK_AND_EQ == Lex(lex));
-	assert(TK_OR_EQ == Lex(lex));
-	assert(TK_XOR_EQ == Lex(lex));
-	assert(TK_ARROW == Lex(lex));
-	assert(TK_DOT_DOT_DOT == Lex(lex));
-	assert(TK_MOD_EQ == Lex(lex));
-	assert(TK_NAME == Lex(lex));
-	assert(!strcmp(lex->string, "o"));
-	assert(TK_I64 == Lex(lex));
-	assert(lex->integer == 1);
-	assert(TK_I64 == Lex(lex));
-	assert(lex->integer == 11);
-	assert(TK_I64 == Lex(lex));
-	assert(lex->integer == 111);
-	assert(TK_I64 == Lex(lex));
-	assert(lex->integer == 1111);
-	assert(TK_I64 == Lex(lex));
-	assert(lex->integer == 11111);
-	assert(TK_I64 == Lex(lex));
-	assert(lex->integer == 111111);
-#define AROUND(v, n, off) (((v) >= (n) - (off)) && ((v) <= (n) + (off)))
-	assert(TK_F64 == Lex(lex));
-	assert(AROUND(lex->flt, 123., 0.1));
-	assert(TK_F64 == Lex(lex));
-	assert(AROUND(lex->flt, 123.000456, 0.0001));
-	assert(TK_F64 == Lex(lex));
-	assert(AROUND(lex->flt, 123e10, 1));
-	assert(TK_F64 == Lex(lex));
-	assert(AROUND(lex->flt, 123e10, 1));
-	assert(TK_F64 == Lex(lex));
-	assert(AROUND(lex->flt, 123e-10, 1));
-	assert(TK_F64 == Lex(lex));
-	assert(AROUND(lex->flt, 123.456e10, 1));
-	assert(TK_I64 == Lex(lex));
-	assert(lex->integer == 1234);
-	assert(TK_I64 == Lex(lex));
-	assert(lex->integer == 12345);
-	assert(TK_I64 == Lex(lex));
-	assert(lex->integer == 123456);
-	assert(TK_I64 == Lex(lex));
-	assert(lex->integer == 123456);
-	assert(TK_I64 == Lex(lex));
-	assert(lex->integer == 1234567);
-	assert(TK_I64 == Lex(lex));
-	assert(lex->integer == 1234567);
-	assert(TK_I64 == Lex(lex));
-	assert(lex->integer == 1);
-	assert(TK_I64 == Lex(lex));
-	assert(lex->integer == 2);
-	assert(TK_I64 == Lex(lex));
-	assert(lex->integer == 3);
+  #include <assert.h>
+void LexTests() {
+  char tmpf[TMP_MAX];
+  tmpnam(tmpf);
+  CLexer *lex = LexerNew("None", "if poodle\n"
+                                 "0 123 0b11 0xfeF0\n"
+                                 "'abcd1234'\n"
+                                 "\"ab\\\"c\"\n"
+                                 "++\n"
+                                 "--\n"
+                                 "&&^^||\n"
+                                 "== !=\n"
+                                 "<= >= <>\n"
+                                 "<<\n"
+                                 ">>\n"
+                                 "+=\n"
+                                 "-=\n"
+                                 "*=\n"
+                                 "/=\n"
+                                 "<<=\n"
+                                 ">>=\n"
+                                 "&=\n"
+                                 "|=\n"
+                                 "^=\n"
+                                 "->\n"
+                                 "...\n"
+                                 "%=\n"
+                                 "#define onion o \n"
+                                 "onion\n"
+                                 "#ifdef onion\n"
+                                 "1\n"
+                                 "#endif\n"
+                                 "#ifndef onion\n"
+                                 "0\n"
+                                 "#endif\n"
+                                 "#ifdef onion2\n"
+                                 "0\n"
+                                 "#endif\n"
+                                 "#ifndef onion2\n"
+                                 "11\n"
+                                 "#endif\n"
+                                 "#ifdef onion\n"
+                                 "111\n"
+                                 "#else\n"
+                                 "0\n"
+                                 "#endif\n"
+                                 "#ifndef onion\n"
+                                 "0\n"
+                                 "#else\n"
+                                 "1111\n"
+                                 "#endif\n"
+                                 "#ifndef onion2\n"
+                                 "11111\n"
+                                 "#else\n"
+                                 "0\n"
+                                 "#endif\n"
+                                 // Nested #if test
+                                 "#ifdef onion\n"
+                                 "#ifdef onion2\n"
+                                 "#else\n"
+                                 "#ifdef onion2\n"
+                                 "#else\n"
+                                 "111111\n"
+                                 "#endif\n"
+                                 "#endif\n"
+                                 "#endif\n"
+                                 "123.\n"
+                                 "123.000456\n"
+                                 "123e10\n"
+                                 "123e+10\n"
+                                 "123e-10\n"
+                                 "123.456e+10\n"
+                                 "// 123 \n"
+                                 "1234\n"
+                                 "/*\n"
+                                 "1\n"
+                                 "2\n"
+                                 "*/\n"
+                                 "12345\n"
+                                 "#define onion 123456 //poop \n"
+                                 "onion onion\n"
+                                 "#define onion 1234567 /*poop */\n"
+                                 "onion onion\n"
+                                 "#define onion 1 \\ \n"
+                                 "2 \\ \n"
+                                 "3 \n"
+                                 "onion\n");
+  assert(TK_NAME == Lex(lex));
+  assert(HashFind("if", Fs->hash_table, HTT_KEYWORD, 1));
+  assert(TK_NAME == Lex(lex));
+  assert(!strcmp(lex->string, "poodle"));
+  assert(TK_I64 == Lex(lex));
+  assert(lex->integer == 0);
+  assert(TK_I64 == Lex(lex));
+  assert(lex->integer == 123);
+  assert(TK_I64 == Lex(lex));
+  assert(lex->integer == 0b11);
+  assert(TK_I64 == Lex(lex));
+  assert(lex->integer == 0xfef0);
+  assert(TK_CHR == Lex(lex));
+  assert(lex->integer == *(int64_t *)"abcd1234");
+  assert(TK_STR == Lex(lex));
+  assert(!strcmp(lex->string, "ab\"c"));
+  assert(TK_INC_INC == Lex(lex));
+  assert(TK_DEC_DEC == Lex(lex));
+  assert(TK_AND_AND == Lex(lex));
+  assert(TK_XOR_XOR == Lex(lex));
+  assert(TK_OR_OR == Lex(lex));
+  assert(TK_EQ_EQ == Lex(lex));
+  assert(TK_NE == Lex(lex));
+  assert(TK_LE == Lex(lex));
+  assert(TK_GE == Lex(lex));
+  assert('<' == Lex(lex));
+  assert('>' == Lex(lex));
+  assert(TK_LSH == Lex(lex));
+  assert(TK_RSH == Lex(lex));
+  assert(TK_ADD_EQ == Lex(lex));
+  assert(TK_SUB_EQ == Lex(lex));
+  assert(TK_MUL_EQ == Lex(lex));
+  assert(TK_DIV_EQ == Lex(lex));
+  assert(TK_LSH_EQ == Lex(lex));
+  assert(TK_RSH_EQ == Lex(lex));
+  assert(TK_AND_EQ == Lex(lex));
+  assert(TK_OR_EQ == Lex(lex));
+  assert(TK_XOR_EQ == Lex(lex));
+  assert(TK_ARROW == Lex(lex));
+  assert(TK_DOT_DOT_DOT == Lex(lex));
+  assert(TK_MOD_EQ == Lex(lex));
+  assert(TK_NAME == Lex(lex));
+  assert(!strcmp(lex->string, "o"));
+  assert(TK_I64 == Lex(lex));
+  assert(lex->integer == 1);
+  assert(TK_I64 == Lex(lex));
+  assert(lex->integer == 11);
+  assert(TK_I64 == Lex(lex));
+  assert(lex->integer == 111);
+  assert(TK_I64 == Lex(lex));
+  assert(lex->integer == 1111);
+  assert(TK_I64 == Lex(lex));
+  assert(lex->integer == 11111);
+  assert(TK_I64 == Lex(lex));
+  assert(lex->integer == 111111);
+  #define AROUND(v, n, off) (((v) >= (n) - (off)) && ((v) <= (n) + (off)))
+  assert(TK_F64 == Lex(lex));
+  assert(AROUND(lex->flt, 123., 0.1));
+  assert(TK_F64 == Lex(lex));
+  assert(AROUND(lex->flt, 123.000456, 0.0001));
+  assert(TK_F64 == Lex(lex));
+  assert(AROUND(lex->flt, 123e10, 1));
+  assert(TK_F64 == Lex(lex));
+  assert(AROUND(lex->flt, 123e10, 1));
+  assert(TK_F64 == Lex(lex));
+  assert(AROUND(lex->flt, 123e-10, 1));
+  assert(TK_F64 == Lex(lex));
+  assert(AROUND(lex->flt, 123.456e10, 1));
+  assert(TK_I64 == Lex(lex));
+  assert(lex->integer == 1234);
+  assert(TK_I64 == Lex(lex));
+  assert(lex->integer == 12345);
+  assert(TK_I64 == Lex(lex));
+  assert(lex->integer == 123456);
+  assert(TK_I64 == Lex(lex));
+  assert(lex->integer == 123456);
+  assert(TK_I64 == Lex(lex));
+  assert(lex->integer == 1234567);
+  assert(TK_I64 == Lex(lex));
+  assert(lex->integer == 1234567);
+  assert(TK_I64 == Lex(lex));
+  assert(lex->integer == 1);
+  assert(TK_I64 == Lex(lex));
+  assert(lex->integer == 2);
+  assert(TK_I64 == Lex(lex));
+  assert(lex->integer == 3);
 }
 #endif

--- a/main.c
+++ b/main.c
@@ -1,1636 +1,1414 @@
 #define AIWN_BOOTSTRAP
 #define AIWNIOS_TESTS
 #include "aiwn.h"
+#include "argtable3.h"
 #include <errno.h>
 #include <math.h>
 #include <stdio.h>
 #include <time.h>
 #include <unistd.h>
-#include "argtable3.h"
-struct arg_lit *arg_help,*arg_overwrite,*arg_new_boot_dir,*arg_asan_enable;
-struct arg_file *arg_t_dir,*arg_bootstrap_bin;
+struct arg_lit *arg_help, *arg_overwrite, *arg_new_boot_dir, *arg_asan_enable;
+struct arg_file *arg_t_dir, *arg_bootstrap_bin;
 static struct arg_end *_arg_end;
 #ifdef AIWNIOS_TESTS
 // Import PrintI first
-static void PrintI(char* str, int64_t i) { printf("%s:%ld\n", str, i); }
-static void PrintF(char* str, double f) { printf("%s:%lf\n", str, f); }
-static void PrintPtr(char* str, void* f) { printf("%s:%p\n", str, f); }
-static int64_t STK_PrintI(int64_t*);
-static int64_t STK_PrintF(double*);
-static int64_t STK_PrintPtr(int64_t* stk) { PrintPtr((char*)(stk[0]), (void*)stk[1]); }
+static void PrintI(char *str, int64_t i) {
+  printf("%s:%ld\n", str, i);
+}
+static void PrintF(char *str, double f) {
+  printf("%s:%lf\n", str, f);
+}
+static void PrintPtr(char *str, void *f) {
+  printf("%s:%p\n", str, f);
+}
+static int64_t STK_PrintI(int64_t *);
+static int64_t STK_PrintF(double *);
+static int64_t STK_PrintPtr(int64_t *stk) {
+  PrintPtr((char *)(stk[0]), (void *)stk[1]);
+}
 static void ExitAiwnios();
-static void PrsAddSymbol(char* name, void* ptr, int64_t arity)
-{
-	PrsBindCSymbol(name, ptr,arity);
+static void PrsAddSymbol(char *name, void *ptr, int64_t arity) {
+  PrsBindCSymbol(name, ptr, arity);
 }
-static void PrsAddSymbolNaked(char* name, void* ptr, int64_t arity)
-{
-	PrsBindCSymbolNaked(name, ptr,arity);
+static void PrsAddSymbolNaked(char *name, void *ptr, int64_t arity) {
+  PrsBindCSymbolNaked(name, ptr, arity);
 }
-static void FuzzTest1()
-{
-	int64_t i, i2, o;
-	char tf[TMP_MAX];
-	strcpy(tf, "FUZZ1.HC");
-	char buf[TMP_MAX + 64];
-	FILE* f = fopen(tf, "w");
-	fprintf(f, "extern U0 PrintI(U8i *,I64i);\n");
-	// Do complicated expr to dirty some temp registers
-	fprintf(f, "I64i Fa() {I64i a,b,c;a=50,b=2,c=1; return c+(10*b)+(a*(1+!!c))+b;}\n");
-	fprintf(f, "I64i Fb() {return Fa-123+6;}\n");
-	fprintf(f, "U0 Fuzz() {\n");
-	fprintf(f, "    I64i ra,rb,na,nb,*pna,*pnb;\n");
-	fprintf(f, "    pna=&na,pnb=&nb;\n");
-	fprintf(f, "    ra=na=123;\n");
-	fprintf(f, "    rb=nb=6;\n");
-	char* operandsA[] = {
-		"ra",
-		"na",
-		"*pna(I32i*)",
-		"Fa",
-		"123",
-	};
-	char* operandsB[] = {
-		"rb",
-		"nb",
-		"*pnb(I32i*)",
-		"Fb",
-		"6",
-	};
-	char* bopers[] = {
-		"+",
-		"-",
-		"*",
-		"%",
-		"/",
-		"==",
-		"!=",
-		">",
-		"<",
-		">=",
-		"<=",
-		"&",
-		"^",
-		"|",
-		"<<",
-		">>",
-	};
-	char* assignOps[] = {
-		"=", "+=", "-=", "*=", "%=", "/=", "<<=", ">>=", "&=", "|=", "^="
-	};
-	char* assignUOps[] = { "++", "--" };
-	for (o = 0; o != sizeof(bopers) / sizeof(char*); o++) {
-		for (i = 0; i != sizeof(operandsA) / sizeof(char*); i++)
-			for (i2 = 0; i2 != sizeof(operandsB) / sizeof(char*); i2++) {
-				fprintf(f, "PrintI(\"%s(123) %s %s(6) ==\", %s %s %s);\n", operandsA[i],
-					bopers[o], operandsB[i2], operandsA[i], bopers[o],
-					operandsB[i2]);
-			}
-	}
-	for (o = 0; o != sizeof(assignOps) / sizeof(char*); o++) {
-		// Last 2 of operandsA/B are immuatable,so dont change them
-		for (i = 0; i != sizeof(operandsA) / sizeof(char*) - 2; i++)
-			for (i2 = 0; i2 != sizeof(operandsB) / sizeof(char*); i2++) {
-				fprintf(f, "%s = 123;\n", operandsA[i]);
-				fprintf(f, "%s %s %s;\nPrintI(\"%s(123) %s %s(6) ==\", %s);\n", operandsA[i],
-					assignOps[o], operandsB[i2], operandsA[i], assignOps[o],
-					operandsB[i2], operandsA[i]);
-			}
-	}
-	for (o = 0; o != sizeof(assignUOps) / sizeof(char*); o++) {
-		// Last 2 of operandsA/B are immuatable,so dont change them
-		for (i = 0; i != sizeof(operandsA) / sizeof(char*) - 2; i++) {
-			fprintf(f, "%s = 123;\n", operandsA[i]);
-			fprintf(f, "PrintI(\"(%s) %s\",(%s) %s);", operandsA[i], assignUOps[o],
-				operandsA[i], assignUOps[o]);
-			fprintf(f, "PrintI(\"%s\",%s);\n", operandsA[i], operandsA[i]);
-			fprintf(f, "%s = 123;\n", operandsA[i]);
-			fprintf(f, "PrintI(\"%s (%s)\",%s (%s));\n", assignUOps[o], operandsA[i],
-				assignUOps[o], operandsA[i]);
-			fprintf(f, "PrintI(\"%s\",%s);\n", operandsA[i], operandsA[i]);
-		}
-	}
-	fprintf(f, "}\n");
-	fclose(f);
-	sprintf(buf, "#include \"%s\";\n", tf);
-	CLexer* lex = LexerNew("None", buf);
-	CCmpCtrl* ccmp = CmpCtrlNew(lex);
-	CodeCtrlPush(ccmp);
-	Lex(lex);
-	PrsStmt(ccmp);
-	PrsStmt(ccmp);
-	PrsStmt(ccmp);
-	PrsStmt(ccmp);
-	PrsStmt(ccmp);
-	PrsAddSymbol("PrintI", &STK_PrintI, 2);
-	ccmp->cur_fun = HashFind("Fuzz", Fs->hash_table, HTT_FUN, 1);
-	int64_t (*poop5)() = ccmp->cur_fun->fun_ptr;
-	FFI_CALL_TOS_0(poop5);
+static void FuzzTest1() {
+  int64_t i, i2, o;
+  char tf[TMP_MAX];
+  strcpy(tf, "FUZZ1.HC");
+  char buf[TMP_MAX + 64];
+  FILE *f = fopen(tf, "w");
+  fprintf(f, "extern U0 PrintI(U8i *,I64i);\n");
+  // Do complicated expr to dirty some temp registers
+  fprintf(
+      f,
+      "I64i Fa() {I64i a,b,c;a=50,b=2,c=1; return c+(10*b)+(a*(1+!!c))+b;}\n");
+  fprintf(f, "I64i Fb() {return Fa-123+6;}\n");
+  fprintf(f, "U0 Fuzz() {\n");
+  fprintf(f, "    I64i ra,rb,na,nb,*pna,*pnb;\n");
+  fprintf(f, "    pna=&na,pnb=&nb;\n");
+  fprintf(f, "    ra=na=123;\n");
+  fprintf(f, "    rb=nb=6;\n");
+  char *operandsA[] = {
+      "ra", "na", "*pna(I32i*)", "Fa", "123",
+  };
+  char *operandsB[] = {
+      "rb", "nb", "*pnb(I32i*)", "Fb", "6",
+  };
+  char *bopers[] = {
+      "+", "-",  "*",  "%", "/", "==", "!=", ">",
+      "<", ">=", "<=", "&", "^", "|",  "<<", ">>",
+  };
+  char *assignOps[] = {
+      "=", "+=", "-=", "*=", "%=", "/=", "<<=", ">>=", "&=", "|=", "^="};
+  char *assignUOps[] = {"++", "--"};
+  for (o = 0; o != sizeof(bopers) / sizeof(char *); o++) {
+    for (i = 0; i != sizeof(operandsA) / sizeof(char *); i++)
+      for (i2 = 0; i2 != sizeof(operandsB) / sizeof(char *); i2++) {
+        fprintf(f, "PrintI(\"%s(123) %s %s(6) ==\", %s %s %s);\n", operandsA[i],
+                bopers[o], operandsB[i2], operandsA[i], bopers[o],
+                operandsB[i2]);
+      }
+  }
+  for (o = 0; o != sizeof(assignOps) / sizeof(char *); o++) {
+    // Last 2 of operandsA/B are immuatable,so dont change them
+    for (i = 0; i != sizeof(operandsA) / sizeof(char *) - 2; i++)
+      for (i2 = 0; i2 != sizeof(operandsB) / sizeof(char *); i2++) {
+        fprintf(f, "%s = 123;\n", operandsA[i]);
+        fprintf(f, "%s %s %s;\nPrintI(\"%s(123) %s %s(6) ==\", %s);\n",
+                operandsA[i], assignOps[o], operandsB[i2], operandsA[i],
+                assignOps[o], operandsB[i2], operandsA[i]);
+      }
+  }
+  for (o = 0; o != sizeof(assignUOps) / sizeof(char *); o++) {
+    // Last 2 of operandsA/B are immuatable,so dont change them
+    for (i = 0; i != sizeof(operandsA) / sizeof(char *) - 2; i++) {
+      fprintf(f, "%s = 123;\n", operandsA[i]);
+      fprintf(f, "PrintI(\"(%s) %s\",(%s) %s);", operandsA[i], assignUOps[o],
+              operandsA[i], assignUOps[o]);
+      fprintf(f, "PrintI(\"%s\",%s);\n", operandsA[i], operandsA[i]);
+      fprintf(f, "%s = 123;\n", operandsA[i]);
+      fprintf(f, "PrintI(\"%s (%s)\",%s (%s));\n", assignUOps[o], operandsA[i],
+              assignUOps[o], operandsA[i]);
+      fprintf(f, "PrintI(\"%s\",%s);\n", operandsA[i], operandsA[i]);
+    }
+  }
+  fprintf(f, "}\n");
+  fclose(f);
+  sprintf(buf, "#include \"%s\";\n", tf);
+  CLexer *lex = LexerNew("None", buf);
+  CCmpCtrl *ccmp = CmpCtrlNew(lex);
+  CodeCtrlPush(ccmp);
+  Lex(lex);
+  PrsStmt(ccmp);
+  PrsStmt(ccmp);
+  PrsStmt(ccmp);
+  PrsStmt(ccmp);
+  PrsStmt(ccmp);
+  PrsAddSymbol("PrintI", &STK_PrintI, 2);
+  ccmp->cur_fun = HashFind("Fuzz", Fs->hash_table, HTT_FUN, 1);
+  int64_t (*poop5)() = ccmp->cur_fun->fun_ptr;
+  FFI_CALL_TOS_0(poop5);
 }
-static void FuzzTest2()
-{
-	int64_t i, i2, o;
-	char tf[TMP_MAX];
-	strcpy(tf, "FUZZ2.HC");
-	char buf[TMP_MAX + 64];
-	FILE* f = fopen(tf, "w");
-	fprintf(f, "extern U0 PrintF(U8i *,F64);\n");
-	// Do complicated expr to dirty some temp registers
-	fprintf(f, "F64 Fa() {F64 a=50,b=2,c=1; return c+(10*b)+(a*(1+!!c))+b;}\n");
-	fprintf(f, "F64 Fb() {return Fa-123. +6.;}\n");
-	char* operandsA[] = {
-		"ra",
-		"na",
-		"*pna",
-		"Fa",
-		"123.",
-	};
-	char* operandsB[] = {
-		"rb",
-		"nb",
-		"*pnb",
-		"Fb",
-		"6.",
-	};
-	char* bopers[] = { "+", "-", "*", "%", "/", "==", "!=", ">", "<", ">=", "<=" };
-	char* assignOps[] = { "=", "+=", "-=", "*=", "%=", "/=" };
-	char* assignUOps[] = { "++", "--" };
-	fprintf(f, "U0 Fuzz() {\n");
-	fprintf(f, "    F64 ra,rb,na,nb,*pna,*pnb;\n");
-	fprintf(f, "    pna=&na,pnb=&nb;\n");
-	fprintf(f, "    ra=na=123.;\n");
-	fprintf(f, "    rb=nb=6.;\n");
-	for (o = 0; o != sizeof(bopers) / sizeof(*bopers); o++)
-		for (i = 0; i != sizeof(operandsA) / sizeof(*operandsA); i++)
-			for (i2 = 0; i2 != sizeof(operandsA) / sizeof(*operandsA); i2++) {
-				fprintf(f, "PrintF(\"%s %s %s ==\", %s %s %s);\n", operandsA[i],
-					bopers[o], operandsB[i2], operandsA[i], bopers[o],
-					operandsB[i2]);
-			}
-	for (o = 0; o != sizeof(assignOps) / sizeof(*assignOps); o++)
-		for (i = 0; i != sizeof(operandsA) / sizeof(*operandsA) - 2; i++)
-			for (i2 = 0; i2 != sizeof(operandsB) / sizeof(*operandsB); i2++) {
-				fprintf(f, "%s=123.;\n", operandsA[i]);
-				fprintf(f, "PrintF(\"%s %s %s ==\", %s %s %s);\n", operandsA[i],
-					assignOps[o], operandsB[i2], operandsA[i], assignOps[o],
-					operandsB[i2]);
-			}
-	for (o = 0; o != sizeof(assignUOps) / sizeof(char*); o++) {
-		// Last 2 of operandsA/B are immuatable,so dont change them
-		for (i = 0; i != sizeof(operandsA) / sizeof(char*) - 2; i++) {
-			fprintf(f, "%s=123;\n", operandsA[i]);
-			fprintf(f, "PrintF(\"(%s)%s\",(%s)%s);", operandsA[i], assignUOps[o],
-				operandsA[i], assignUOps[o]);
-			fprintf(f, "PrintF(\"%s\",%s);\n", operandsA[i], operandsA[i]);
-			fprintf(f, "%s=123;\n", operandsA[i]);
-			fprintf(f, "PrintF(\"%s(%s)\",%s(%s));\n", assignUOps[o], operandsA[i],
-				assignUOps[o], operandsA[i]);
-			fprintf(f, "PrintF(\"%s\",%s);\n", operandsA[i], operandsA[i]);
-		}
-	}
-	fprintf(f, "}\n");
-	fclose(f);
-	sprintf(buf, "#include \"%s\";\n", tf);
-	CLexer* lex = LexerNew("None", buf);
-	CCmpCtrl* ccmp = CmpCtrlNew(lex);
-	CodeCtrlPush(ccmp);
-	Lex(lex);
-	PrsStmt(ccmp);
-	PrsStmt(ccmp);
-	PrsStmt(ccmp);
-	PrsStmt(ccmp);
-	PrsStmt(ccmp);
-	PrsAddSymbol("PrintF", &STK_PrintF, 2);
-	ccmp->cur_fun = HashFind("Fuzz", Fs->hash_table, HTT_FUN, 1);
-	int64_t (*poopf)() = ccmp->cur_fun->fun_ptr;
-	FFI_CALL_TOS_0(poopf);
+static void FuzzTest2() {
+  int64_t i, i2, o;
+  char tf[TMP_MAX];
+  strcpy(tf, "FUZZ2.HC");
+  char buf[TMP_MAX + 64];
+  FILE *f = fopen(tf, "w");
+  fprintf(f, "extern U0 PrintF(U8i *,F64);\n");
+  // Do complicated expr to dirty some temp registers
+  fprintf(f, "F64 Fa() {F64 a=50,b=2,c=1; return c+(10*b)+(a*(1+!!c))+b;}\n");
+  fprintf(f, "F64 Fb() {return Fa-123. +6.;}\n");
+  char *operandsA[] = {
+      "ra", "na", "*pna", "Fa", "123.",
+  };
+  char *operandsB[] = {
+      "rb", "nb", "*pnb", "Fb", "6.",
+  };
+  char *bopers[] = {"+", "-", "*", "%", "/", "==", "!=", ">", "<", ">=", "<="};
+  char *assignOps[] = {"=", "+=", "-=", "*=", "%=", "/="};
+  char *assignUOps[] = {"++", "--"};
+  fprintf(f, "U0 Fuzz() {\n");
+  fprintf(f, "    F64 ra,rb,na,nb,*pna,*pnb;\n");
+  fprintf(f, "    pna=&na,pnb=&nb;\n");
+  fprintf(f, "    ra=na=123.;\n");
+  fprintf(f, "    rb=nb=6.;\n");
+  for (o = 0; o != sizeof(bopers) / sizeof(*bopers); o++)
+    for (i = 0; i != sizeof(operandsA) / sizeof(*operandsA); i++)
+      for (i2 = 0; i2 != sizeof(operandsA) / sizeof(*operandsA); i2++) {
+        fprintf(f, "PrintF(\"%s %s %s ==\", %s %s %s);\n", operandsA[i],
+                bopers[o], operandsB[i2], operandsA[i], bopers[o],
+                operandsB[i2]);
+      }
+  for (o = 0; o != sizeof(assignOps) / sizeof(*assignOps); o++)
+    for (i = 0; i != sizeof(operandsA) / sizeof(*operandsA) - 2; i++)
+      for (i2 = 0; i2 != sizeof(operandsB) / sizeof(*operandsB); i2++) {
+        fprintf(f, "%s=123.;\n", operandsA[i]);
+        fprintf(f, "PrintF(\"%s %s %s ==\", %s %s %s);\n", operandsA[i],
+                assignOps[o], operandsB[i2], operandsA[i], assignOps[o],
+                operandsB[i2]);
+      }
+  for (o = 0; o != sizeof(assignUOps) / sizeof(char *); o++) {
+    // Last 2 of operandsA/B are immuatable,so dont change them
+    for (i = 0; i != sizeof(operandsA) / sizeof(char *) - 2; i++) {
+      fprintf(f, "%s=123;\n", operandsA[i]);
+      fprintf(f, "PrintF(\"(%s)%s\",(%s)%s);", operandsA[i], assignUOps[o],
+              operandsA[i], assignUOps[o]);
+      fprintf(f, "PrintF(\"%s\",%s);\n", operandsA[i], operandsA[i]);
+      fprintf(f, "%s=123;\n", operandsA[i]);
+      fprintf(f, "PrintF(\"%s(%s)\",%s(%s));\n", assignUOps[o], operandsA[i],
+              assignUOps[o], operandsA[i]);
+      fprintf(f, "PrintF(\"%s\",%s);\n", operandsA[i], operandsA[i]);
+    }
+  }
+  fprintf(f, "}\n");
+  fclose(f);
+  sprintf(buf, "#include \"%s\";\n", tf);
+  CLexer *lex = LexerNew("None", buf);
+  CCmpCtrl *ccmp = CmpCtrlNew(lex);
+  CodeCtrlPush(ccmp);
+  Lex(lex);
+  PrsStmt(ccmp);
+  PrsStmt(ccmp);
+  PrsStmt(ccmp);
+  PrsStmt(ccmp);
+  PrsStmt(ccmp);
+  PrsAddSymbol("PrintF", &STK_PrintF, 2);
+  ccmp->cur_fun = HashFind("Fuzz", Fs->hash_table, HTT_FUN, 1);
+  int64_t (*poopf)() = ccmp->cur_fun->fun_ptr;
+  FFI_CALL_TOS_0(poopf);
 }
-static void FuzzTest3()
-{
-	int64_t i, i2, o;
-	char tf[TMP_MAX];
-	strcpy(tf, "FUZZ3.HC");
-	char buf[TMP_MAX + 64];
-	FILE* f = fopen(tf, "w");
-	fprintf(f, "extern U0 PrintPtr(U8i *,I64i);\n");
-	// Do complicated expr to dirty some temp registers
-	fprintf(f, "I64i Fa() {I64i a=50,b=2,c=1; return (c+(10*b)+(a*(1+!!c))+b-23)/100*0x100;}\n");
-	fprintf(f, "I64i Fb() {return Fa-0x100 +2;}\n");
-	char* operandsA[] = {
-		"ra",
-		"na",
-		"*pna",
-		"Fa(I32i*)",
-		"0x100(I32i*)",
-	};
-	char* operandsB[] = {
-		"rb",
-		"nb",
-		"*pnb",
-		"Fb",
-		"2",
-	};
-	char* bopers[] = { "+", "-" };
-	char* assignOps[] = { "=", "+=", "-=" };
-	char* assignUOps[] = { "++", "--" };
-	fprintf(f, "U0 Fuzz() {\n");
-	fprintf(f, "    I32i *ra,*na,**pna;\n");
-	fprintf(f, "    I64i rb,nb,*pnb;\n");
-	fprintf(f, "    pna=&na,pnb=&nb;\n");
-	fprintf(f, "    ra=na=0x100;\n");
-	fprintf(f, "    rb=nb=2;\n");
-	for (o = 0; o != sizeof(bopers) / sizeof(*bopers); o++)
-		for (i = 0; i != sizeof(operandsA) / sizeof(*operandsA); i++)
-			for (i2 = 0; i2 != sizeof(operandsA) / sizeof(*operandsA); i2++) {
-				fprintf(f, "PrintPtr(\"%s %s %s ==\", %s %s %s);\n", operandsA[i],
-					bopers[o], operandsB[i2], operandsA[i], bopers[o],
-					operandsB[i2]);
-			}
+static void FuzzTest3() {
+  int64_t i, i2, o;
+  char tf[TMP_MAX];
+  strcpy(tf, "FUZZ3.HC");
+  char buf[TMP_MAX + 64];
+  FILE *f = fopen(tf, "w");
+  fprintf(f, "extern U0 PrintPtr(U8i *,I64i);\n");
+  // Do complicated expr to dirty some temp registers
+  fprintf(f, "I64i Fa() {I64i a=50,b=2,c=1; return "
+             "(c+(10*b)+(a*(1+!!c))+b-23)/100*0x100;}\n");
+  fprintf(f, "I64i Fb() {return Fa-0x100 +2;}\n");
+  char *operandsA[] = {
+      "ra", "na", "*pna", "Fa(I32i*)", "0x100(I32i*)",
+  };
+  char *operandsB[] = {
+      "rb", "nb", "*pnb", "Fb", "2",
+  };
+  char *bopers[] = {"+", "-"};
+  char *assignOps[] = {"=", "+=", "-="};
+  char *assignUOps[] = {"++", "--"};
+  fprintf(f, "U0 Fuzz() {\n");
+  fprintf(f, "    I32i *ra,*na,**pna;\n");
+  fprintf(f, "    I64i rb,nb,*pnb;\n");
+  fprintf(f, "    pna=&na,pnb=&nb;\n");
+  fprintf(f, "    ra=na=0x100;\n");
+  fprintf(f, "    rb=nb=2;\n");
+  for (o = 0; o != sizeof(bopers) / sizeof(*bopers); o++)
+    for (i = 0; i != sizeof(operandsA) / sizeof(*operandsA); i++)
+      for (i2 = 0; i2 != sizeof(operandsA) / sizeof(*operandsA); i2++) {
+        fprintf(f, "PrintPtr(\"%s %s %s ==\", %s %s %s);\n", operandsA[i],
+                bopers[o], operandsB[i2], operandsA[i], bopers[o],
+                operandsB[i2]);
+      }
 
-	// Test subtraction between ptr and ptr
-	for (i = 0; i != sizeof(operandsA) / sizeof(char*) - 2; i++) {
-		fprintf(f, "PrintPtr(\"%s-0x10(I32i*)\",%s-0x10(I32i*));\n",
-			operandsA[i],
-			operandsA[i]);
-	}
-	for (o = 0; o != sizeof(assignOps) / sizeof(*assignOps); o++)
-		for (i = 0; i != sizeof(operandsA) / sizeof(*operandsA) - 2; i++)
-			for (i2 = 0; i2 != sizeof(operandsB) / sizeof(*operandsB); i2++) {
-				fprintf(f, "%s=0x100;\n", operandsA[i]);
-				fprintf(f, "PrintPtr(\"%s %s %s ==\", %s %s %s);\n", operandsA[i],
-					assignOps[o], operandsB[i2], operandsA[i], assignOps[o],
-					operandsB[i2]);
-			}
-	for (o = 0; o != sizeof(assignUOps) / sizeof(char*); o++) {
-		// Last 2 of operandsA/B are immuatable,so dont change them
-		for (i = 0; i != sizeof(operandsA) / sizeof(char*) - 2; i++) {
-			fprintf(f, "%s=0x100;\n", operandsA[i]);
-			fprintf(f, "PrintPtr(\"(%s)%s\",(%s)%s);", operandsA[i], assignUOps[o],
-				operandsA[i], assignUOps[o]);
-			fprintf(f, "PrintPtr(\"%s\",%s);\n", operandsA[i], operandsA[i]);
-			fprintf(f, "%s=0x100;\n", operandsA[i]);
-			fprintf(f, "PrintPtr(\"%s(%s)\",%s(%s));\n", assignUOps[o], operandsA[i],
-				assignUOps[o], operandsA[i]);
-			fprintf(f, "PrintPtr(\"%s\",%s);\n", operandsA[i], operandsA[i]);
-		}
-	}
-	fprintf(f, "}\n");
-	fclose(f);
-	sprintf(buf, "#include \"%s\";\n", tf);
-	CLexer* lex = LexerNew("None", buf);
-	CCmpCtrl* ccmp = CmpCtrlNew(lex);
-	CodeCtrlPush(ccmp);
-	Lex(lex);
-	PrsStmt(ccmp);
-	PrsStmt(ccmp);
-	PrsStmt(ccmp);
-	PrsStmt(ccmp);
-	PrsStmt(ccmp);
-	PrsAddSymbol("PrintPtr", &STK_PrintPtr, 2);
-	ccmp->cur_fun = HashFind("Fuzz", Fs->hash_table, HTT_FUN, 1);
-	int64_t (*poop_ptr)() = ccmp->cur_fun->fun_ptr;
-	FFI_CALL_TOS_0(poop_ptr);
+  // Test subtraction between ptr and ptr
+  for (i = 0; i != sizeof(operandsA) / sizeof(char *) - 2; i++) {
+    fprintf(f, "PrintPtr(\"%s-0x10(I32i*)\",%s-0x10(I32i*));\n", operandsA[i],
+            operandsA[i]);
+  }
+  for (o = 0; o != sizeof(assignOps) / sizeof(*assignOps); o++)
+    for (i = 0; i != sizeof(operandsA) / sizeof(*operandsA) - 2; i++)
+      for (i2 = 0; i2 != sizeof(operandsB) / sizeof(*operandsB); i2++) {
+        fprintf(f, "%s=0x100;\n", operandsA[i]);
+        fprintf(f, "PrintPtr(\"%s %s %s ==\", %s %s %s);\n", operandsA[i],
+                assignOps[o], operandsB[i2], operandsA[i], assignOps[o],
+                operandsB[i2]);
+      }
+  for (o = 0; o != sizeof(assignUOps) / sizeof(char *); o++) {
+    // Last 2 of operandsA/B are immuatable,so dont change them
+    for (i = 0; i != sizeof(operandsA) / sizeof(char *) - 2; i++) {
+      fprintf(f, "%s=0x100;\n", operandsA[i]);
+      fprintf(f, "PrintPtr(\"(%s)%s\",(%s)%s);", operandsA[i], assignUOps[o],
+              operandsA[i], assignUOps[o]);
+      fprintf(f, "PrintPtr(\"%s\",%s);\n", operandsA[i], operandsA[i]);
+      fprintf(f, "%s=0x100;\n", operandsA[i]);
+      fprintf(f, "PrintPtr(\"%s(%s)\",%s(%s));\n", assignUOps[o], operandsA[i],
+              assignUOps[o], operandsA[i]);
+      fprintf(f, "PrintPtr(\"%s\",%s);\n", operandsA[i], operandsA[i]);
+    }
+  }
+  fprintf(f, "}\n");
+  fclose(f);
+  sprintf(buf, "#include \"%s\";\n", tf);
+  CLexer *lex = LexerNew("None", buf);
+  CCmpCtrl *ccmp = CmpCtrlNew(lex);
+  CodeCtrlPush(ccmp);
+  Lex(lex);
+  PrsStmt(ccmp);
+  PrsStmt(ccmp);
+  PrsStmt(ccmp);
+  PrsStmt(ccmp);
+  PrsStmt(ccmp);
+  PrsAddSymbol("PrintPtr", &STK_PrintPtr, 2);
+  ccmp->cur_fun = HashFind("Fuzz", Fs->hash_table, HTT_FUN, 1);
+  int64_t (*poop_ptr)() = ccmp->cur_fun->fun_ptr;
+  FFI_CALL_TOS_0(poop_ptr);
 }
 #endif
-static double Pow10(double d)
-{
-	return pow(10, d);
+static double Pow10(double d) {
+  return pow(10, d);
 }
-static void* MemSetU16(int16_t* dst, int16_t with, int64_t cnt)
-{
-	while (--cnt >= 0) {
-		dst[cnt] = with;
-	}
-	return dst;
+static void *MemSetU16(int16_t *dst, int16_t with, int64_t cnt) {
+  while (--cnt >= 0) {
+    dst[cnt] = with;
+  }
+  return dst;
 }
-static void* MemSetU32(int32_t* dst, int32_t with, int64_t cnt)
-{
-	while (--cnt >= 0) {
-		dst[cnt] = with;
-	}
-	return dst;
+static void *MemSetU32(int32_t *dst, int32_t with, int64_t cnt) {
+  while (--cnt >= 0) {
+    dst[cnt] = with;
+  }
+  return dst;
 }
-static void* MemSetU64(int64_t* dst, int64_t with, int64_t cnt)
-{
-	while (--cnt >= 0) {
-		dst[cnt] = with;
-	}
-	return dst;
+static void *MemSetU64(int64_t *dst, int64_t with, int64_t cnt) {
+  while (--cnt >= 0) {
+    dst[cnt] = with;
+  }
+  return dst;
 }
-static void PutS(char* s)
-{
-	printf("%s", s);
+static void PutS(char *s) {
+  printf("%s", s);
 }
 
 // This a "symbolic" Fs only used from the HolyC part
-static void SetHolyFs(void* fs)
-{
-	HolyFs = fs;
+static void SetHolyFs(void *fs) {
+  HolyFs = fs;
 }
 extern int64_t GetTicksHP();
-static int64_t __GetTicksHP()
-{
-#if defined (_WIN32) || defined (WIN32)
-	return GetTicksHP(); //From multic.c
+static int64_t __GetTicksHP() {
+#if defined(_WIN32) || defined(WIN32)
+  return GetTicksHP(); // From multic.c
 #else
-	struct timespec ts;
-	static int64_t initial = 0;
-	int64_t theTick = 0U;
-	if (!initial) {
-		clock_gettime(CLOCK_REALTIME, &ts);
-		theTick = ts.tv_nsec / 1000;
-		theTick += ts.tv_sec * 1000000U;
-		initial = theTick;
-		return 0;
-	}
-	clock_gettime(CLOCK_REALTIME, &ts);
-	theTick = ts.tv_nsec / 1000;
-	theTick += ts.tv_sec * 1000000U;
-	return theTick - initial;
+  struct timespec ts;
+  static int64_t initial = 0;
+  int64_t theTick = 0U;
+  if (!initial) {
+    clock_gettime(CLOCK_REALTIME, &ts);
+    theTick = ts.tv_nsec / 1000;
+    theTick += ts.tv_sec * 1000000U;
+    initial = theTick;
+    return 0;
+  }
+  clock_gettime(CLOCK_REALTIME, &ts);
+  theTick = ts.tv_nsec / 1000;
+  theTick += ts.tv_sec * 1000000U;
+  return theTick - initial;
 #endif
 }
-static int64_t __GetTicks()
-{
-	return __GetTicksHP() / 1000;
+static int64_t __GetTicks() {
+  return __GetTicksHP() / 1000;
 }
-static void __SleepHP(int64_t us)
-{
-	usleep(us);
+static void __SleepHP(int64_t us) {
+  usleep(us);
 }
-void* GetHolyFs()
-{
-	return HolyFs;
+void *GetHolyFs() {
+  return HolyFs;
 }
-static __thread void* HolyGs;
-void* GetHolyGs()
-{
-	return HolyGs;
+static __thread void *HolyGs;
+void *GetHolyGs() {
+  return HolyGs;
 }
-void SetHolyGs(void* ptr)
-{
-	HolyGs = ptr;
+void SetHolyGs(void *ptr) {
+  HolyGs = ptr;
 }
-static int64_t MemCmp(char* a, char* b, int64_t s)
-{
-	return memcmp(a, b, s);
+static int64_t MemCmp(char *a, char *b, int64_t s) {
+  return memcmp(a, b, s);
 }
-int64_t UnixNow()
-{
-	return (int64_t)time(NULL);
+int64_t UnixNow() {
+  return (int64_t)time(NULL);
 }
-static double Arg(double x, double y)
-{
-	return atan2(y, x);
+static double Arg(double x, double y) {
+  return atan2(y, x);
 }
-static void __Sleep(int64_t ms)
-{
-	SDL_Delay(ms);
+static void __Sleep(int64_t ms) {
+  SDL_Delay(ms);
 }
-static char* AiwniosGetClipboard()
-{
-	char *has, *ret;
-	if (!SDL_HasClipboardText())
-		return A_STRDUP("", NULL);
-	has = SDL_GetClipboardText();
-	ret = A_STRDUP(has, NULL);
-	SDL_free(has);
-	return ret;
+static char *AiwniosGetClipboard() {
+  char *has, *ret;
+  if (!SDL_HasClipboardText())
+    return A_STRDUP("", NULL);
+  has = SDL_GetClipboardText();
+  ret = A_STRDUP(has, NULL);
+  SDL_free(has);
+  return ret;
 }
-static void AiwniosSetClipboard(char* c)
-{
-	if (c)
-		SDL_SetClipboardText(c);
+static void AiwniosSetClipboard(char *c) {
+  if (c)
+    SDL_SetClipboardText(c);
 }
 
-static void TaskContextSetRIP(int64_t* ctx, void* p)
-{
-	ctx[0] = (int64_t)p;
+static void TaskContextSetRIP(int64_t *ctx, void *p) {
+  ctx[0] = (int64_t)p;
 }
 
-static STK_TaskContextSetRIP(int64_t* stk)
-{
-	TaskContextSetRIP((int64_t*)(stk[0]), (void*)stk[1]);
+static STK_TaskContextSetRIP(int64_t *stk) {
+  TaskContextSetRIP((int64_t *)(stk[0]), (void *)stk[1]);
 }
 
 // strcmp returns int(32 bit on some platforms)
-static int64_t StrCmp(char* a, char* b)
-{
-	return strcmp(a, b);
+static int64_t StrCmp(char *a, char *b) {
+  return strcmp(a, b);
 }
 
-static int64_t STK_GenerateFFIForFun(void** stk)
-{
-	TaskContextSetRIP(stk[0], (void*)stk[1]);
+static int64_t STK_GenerateFFIForFun(void **stk) {
+  TaskContextSetRIP(stk[0], (void *)stk[1]);
 }
 
-static int64_t STK_AIWNIOS_makecontext(void** stk)
-{
-	return AIWNIOS_makecontext(stk[0], stk[1], stk[2]);
+static int64_t STK_AIWNIOS_makecontext(void **stk) {
+  return AIWNIOS_makecontext(stk[0], stk[1], stk[2]);
 }
 
-static int64_t STK___HC_SetAOTRelocBeforeRIP(void** stk)
-{
-	__HC_SetAOTRelocBeforeRIP(stk[0], (int64_t)stk[1]);
+static int64_t STK___HC_SetAOTRelocBeforeRIP(void **stk) {
+  __HC_SetAOTRelocBeforeRIP(stk[0], (int64_t)stk[1]);
 }
 
-static int64_t STK___HC_CodeMiscIsUsed(void** stk)
-{
-	__HC_CodeMiscIsUsed((CCodeMisc*)stk[0]);
+static int64_t STK___HC_CodeMiscIsUsed(void **stk) {
+  __HC_CodeMiscIsUsed((CCodeMisc *)stk[0]);
 }
 
-static int64_t STK_AiwniosSetClipboard(void** stk)
-{
-	AiwniosSetClipboard((char*)stk[0]);
+static int64_t STK_AiwniosSetClipboard(void **stk) {
+  AiwniosSetClipboard((char *)stk[0]);
 }
 
-static int64_t STK_AiwniosGetClipboard(void** stk)
-{
-	return (int64_t)AiwniosGetClipboard();
+static int64_t STK_AiwniosGetClipboard(void **stk) {
+  return (int64_t)AiwniosGetClipboard();
 }
 
-static int64_t STK_CmpCtrlDel(void** stk)
-{
-	CmpCtrlDel((CCmpCtrl*)stk[0]);
+static int64_t STK_CmpCtrlDel(void **stk) {
+  CmpCtrlDel((CCmpCtrl *)stk[0]);
 }
 
-static int64_t STK_cos(double* stk)
-{
-	double r = cos(stk[0]);
-	return *(int64_t*)&r;
+static int64_t STK_cos(double *stk) {
+  double r = cos(stk[0]);
+  return *(int64_t *)&r;
 }
 
-static int64_t STK_sin(double* stk)
-{
-	double r = sin(stk[0]);
-	return *(int64_t*)&r;
+static int64_t STK_sin(double *stk) {
+  double r = sin(stk[0]);
+  return *(int64_t *)&r;
 }
 
-static int64_t STK_tan(double* stk)
-{
-	double r = tan(stk[0]);
-	return *(int64_t*)&r;
+static int64_t STK_tan(double *stk) {
+  double r = tan(stk[0]);
+  return *(int64_t *)&r;
 }
 
-static int64_t STK_Arg(double* stk)
-{
-	double r = Arg(stk[0], stk[1]);
-	return *(int64_t*)&r;
+static int64_t STK_Arg(double *stk) {
+  double r = Arg(stk[0], stk[1]);
+  return *(int64_t *)&r;
 }
 
-static int64_t STK_acos(double* stk)
-{
-	double r = acos(stk[0]);
-	return *(int64_t*)&r;
+static int64_t STK_acos(double *stk) {
+  double r = acos(stk[0]);
+  return *(int64_t *)&r;
 }
 
-static int64_t STK_asin(double* stk)
-{
-	double r = asin(stk[0]);
-	return *(int64_t*)&r;
+static int64_t STK_asin(double *stk) {
+  double r = asin(stk[0]);
+  return *(int64_t *)&r;
 }
 
-static int64_t STK_atan(double* stk)
-{
-	double r = atan(stk[0]);
-	return *(int64_t*)&r;
+static int64_t STK_atan(double *stk) {
+  double r = atan(stk[0]);
+  return *(int64_t *)&r;
 }
 
-static int64_t STK_Misc_Btc(int64_t* stk)
-{
-	return Misc_Btc((void*)stk[0], stk[1]);
+static int64_t STK_Misc_Btc(int64_t *stk) {
+  return Misc_Btc((void *)stk[0], stk[1]);
 }
 
-static int64_t STK_Misc_Btr(int64_t* stk)
-{
-	return Misc_Btr((void*)stk[0], stk[1]);
+static int64_t STK_Misc_Btr(int64_t *stk) {
+  return Misc_Btr((void *)stk[0], stk[1]);
 }
-static int64_t STK_Misc_LBtr(int64_t* stk)
-{
-	return Misc_LBtr((void*)stk[0], stk[1]);
+static int64_t STK_Misc_LBtr(int64_t *stk) {
+  return Misc_LBtr((void *)stk[0], stk[1]);
 }
-static int64_t STK_Misc_LBts(int64_t* stk)
-{
-	return Misc_LBts((void*)stk[0], stk[1]);
+static int64_t STK_Misc_LBts(int64_t *stk) {
+  return Misc_LBts((void *)stk[0], stk[1]);
 }
-static int64_t STK_Misc_Bt(int64_t* stk)
-{
-	return Misc_Bt((void*)stk[0], stk[1]);
+static int64_t STK_Misc_Bt(int64_t *stk) {
+  return Misc_Bt((void *)stk[0], stk[1]);
 }
-static int64_t STK_Misc_LBtc(int64_t* stk)
-{
-	return Misc_LBtc((void*)stk[0], stk[1]);
+static int64_t STK_Misc_LBtc(int64_t *stk) {
+  return Misc_LBtc((void *)stk[0], stk[1]);
 }
-static int64_t STK_Misc_Bts(int64_t* stk)
-{
-	return Misc_Bts((void*)stk[0], stk[1]);
+static int64_t STK_Misc_Bts(int64_t *stk) {
+  return Misc_Bts((void *)stk[0], stk[1]);
 }
 
-static int64_t STK_HeapCtrlInit(int64_t* stk)
-{
-	return (int64_t)HeapCtrlInit((CHeapCtrl*)stk[0], (CTask*)stk[1],stk[2]);
+static int64_t STK_HeapCtrlInit(int64_t *stk) {
+  return (int64_t)HeapCtrlInit((CHeapCtrl *)stk[0], (CTask *)stk[1], stk[2]);
 }
 
-static int64_t STK_HeapCtrlDel(int64_t* stk)
-{
-	HeapCtrlDel((CHeapCtrl*)stk[0]);
+static int64_t STK_HeapCtrlDel(int64_t *stk) {
+  HeapCtrlDel((CHeapCtrl *)stk[0]);
 }
 
-static int64_t STK___AIWNIOS_MAlloc(int64_t* stk)
-{
-	return (int64_t)__AIWNIOS_MAlloc(stk[0], (CTask*)stk[1]);
+static int64_t STK___AIWNIOS_MAlloc(int64_t *stk) {
+  return (int64_t)__AIWNIOS_MAlloc(stk[0], (CTask *)stk[1]);
 }
-static int64_t STK___AIWNIOS_CAlloc(int64_t* stk)
-{
-	return (int64_t)__AIWNIOS_CAlloc(stk[0], (CTask*)stk[1]);
+static int64_t STK___AIWNIOS_CAlloc(int64_t *stk) {
+  return (int64_t)__AIWNIOS_CAlloc(stk[0], (CTask *)stk[1]);
 }
 
-static int64_t STK___AIWNIOS_Free(int64_t* stk)
-{
-	__AIWNIOS_Free((void*)stk[0]);
+static int64_t STK___AIWNIOS_Free(int64_t *stk) {
+  __AIWNIOS_Free((void *)stk[0]);
 }
 
-static int64_t STK_MSize(int64_t* stk)
-{
-	return MSize((void*)stk[0]);
+static int64_t STK_MSize(int64_t *stk) {
+  return MSize((void *)stk[0]);
 }
 
-static int64_t STK___SleepHP(int64_t* stk)
-{
-	__SleepHP(stk[0]);
+static int64_t STK___SleepHP(int64_t *stk) {
+  __SleepHP(stk[0]);
 }
 
-static int64_t STK___GetTicksHP(int64_t* stk)
-{
-	return __GetTicksHP(stk[0]);
+static int64_t STK___GetTicksHP(int64_t *stk) {
+  return __GetTicksHP(stk[0]);
 }
 
-static int64_t STK___AIWNIOS_StrDup(int64_t* stk)
-{
-	return (int64_t)__AIWNIOS_StrDup((char*)stk[0], (void*)stk[1]);
+static int64_t STK___AIWNIOS_StrDup(int64_t *stk) {
+  return (int64_t)__AIWNIOS_StrDup((char *)stk[0], (void *)stk[1]);
 }
 
-static int64_t STK_memcpy(int64_t* stk)
-{
-	return (int64_t)memcpy((void*)stk[0], (void*)stk[1], stk[2]);
+static int64_t STK_memcpy(int64_t *stk) {
+  return (int64_t)memcpy((void *)stk[0], (void *)stk[1], stk[2]);
 }
 
-static int64_t STK_memset(int64_t* stk)
-{
-	return (int64_t)memset((void*)stk[0], stk[1], stk[2]);
+static int64_t STK_memset(int64_t *stk) {
+  return (int64_t)memset((void *)stk[0], stk[1], stk[2]);
 }
 
-static int64_t STK_MemSetU16(int64_t* stk)
-{
-	return (int64_t)MemSetU16((void*)stk[0], stk[1], stk[2]);
+static int64_t STK_MemSetU16(int64_t *stk) {
+  return (int64_t)MemSetU16((void *)stk[0], stk[1], stk[2]);
 }
 
-static int64_t STK_MemSetU32(int64_t* stk)
-{
-	return (int64_t)MemSetU32((void*)stk[0], stk[1], stk[2]);
+static int64_t STK_MemSetU32(int64_t *stk) {
+  return (int64_t)MemSetU32((void *)stk[0], stk[1], stk[2]);
 }
 
-static int64_t STK_MemSetU64(int64_t* stk)
-{
-	return (int64_t)MemSetU64((void*)stk[0], stk[1], stk[2]);
+static int64_t STK_MemSetU64(int64_t *stk) {
+  return (int64_t)MemSetU64((void *)stk[0], stk[1], stk[2]);
 }
 
-static int64_t STK_strlen(int64_t* stk)
-{
-	return (int64_t)strlen((void*)stk[0]);
+static int64_t STK_strlen(int64_t *stk) {
+  return (int64_t)strlen((void *)stk[0]);
 }
 
-static int64_t STK_strcmp(int64_t* stk)
-{
-	return (int64_t)strcmp((void*)stk[0], (void*)stk[1]);
+static int64_t STK_strcmp(int64_t *stk) {
+  return (int64_t)strcmp((void *)stk[0], (void *)stk[1]);
 }
 
-static int64_t STK_toupper(int64_t* stk)
-{
-	return toupper(stk[0]);
+static int64_t STK_toupper(int64_t *stk) {
+  return toupper(stk[0]);
 }
 
-static int64_t STK_log10(double* stk)
-{
-	double r = log10(stk[0]);
-	return *(int64_t*)&r;
+static int64_t STK_log10(double *stk) {
+  double r = log10(stk[0]);
+  return *(int64_t *)&r;
 }
-static int64_t STK_log2(double* stk)
-{
-	double r = log2(stk[0]);
-	return *(int64_t*)&r;
+static int64_t STK_log2(double *stk) {
+  double r = log2(stk[0]);
+  return *(int64_t *)&r;
 }
-static int64_t STK_Pow10(double* stk)
-{
-	double r = Pow10(stk[0]);
-	return *(int64_t*)&r;
+static int64_t STK_Pow10(double *stk) {
+  double r = Pow10(stk[0]);
+  return *(int64_t *)&r;
 }
-static int64_t STK_sqrt(double* stk)
-{
-	double r = sqrt(stk[0]);
-	return *(int64_t*)&r;
+static int64_t STK_sqrt(double *stk) {
+  double r = sqrt(stk[0]);
+  return *(int64_t *)&r;
 }
 
-static int64_t STK_pow(double* stk)
-{
-	double r = pow(stk[0], stk[1]);
-	return *(int64_t*)&r;
+static int64_t STK_pow(double *stk) {
+  double r = pow(stk[0], stk[1]);
+  return *(int64_t *)&r;
 }
-static int64_t STK_exp(double* stk)
-{
-	double r = exp(stk[0]);
-	return *(int64_t*)&r;
+static int64_t STK_exp(double *stk) {
+  double r = exp(stk[0]);
+  return *(int64_t *)&r;
 }
 
-static int64_t STK_PrintI(int64_t* stk)
-{
-	PrintI((char*)stk[0], stk[1]);
+static int64_t STK_PrintI(int64_t *stk) {
+  PrintI((char *)stk[0], stk[1]);
 }
 
-static int64_t STK_PrintF(double* stk)
-{
-	PrintF(((char**)stk)[0], stk[1]);
+static int64_t STK_PrintF(double *stk) {
+  PrintF(((char **)stk)[0], stk[1]);
 }
 
-static int64_t STK_round(double* stk)
-{
-	double r = round(stk[0]);
-	return *(int64_t*)&r;
+static int64_t STK_round(double *stk) {
+  double r = round(stk[0]);
+  return *(int64_t *)&r;
 }
 
-static int64_t STK_log(double* stk)
-{
-	double r = log(stk[0]);
-	return *(int64_t*)&r;
+static int64_t STK_log(double *stk) {
+  double r = log(stk[0]);
+  return *(int64_t *)&r;
 }
 
-static int64_t STK_floor(double* stk)
-{
-	double r = floor(stk[0]);
-	return *(int64_t*)&r;
+static int64_t STK_floor(double *stk) {
+  double r = floor(stk[0]);
+  return *(int64_t *)&r;
 }
 
-static int64_t STK_ceil(double* stk)
-{
-	double r = ceil(stk[0]);
-	return *(int64_t*)&r;
+static int64_t STK_ceil(double *stk) {
+  double r = ceil(stk[0]);
+  return *(int64_t *)&r;
 }
 
-static int64_t STK_memcmp(int64_t* stk)
-{
-	return (int64_t)memcmp((void*)stk[0], (void*)stk[1], stk[2]);
+static int64_t STK_memcmp(int64_t *stk) {
+  return (int64_t)memcmp((void *)stk[0], (void *)stk[1], stk[2]);
 }
 
-static int64_t STK_Bt(int64_t* stk)
-{
-	return Misc_Bt((void*)stk[0], stk[1]);
+static int64_t STK_Bt(int64_t *stk) {
+  return Misc_Bt((void *)stk[0], stk[1]);
 }
 
-static int64_t STK_LBts(int64_t* stk)
-{
-	return Misc_LBts((void*)stk[0], stk[1]);
+static int64_t STK_LBts(int64_t *stk) {
+  return Misc_LBts((void *)stk[0], stk[1]);
 }
-static int64_t STK_LBtr(int64_t* stk)
-{
-	return Misc_LBtr((void*)stk[0], stk[1]);
+static int64_t STK_LBtr(int64_t *stk) {
+  return Misc_LBtr((void *)stk[0], stk[1]);
 }
-static int64_t STK_LBtc(int64_t* stk)
-{
-	return Misc_LBtc((void*)stk[0], stk[1]);
+static int64_t STK_LBtc(int64_t *stk) {
+  return Misc_LBtc((void *)stk[0], stk[1]);
 }
-static int64_t STK_Btr(int64_t* stk)
-{
-	return Misc_Btr((void*)stk[0], stk[1]);
+static int64_t STK_Btr(int64_t *stk) {
+  return Misc_Btr((void *)stk[0], stk[1]);
 }
-static int64_t STK_Bts(int64_t* stk)
-{
-	return Misc_Bts((void*)stk[0], stk[1]);
+static int64_t STK_Bts(int64_t *stk) {
+  return Misc_Bts((void *)stk[0], stk[1]);
 }
-static int64_t STK_Bsf(int64_t* stk)
-{
-	return Bsf(stk[0]);
+static int64_t STK_Bsf(int64_t *stk) {
+  return Bsf(stk[0]);
 }
-static int64_t STK_Bsr(int64_t* stk)
-{
-	return Bsr(stk[0]);
+static int64_t STK_Bsr(int64_t *stk) {
+  return Bsr(stk[0]);
 }
 
-static int64_t STK_DbgPutS(int64_t* stk)
-{
-	puts((char*)stk[0]);
+static int64_t STK_DbgPutS(int64_t *stk) {
+  puts((char *)stk[0]);
 }
-static int64_t STK_PutS(int64_t* stk)
-{
-	puts((char*)stk[0]);
+static int64_t STK_PutS(int64_t *stk) {
+  puts((char *)stk[0]);
 }
-static int64_t STK_SetHolyFs(int64_t* stk)
-{
-	SetHolyFs((void*)stk[0]);
+static int64_t STK_SetHolyFs(int64_t *stk) {
+  SetHolyFs((void *)stk[0]);
 }
 
-static int64_t STK_GetHolyFs(int64_t* stk)
-{
-	return (int64_t)GetHolyFs();
+static int64_t STK_GetHolyFs(int64_t *stk) {
+  return (int64_t)GetHolyFs();
 }
 
-static int64_t STK_SpawnCore(int64_t* stk)
-{
-	SpawnCore((void*)stk[0], (void*)stk[1], stk[2]);
+static int64_t STK_SpawnCore(int64_t *stk) {
+  SpawnCore((void *)stk[0], (void *)stk[1], stk[2]);
 }
 
-static int64_t STK_MPSleepHP(int64_t* stk)
-{
-	MPSleepHP(stk[0]);
+static int64_t STK_MPSleepHP(int64_t *stk) {
+  MPSleepHP(stk[0]);
 }
 
-static int64_t STK_MPAwake(int64_t* stk)
-{
-	MPAwake(stk[0]);
+static int64_t STK_MPAwake(int64_t *stk) {
+  MPAwake(stk[0]);
 }
 
-static int64_t STK_mp_cnt(int64_t* stk)
-{
-	return mp_cnt();
+static int64_t STK_mp_cnt(int64_t *stk) {
+  return mp_cnt();
 }
 
-static int64_t STK_SetHolyGs(int64_t* stk)
-{
-	SetHolyGs((void*)stk[0]);
+static int64_t STK_SetHolyGs(int64_t *stk) {
+  SetHolyGs((void *)stk[0]);
 }
-static int64_t STK___GetTicks(int64_t* stk)
-{
-	return __GetTicks();
+static int64_t STK___GetTicks(int64_t *stk) {
+  return __GetTicks();
 }
 
-static int64_t STK___Sleep(int64_t* stk)
-{
-	__Sleep(stk[0]);
+static int64_t STK___Sleep(int64_t *stk) {
+  __Sleep(stk[0]);
 }
 
-static int64_t STK_ImportSymbolsToHolyC(int64_t* stk)
-{
-	ImportSymbolsToHolyC((void*)stk[0]);
+static int64_t STK_ImportSymbolsToHolyC(int64_t *stk) {
+  ImportSymbolsToHolyC((void *)stk[0]);
 }
-static int64_t STK_AIWNIOS_getcontext(int64_t* stk)
-{
-	return AIWNIOS_getcontext((void*)stk[0]);
+static int64_t STK_AIWNIOS_getcontext(int64_t *stk) {
+  return AIWNIOS_getcontext((void *)stk[0]);
 }
 
-static int64_t STK_AIWNIOS_setcontext(int64_t* stk)
-{
-	AIWNIOS_setcontext((void*)stk[0]);
+static int64_t STK_AIWNIOS_setcontext(int64_t *stk) {
+  AIWNIOS_setcontext((void *)stk[0]);
 }
 
-static int64_t STK_IsValidPtr(int64_t* stk)
-{
-	return IsValidPtr((char*)stk[0]);
+static int64_t STK_IsValidPtr(int64_t *stk) {
+  return IsValidPtr((char *)stk[0]);
 }
-static int64_t STK___HC_CmpCtrl_SetAOT(int64_t* stk)
-{
-	__HC_CmpCtrl_SetAOT((CCmpCtrl*)stk[0]);
+static int64_t STK___HC_CmpCtrl_SetAOT(int64_t *stk) {
+  __HC_CmpCtrl_SetAOT((CCmpCtrl *)stk[0]);
 }
 
 static int64_t STK__HC_ICAdd_RawBytes(int64_t *stk) {
-	return (int64_t)__HC_ICAdd_RawBytes((CCmpCtrl*)stk[0],(char*)stk[1],stk[2]);
+  return (int64_t)__HC_ICAdd_RawBytes((CCmpCtrl *)stk[0], (char *)stk[1],
+                                      stk[2]);
 }
 
 static int64_t STK___HC_ICAdd_GetVargsPtr(int64_t *stk) {
-	return (int64_t)__HC_ICAdd_GetVargsPtr((CCmpCtrl*)stk[0]);
+  return (int64_t)__HC_ICAdd_GetVargsPtr((CCmpCtrl *)stk[0]);
 }
 
-static int64_t STK___HC_ICAdd_Typecast(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_Typecast((CCodeCtrl*)stk[0], stk[1], stk[2]);
+static int64_t STK___HC_ICAdd_Typecast(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_Typecast((CCodeCtrl *)stk[0], stk[1], stk[2]);
 }
 
-static int64_t STK___HC_ICAdd_SubCall(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_SubCall((CCodeCtrl*)stk[0], (CCodeMisc*)stk[1]);
+static int64_t STK___HC_ICAdd_SubCall(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_SubCall((CCodeCtrl *)stk[0], (CCodeMisc *)stk[1]);
 }
 
-static int64_t STK___HC_ICAdd_SubProlog(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_SubProlog((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_SubProlog(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_SubProlog((CCodeCtrl *)stk[0]);
 }
 
-static int64_t STK___HC_ICAdd_SubRet(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_SubRet((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_SubRet(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_SubRet((CCodeCtrl *)stk[0]);
 }
 
-static int64_t STK___HC_ICAdd_Switch(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_Switch((CCodeCtrl*)stk[0], (CCodeMisc*)stk[1], (CCodeMisc*)stk[2]);
+static int64_t STK___HC_ICAdd_Switch(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_Switch((CCodeCtrl *)stk[0], (CCodeMisc *)stk[1],
+                                    (CCodeMisc *)stk[2]);
 }
 
-static int64_t STK___HC_ICAdd_UnboundedSwitch(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_UnboundedSwitch((CCodeCtrl*)stk[0], (CCodeMisc*)stk[1]);
+static int64_t STK___HC_ICAdd_UnboundedSwitch(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_UnboundedSwitch((CCodeCtrl *)stk[0],
+                                             (CCodeMisc *)stk[1]);
 }
 
-static int64_t STK___HC_ICAdd_PreInc(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_PreInc((CCodeCtrl*)stk[0], stk[1]);
+static int64_t STK___HC_ICAdd_PreInc(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_PreInc((CCodeCtrl *)stk[0], stk[1]);
 }
 
-static int64_t STK___HC_ICAdd_Call(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_Call((CCodeCtrl*)stk[0], stk[1], stk[2], stk[3]);
+static int64_t STK___HC_ICAdd_Call(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_Call((CCodeCtrl *)stk[0], stk[1], stk[2], stk[3]);
 }
 
-static int64_t STK___HC_ICAdd_F64(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_F64((CCodeCtrl*)stk[0], ((double*)stk)[1]);
+static int64_t STK___HC_ICAdd_F64(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_F64((CCodeCtrl *)stk[0], ((double *)stk)[1]);
 }
 
-static int64_t STK___HC_ICAdd_I64(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_I64((CCodeCtrl*)stk[0], stk[1]);
+static int64_t STK___HC_ICAdd_I64(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_I64((CCodeCtrl *)stk[0], stk[1]);
 }
 
-static int64_t STK___HC_ICAdd_PreDec(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_PreDec((CCodeCtrl*)stk[0], stk[1]);
+static int64_t STK___HC_ICAdd_PreDec(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_PreDec((CCodeCtrl *)stk[0], stk[1]);
 }
 
-static int64_t STK___HC_ICAdd_PostInc(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_PostInc((CCodeCtrl*)stk[0], stk[1]);
+static int64_t STK___HC_ICAdd_PostInc(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_PostInc((CCodeCtrl *)stk[0], stk[1]);
 }
 
-static int64_t STK___HC_ICAdd_PostDec(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_PostDec((CCodeCtrl*)stk[0], stk[1]);
+static int64_t STK___HC_ICAdd_PostDec(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_PostDec((CCodeCtrl *)stk[0], stk[1]);
 }
 
-static int64_t STK___HC_ICAdd_Pow(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_Pow((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_Pow(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_Pow((CCodeCtrl *)stk[0]);
 }
 
-static int64_t STK___HC_ICAdd_Eq(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_Eq((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_Eq(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_Eq((CCodeCtrl *)stk[0]);
 }
 
-static int64_t STK___HC_ICAdd_Div(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_Div((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_Div(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_Div((CCodeCtrl *)stk[0]);
 }
 
-static int64_t STK___HC_ICAdd_Sub(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_Sub((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_Sub(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_Sub((CCodeCtrl *)stk[0]);
 }
 
-static int64_t STK___HC_ICAdd_Mul(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_Mul((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_Mul(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_Mul((CCodeCtrl *)stk[0]);
 }
 
-static int64_t STK___HC_ICAdd_Add(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_Add((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_Add(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_Add((CCodeCtrl *)stk[0]);
 }
 
-static int64_t STK___HC_ICAdd_Deref(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_Deref((CCodeCtrl*)stk[0], stk[1], stk[2]);
+static int64_t STK___HC_ICAdd_Deref(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_Deref((CCodeCtrl *)stk[0], stk[1], stk[2]);
 }
 
-static int64_t STK___HC_ICAdd_Comma(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_Comma((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_Comma(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_Comma((CCodeCtrl *)stk[0]);
 }
 
-static int64_t STK___HC_ICAdd_Addr(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_Addr((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_Addr(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_Addr((CCodeCtrl *)stk[0]);
 }
 
-static int64_t STK___HC_ICAdd_Xor(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_Xor((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_Xor(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_Xor((CCodeCtrl *)stk[0]);
 }
 
-static int64_t STK___HC_ICAdd_Mod(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_Mod((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_Mod(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_Mod((CCodeCtrl *)stk[0]);
 }
-static int64_t STK___HC_ICAdd_Or(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_Or((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_Or(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_Or((CCodeCtrl *)stk[0]);
 }
-static int64_t STK___HC_ICAdd_Lt(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_Lt((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_Lt(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_Lt((CCodeCtrl *)stk[0]);
 }
-static int64_t STK___HC_ICAdd_Gt(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_Gt((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_Gt(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_Gt((CCodeCtrl *)stk[0]);
 }
-static int64_t STK___HC_ICAdd_Ge(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_Ge((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_Ge(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_Ge((CCodeCtrl *)stk[0]);
 }
-static int64_t STK___HC_ICAdd_Le(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_Le((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_Le(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_Le((CCodeCtrl *)stk[0]);
 }
-static int64_t STK___HC_ICAdd_LNot(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_LNot((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_LNot(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_LNot((CCodeCtrl *)stk[0]);
 }
-static int64_t STK___HC_ICAdd_Vargs(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_Vargs((CCodeCtrl*)stk[0], stk[1]);
+static int64_t STK___HC_ICAdd_Vargs(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_Vargs((CCodeCtrl *)stk[0], stk[1]);
 }
-static int64_t STK___HC_ICAdd_BNot(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_BNot((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_BNot(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_BNot((CCodeCtrl *)stk[0]);
 }
-static int64_t STK___HC_ICAdd_AndAnd(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_AndAnd((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_AndAnd(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_AndAnd((CCodeCtrl *)stk[0]);
 }
-static int64_t STK___HC_ICAdd_OrOr(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_OrOr((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_OrOr(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_OrOr((CCodeCtrl *)stk[0]);
 }
-static int64_t STK___HC_ICAdd_XorXor(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_XorXor((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_XorXor(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_XorXor((CCodeCtrl *)stk[0]);
 }
-static int64_t STK___HC_ICAdd_Ne(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_Ne((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_Ne(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_Ne((CCodeCtrl *)stk[0]);
 }
-static int64_t STK___HC_ICAdd_Lsh(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_Lsh((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_Lsh(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_Lsh((CCodeCtrl *)stk[0]);
 }
-static int64_t STK___HC_ICAdd_Rsh(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_Rsh((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_Rsh(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_Rsh((CCodeCtrl *)stk[0]);
 }
-static int64_t STK___HC_ICAdd_AddEq(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_AddEq((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_AddEq(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_AddEq((CCodeCtrl *)stk[0]);
 }
-static int64_t STK___HC_ICAdd_SubEq(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_SubEq((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_SubEq(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_SubEq((CCodeCtrl *)stk[0]);
 }
-static int64_t STK___HC_ICAdd_MulEq(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_MulEq((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_MulEq(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_MulEq((CCodeCtrl *)stk[0]);
 }
-static int64_t STK___HC_ICAdd_DivEq(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_DivEq((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_DivEq(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_DivEq((CCodeCtrl *)stk[0]);
 }
-static int64_t STK___HC_ICAdd_LshEq(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_LshEq((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_LshEq(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_LshEq((CCodeCtrl *)stk[0]);
 }
-static int64_t STK___HC_ICAdd_RshEq(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_RshEq((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_RshEq(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_RshEq((CCodeCtrl *)stk[0]);
 }
-static int64_t STK___HC_ICAdd_AndEq(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_AndEq((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_AndEq(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_AndEq((CCodeCtrl *)stk[0]);
 }
-static int64_t STK___HC_ICAdd_OrEq(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_OrEq((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_OrEq(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_OrEq((CCodeCtrl *)stk[0]);
 }
-static int64_t STK___HC_ICAdd_XorEq(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_XorEq((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_XorEq(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_XorEq((CCodeCtrl *)stk[0]);
 }
-static int64_t STK___HC_ICAdd_ModEq(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_ModEq((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_ICAdd_ModEq(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_ModEq((CCodeCtrl *)stk[0]);
 }
-static int64_t STK___HC_ICAdd_IReg(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_IReg((CCodeCtrl*)stk[0], stk[1], stk[2], stk[3]);
+static int64_t STK___HC_ICAdd_IReg(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_IReg((CCodeCtrl *)stk[0], stk[1], stk[2], stk[3]);
 }
-static int64_t STK___HC_ICAdd_FReg(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_FReg((CCodeCtrl*)stk[0], stk[1]);
+static int64_t STK___HC_ICAdd_FReg(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_FReg((CCodeCtrl *)stk[0], stk[1]);
 }
-static int64_t STK___HC_ICAdd_Frame(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_Frame((CCodeCtrl*)stk[0], stk[1], stk[2], stk[3]);
+static int64_t STK___HC_ICAdd_Frame(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_Frame((CCodeCtrl *)stk[0], stk[1], stk[2], stk[3]);
 }
-static int64_t STK___HC_CodeMiscStrNew(int64_t* stk)
-{
-	return (int64_t)__HC_CodeMiscStrNew((CCmpCtrl*)stk[0], (char*)stk[1], stk[2]);
+static int64_t STK___HC_CodeMiscStrNew(int64_t *stk) {
+  return (int64_t)__HC_CodeMiscStrNew((CCmpCtrl *)stk[0], (char *)stk[1],
+                                      stk[2]);
 }
-static int64_t STK___HC_CodeMiscLabelNew(int64_t* stk)
-{
-	return (int64_t)__HC_CodeMiscLabelNew((CCmpCtrl*)stk[0],(void**)stk[1]);
+static int64_t STK___HC_CodeMiscLabelNew(int64_t *stk) {
+  return (int64_t)__HC_CodeMiscLabelNew((CCmpCtrl *)stk[0], (void **)stk[1]);
 }
-static int64_t STK___HC_CmpCtrlNew(int64_t* stk)
-{
-	return (int64_t)__HC_CmpCtrlNew();
+static int64_t STK___HC_CmpCtrlNew(int64_t *stk) {
+  return (int64_t)__HC_CmpCtrlNew();
 }
-static int64_t STK___HC_CodeCtrlPush(int64_t* stk)
-{
-	return (int64_t)__HC_CodeCtrlPush((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_CodeCtrlPush(int64_t *stk) {
+  return (int64_t)__HC_CodeCtrlPush((CCodeCtrl *)stk[0]);
 }
-static int64_t STK___HC_CodeCtrlPop(int64_t* stk)
-{
-	return __HC_CodeCtrlPop((CCodeCtrl*)stk[0]);
+static int64_t STK___HC_CodeCtrlPop(int64_t *stk) {
+  return __HC_CodeCtrlPop((CCodeCtrl *)stk[0]);
 }
-static int64_t STK___HC_Compile(int64_t* stk)
-{
-	return (int64_t)__HC_Compile((CCmpCtrl*)stk[0], (int64_t*)stk[1], (char**)stk[2]);
+static int64_t STK___HC_Compile(int64_t *stk) {
+  return (int64_t)__HC_Compile((CCmpCtrl *)stk[0], (int64_t *)stk[1],
+                               (char **)stk[2]);
 }
-static int64_t STK___HC_ICAdd_Label(int64_t* stk)
-{
-	return __HC_ICAdd_Label(stk[0], stk[1]);
+static int64_t STK___HC_ICAdd_Label(int64_t *stk) {
+  return __HC_ICAdd_Label(stk[0], stk[1]);
 }
-static int64_t STK___HC_ICAdd_Goto(int64_t* stk)
-{
-	return __HC_ICAdd_Goto(stk[0], stk[1]);
+static int64_t STK___HC_ICAdd_Goto(int64_t *stk) {
+  return __HC_ICAdd_Goto(stk[0], stk[1]);
 }
-static int64_t STK___HC_ICAdd_GotoIf(int64_t* stk)
-{
-	return __HC_ICAdd_GotoIf(stk[0], stk[1]);
+static int64_t STK___HC_ICAdd_GotoIf(int64_t *stk) {
+  return __HC_ICAdd_GotoIf(stk[0], stk[1]);
 }
-static int64_t STK___HC_ICAdd_Str(int64_t* stk)
-{
-	return __HC_ICAdd_Str(stk[0], stk[1]);
+static int64_t STK___HC_ICAdd_Str(int64_t *stk) {
+  return __HC_ICAdd_Str(stk[0], stk[1]);
 }
-static int64_t STK___HC_ICAdd_And(int64_t* stk)
-{
-	return __HC_ICAdd_And(stk[0]);
+static int64_t STK___HC_ICAdd_And(int64_t *stk) {
+  return __HC_ICAdd_And(stk[0]);
 }
-static int64_t STK___HC_ICAdd_EqEq(int64_t* stk)
-{
-	return __HC_ICAdd_EqEq(stk[0]);
+static int64_t STK___HC_ICAdd_EqEq(int64_t *stk) {
+  return __HC_ICAdd_EqEq(stk[0]);
 }
-static int64_t STK___HC_ICAdd_Neg(int64_t* stk)
-{
-	return __HC_ICAdd_Neg(stk[0]);
+static int64_t STK___HC_ICAdd_Neg(int64_t *stk) {
+  return __HC_ICAdd_Neg(stk[0]);
 }
-static int64_t STK___HC_ICAdd_Ret(int64_t* stk)
-{
-	return __HC_ICAdd_Ret(stk[0]);
+static int64_t STK___HC_ICAdd_Ret(int64_t *stk) {
+  return __HC_ICAdd_Ret(stk[0]);
 }
-static int64_t STK___HC_ICAdd_Arg(int64_t* stk)
-{
-	return __HC_ICAdd_Arg(stk[0], stk[1]);
+static int64_t STK___HC_ICAdd_Arg(int64_t *stk) {
+  return __HC_ICAdd_Arg(stk[0], stk[1]);
 }
-static int64_t STK___HC_ICAdd_SetFrameSize(int64_t* stk)
-{
-	return __HC_ICAdd_SetFrameSize(stk[0], stk[1]);
+static int64_t STK___HC_ICAdd_SetFrameSize(int64_t *stk) {
+  return __HC_ICAdd_SetFrameSize(stk[0], stk[1]);
 }
-static int64_t STK___HC_ICAdd_Reloc(int64_t* stk)
-{
-	return __HC_ICAdd_Reloc(stk[0], stk[1], stk[2], stk[3], stk[4], stk[5]);
+static int64_t STK___HC_ICAdd_Reloc(int64_t *stk) {
+  return __HC_ICAdd_Reloc(stk[0], stk[1], stk[2], stk[3], stk[4], stk[5]);
 }
-static int64_t STK___HC_ICSetLine(int64_t* stk)
-{
-	__HC_ICSetLine(stk[0], stk[1]);
+static int64_t STK___HC_ICSetLine(int64_t *stk) {
+  __HC_ICSetLine(stk[0], stk[1]);
 }
-static int64_t STK___HC_ICAdd_StaticRef(int64_t* stk)
-{
-	return __HC_ICAdd_StaticRef(stk[0], stk[1], stk[2], stk[3]);
+static int64_t STK___HC_ICAdd_StaticRef(int64_t *stk) {
+  return __HC_ICAdd_StaticRef(stk[0], stk[1], stk[2], stk[3]);
 }
-static int64_t STK___HC_ICAdd_StaticData(int64_t* stk)
-{
-	return __HC_ICAdd_StaticData(stk[0], stk[1], stk[2], stk[3], stk[4]);
+static int64_t STK___HC_ICAdd_StaticData(int64_t *stk) {
+  return __HC_ICAdd_StaticData(stk[0], stk[1], stk[2], stk[3], stk[4]);
 }
-static int64_t STK___HC_ICAdd_SetStaticsSize(int64_t* stk)
-{
-	return __HC_ICAdd_SetStaticsSize(stk[0], stk[1]);
+static int64_t STK___HC_ICAdd_SetStaticsSize(int64_t *stk) {
+  return __HC_ICAdd_SetStaticsSize(stk[0], stk[1]);
 }
-static int64_t STK___HC_ICAdd_ToI64(int64_t* stk)
-{
-	return __HC_ICAdd_ToI64(stk[0]);
+static int64_t STK___HC_ICAdd_ToI64(int64_t *stk) {
+  return __HC_ICAdd_ToI64(stk[0]);
 }
-static int64_t STK___HC_ICAdd_BT(int64_t* stk)
-{
-	return __HC_ICAdd_BT(stk[0]);
+static int64_t STK___HC_ICAdd_BT(int64_t *stk) {
+  return __HC_ICAdd_BT(stk[0]);
 }
-static int64_t STK___HC_ICAdd_BTS(int64_t* stk)
-{
-	return __HC_ICAdd_BTS(stk[0]);
+static int64_t STK___HC_ICAdd_BTS(int64_t *stk) {
+  return __HC_ICAdd_BTS(stk[0]);
 }
-static int64_t STK___HC_ICAdd_BTR(int64_t* stk)
-{
-	return __HC_ICAdd_BTR(stk[0]);
+static int64_t STK___HC_ICAdd_BTR(int64_t *stk) {
+  return __HC_ICAdd_BTR(stk[0]);
 }
-static int64_t STK___HC_ICAdd_BTC(int64_t* stk)
-{
-	return __HC_ICAdd_BTC(stk[0]);
+static int64_t STK___HC_ICAdd_BTC(int64_t *stk) {
+  return __HC_ICAdd_BTC(stk[0]);
 }
 
-static int64_t STK___HC_ICAdd_LBTS(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_LBTS(stk[0]);
+static int64_t STK___HC_ICAdd_LBTS(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_LBTS(stk[0]);
 }
-static int64_t STK___HC_ICAdd_LBTR(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_LBTR(stk[0]);
+static int64_t STK___HC_ICAdd_LBTR(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_LBTR(stk[0]);
 }
-static int64_t STK___HC_ICAdd_LBTC(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_LBTC(stk[0]);
+static int64_t STK___HC_ICAdd_LBTC(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_LBTC(stk[0]);
 }
 
-static int64_t STK___HC_ICAdd_ToF64(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_ToF64(stk[0]);
+static int64_t STK___HC_ICAdd_ToF64(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_ToF64(stk[0]);
 }
-static int64_t STK___HC_ICAdd_ShortAddr(int64_t* stk)
-{
-	return (int64_t)__HC_ICAdd_ShortAddr(stk[0], stk[1], stk[2], stk[3]);
+static int64_t STK___HC_ICAdd_ShortAddr(int64_t *stk) {
+  return (int64_t)__HC_ICAdd_ShortAddr(stk[0], stk[1], stk[2], stk[3]);
 }
-static int64_t STK_Misc_Caller(int64_t* stk)
-{
-	return (int64_t)Misc_Caller(stk[0]);
+static int64_t STK_Misc_Caller(int64_t *stk) {
+  return (int64_t)Misc_Caller(stk[0]);
 }
-static int64_t STK_VFsSetPwd(int64_t* stk)
-{
-	VFsSetPwd(stk[0]);
+static int64_t STK_VFsSetPwd(int64_t *stk) {
+  VFsSetPwd(stk[0]);
 }
-static int64_t STK_VFsFileExists(int64_t* stk)
-{
-	return VFsFileExists(stk[0]);
+static int64_t STK_VFsFileExists(int64_t *stk) {
+  return VFsFileExists(stk[0]);
 }
-static int64_t STK_VFsIsDir(int64_t* stk)
-{
-	return VFsIsDir(stk[0]);
+static int64_t STK_VFsIsDir(int64_t *stk) {
+  return VFsIsDir(stk[0]);
 }
-static int64_t STK_VFsFileRead(int64_t* stk)
-{
-	return (int64_t)VFsFileRead(stk[0], stk[1]);
+static int64_t STK_VFsFileRead(int64_t *stk) {
+  return (int64_t)VFsFileRead(stk[0], stk[1]);
 }
-static int64_t STK_VFsFileWrite(int64_t* stk)
-{
-	return VFsFileWrite(stk[0], stk[1], stk[2]);
+static int64_t STK_VFsFileWrite(int64_t *stk) {
+  return VFsFileWrite(stk[0], stk[1], stk[2]);
 }
-static int64_t STK_VFsDel(int64_t* stk)
-{
-	return VFsDel(stk[0]);
+static int64_t STK_VFsDel(int64_t *stk) {
+  return VFsDel(stk[0]);
 }
-static int64_t STK_VFsDir(int64_t* stk)
-{
-	return (int64_t)VFsDir(stk[0]);
+static int64_t STK_VFsDir(int64_t *stk) {
+  return (int64_t)VFsDir(stk[0]);
 }
-static int64_t STK_VFsDirMk(int64_t* stk)
-{
-	return VFsDirMk(stk[0]);
+static int64_t STK_VFsDirMk(int64_t *stk) {
+  return VFsDirMk(stk[0]);
 }
-static int64_t STK_VFsBlkRead(int64_t* stk)
-{
-	return VFsFBlkRead(stk[0], stk[1], stk[2], stk[3]);
+static int64_t STK_VFsBlkRead(int64_t *stk) {
+  return VFsFBlkRead(stk[0], stk[1], stk[2], stk[3]);
 }
-static int64_t STK_VFsBlkWrite(int64_t* stk)
-{
-	return VFsFBlkWrite(stk[0], stk[1], stk[2], stk[3]);
+static int64_t STK_VFsBlkWrite(int64_t *stk) {
+  return VFsFBlkWrite(stk[0], stk[1], stk[2], stk[3]);
 }
-static int64_t STK_VFsFOpenW(int64_t* stk)
-{
-	return VFsFOpenW(stk[0]);
+static int64_t STK_VFsFOpenW(int64_t *stk) {
+  return VFsFOpenW(stk[0]);
 }
-static int64_t STK_VFsFOpenR(int64_t* stk)
-{
-	return VFsFOpenR(stk[0]);
+static int64_t STK_VFsFOpenR(int64_t *stk) {
+  return VFsFOpenR(stk[0]);
 }
-static int64_t STK_VFsFClose(int64_t* stk)
-{
-	return VFsFClose(stk[0]);
+static int64_t STK_VFsFClose(int64_t *stk) {
+  return VFsFClose(stk[0]);
 }
-static int64_t STK_VFsFSeek(int64_t* stk)
-{
-	return VFsFSeek(stk[0], stk[1]);
+static int64_t STK_VFsFSeek(int64_t *stk) {
+  return VFsFSeek(stk[0], stk[1]);
 }
-static int64_t STK_VFsSetDrv(int64_t* stk)
-{
-	VFsSetDrv(stk[0]);
+static int64_t STK_VFsSetDrv(int64_t *stk) {
+  VFsSetDrv(stk[0]);
 }
-static int64_t STK_VFsUnixTime(int64_t* stk)
-{
-	return VFsUnixTime(stk[0]);
+static int64_t STK_VFsUnixTime(int64_t *stk) {
+  return VFsUnixTime(stk[0]);
 }
-static int64_t STK_VFsTrunc(int64_t* stk)
-{
-	return VFsTrunc(stk[0], stk[1]);
+static int64_t STK_VFsTrunc(int64_t *stk) {
+  return VFsTrunc(stk[0], stk[1]);
 }
-static int64_t STK_UpdateScreen(int64_t* stk)
-{
-	UpdateScreen(stk[0], stk[1], stk[2], stk[3]);
+static int64_t STK_UpdateScreen(int64_t *stk) {
+  UpdateScreen(stk[0], stk[1], stk[2], stk[3]);
 }
-static int64_t STK_VFsFSize(int64_t* stk)
-{
-	return VFsFSize(stk[0]);
+static int64_t STK_VFsFSize(int64_t *stk) {
+  return VFsFSize(stk[0]);
 }
-static int64_t STK_UnixNow(int64_t* stk)
-{
-	return UnixNow();
+static int64_t STK_UnixNow(int64_t *stk) {
+  return UnixNow();
 }
-static int64_t STK_GrPaletteColorSet(int64_t* stk)
-{
-	GrPaletteColorSet(stk[0], stk[1]);
+static int64_t STK_GrPaletteColorSet(int64_t *stk) {
+  GrPaletteColorSet(stk[0], stk[1]);
 }
-static int64_t STK_DrawWindowNew(int64_t* stk)
-{
-	DrawWindowNew();
+static int64_t STK_DrawWindowNew(int64_t *stk) {
+  DrawWindowNew();
 }
-static int64_t STK_SetKBCallback(int64_t* stk)
-{
-	SetKBCallback(stk[0]);
+static int64_t STK_SetKBCallback(int64_t *stk) {
+  SetKBCallback(stk[0]);
 }
-static int64_t STK_SndFreq(int64_t* stk)
-{
-	SndFreq(stk[0]);
+static int64_t STK_SndFreq(int64_t *stk) {
+  SndFreq(stk[0]);
 }
-static int64_t STK_SetMSCallback(int64_t* stk)
-{
-	SetMSCallback(stk[0]);
+static int64_t STK_SetMSCallback(int64_t *stk) {
+  SetMSCallback(stk[0]);
 }
-static int64_t STK_InteruptCore(int64_t* stk)
-{
-	InteruptCore(stk[0]);
+static int64_t STK_InteruptCore(int64_t *stk) {
+  InteruptCore(stk[0]);
 }
-static int64_t STK___HC_CodeMiscInterateThroughRefs(int64_t* stk)
-{
-	__HC_CodeMiscInterateThroughRefs(stk[0], stk[1], stk[2]);
+static int64_t STK___HC_CodeMiscInterateThroughRefs(int64_t *stk) {
+  __HC_CodeMiscInterateThroughRefs(stk[0], stk[1], stk[2]);
 }
-static int64_t STK___HC_CodeMiscJmpTableNew(int64_t* stk)
-{
-	return (int64_t)__HC_CodeMiscJmpTableNew(stk[0], stk[1], stk[2], stk[3]);
+static int64_t STK___HC_CodeMiscJmpTableNew(int64_t *stk) {
+  return (int64_t)__HC_CodeMiscJmpTableNew(stk[0], stk[1], stk[2], stk[3]);
 }
 
 static int64_t STK_BoundsCheck(int64_t *stk) {
-	return BoundsCheck((void*)stk[0],(int64_t*)stk[1]);
+  return BoundsCheck((void *)stk[0], (int64_t *)stk[1]);
 }
 
 static int64_t STK_NetPollForHangup(int64_t *stk) {
-	return NetPollForHangup(stk[0],stk[1]);
+  return NetPollForHangup(stk[0], stk[1]);
 }
 
 static int64_t STK_NetPollForWrite(int64_t *stk) {
-	return NetPollForWrite(stk[0],stk[1]);
+  return NetPollForWrite(stk[0], stk[1]);
 }
 
 static int64_t STK_NetPollForRead(int64_t *stk) {
-	return NetPollForRead(stk[0],stk[1]);
+  return NetPollForRead(stk[0], stk[1]);
 }
 
 static int64_t STK_NetWrite(int64_t *stk) {
-	return NetWrite(stk[0],stk[1],stk[2]);
+  return NetWrite(stk[0], stk[1], stk[2]);
 }
 
 static int64_t STK_NetRead(int64_t *stk) {
-	return NetRead(stk[0],stk[1],stk[2]);
+  return NetRead(stk[0], stk[1], stk[2]);
 }
 
 static int64_t STK_NetClose(int64_t *stk) {
-	NetClose(stk[0]);
+  NetClose(stk[0]);
 }
 
 static int64_t STK_NetAccept(int64_t *stk) {
-	return NetAccept(stk[0],stk[1]);
+  return NetAccept(stk[0], stk[1]);
 }
 
 static int64_t STK_NetListen(int64_t *stk) {
-	NetListen(stk[0],stk[1]);
+  NetListen(stk[0], stk[1]);
 }
 
 static int64_t STK_NetBindIn(int64_t *stk) {
-	NetBindIn(stk[0],stk[1]);
+  NetBindIn(stk[0], stk[1]);
 }
 
 static int64_t STK_NetSocketNew(int64_t *stk) {
-	return NetSocketNew();
+  return NetSocketNew();
 }
 
 static int64_t STK_MPSetProfilerInt(int64_t *stk) {
-	MPSetProfilerInt((void*)stk[0],stk[1],stk[2]);
+  MPSetProfilerInt((void *)stk[0], stk[1], stk[2]);
 }
 
 static int64_t STK_NetAddrNew(int64_t *stk) {
-	return NetAddrNew(stk[0],stk[1]);
+  return NetAddrNew(stk[0], stk[1]);
 }
 
 static int64_t STK_NetAddrDel(int64_t *stk) {
-	NetAddrDel(stk[0]);
+  NetAddrDel(stk[0]);
 }
 
-void BootAiwnios(char *bootstrap_text)
-{
-	//Run a dummy expression to link the functions into the hash table
-	CLexer* lex = LexerNew("None", !bootstrap_text?"1+1;":bootstrap_text);
-	CCmpCtrl* ccmp = CmpCtrlNew(lex);
-	void (*to_run)();
-	CodeCtrlPush(ccmp);
-	Lex(lex);
-	while (PrsStmt(ccmp)) {
-		to_run = Compile(ccmp, NULL, NULL);
-		FFI_CALL_TOS_0(to_run);
-		A_FREE(to_run);
-		CodeCtrlPop(ccmp);
-		CodeCtrlPush(ccmp);
-		// TODO make a better way of doing this
-		PrsAddSymbol("MPSetProfilerInt",STK_MPSetProfilerInt,3);
-		PrsAddSymbol("BoundsCheck", STK_BoundsCheck, 2);
-		PrsAddSymbol("TaskContextSetRIP", STK_TaskContextSetRIP, 2);
-		PrsAddSymbol("MakeContext", STK_AIWNIOS_makecontext, 3);
-		PrsAddSymbol("__HC_ICAdd_RawBytes",STK__HC_ICAdd_RawBytes,3);
-		PrsAddSymbol("__HC_SetAOTRelocBeforeRIP", STK___HC_SetAOTRelocBeforeRIP, 2);
-		PrsAddSymbol("__HC_CodeMiscIsUsed", STK___HC_CodeMiscIsUsed, 1);
-		PrsAddSymbol("AiwniosSetClipboard", STK_AiwniosSetClipboard, 1);
-		PrsAddSymbol("AiwniosGetClipboard", STK_AiwniosGetClipboard, 0);
-		PrsAddSymbol("__HC_CmpCtrlDel", STK_CmpCtrlDel, 1);
-		PrsAddSymbol("Cos", STK_cos, 1);
-		PrsAddSymbol("Sin", STK_sin, 1);
-		PrsAddSymbol("Tan", STK_tan, 1);
-		PrsAddSymbol("Arg", STK_Arg, 2);
-		PrsAddSymbol("ACos", STK_acos, 1);
-		PrsAddSymbol("ASin", STK_asin, 1);
-		PrsAddSymbol("ATan", STK_atan, 1);
-		PrsAddSymbol("Exp", STK_exp, 1);
-		PrsAddSymbol("Btc", STK_Misc_Btc, 2);
-		PrsAddSymbol("HeapCtrlInit", STK_HeapCtrlInit, 3);
-		PrsAddSymbol("HeapCtrlDel", STK_HeapCtrlDel, 1);
-		PrsAddSymbol("__MAlloc", STK___AIWNIOS_MAlloc, 2);
-		PrsAddSymbol("__CAlloc", STK___AIWNIOS_CAlloc, 2);
-		PrsAddSymbol("Free", STK___AIWNIOS_Free, 1);
-		PrsAddSymbol("MSize", STK_MSize, 1);
-		PrsAddSymbol("__SleepHP", STK___SleepHP, 1);
-		PrsAddSymbol("__GetTicksHP", STK___GetTicksHP, 0);
-		PrsAddSymbol("__StrNew", STK___AIWNIOS_StrDup, 2);
-		PrsAddSymbol("MemCpy", STK_memcpy, 3);
-		PrsAddSymbol("MemSet", STK_memset, 3);
-		PrsAddSymbol("MemSetU16", STK_MemSetU16, 3);
-		PrsAddSymbol("MemSetU32", STK_MemSetU32, 3);
-		PrsAddSymbol("MemSetU64", STK_MemSetU64, 3);
-		PrsAddSymbol("StrLen", STK_strlen, 1);
-		PrsAddSymbol("StrCmp", STK_strcmp, 2);
-		PrsAddSymbol("ToUpper", STK_toupper, 1);
-		PrsAddSymbol("Log10", STK_log10, 1);
-		PrsAddSymbol("Log2", STK_log2, 1);
-		PrsAddSymbol("Pow10", STK_Pow10, 1);
-		PrsAddSymbol("Pow", STK_pow, 2);
-		PrsAddSymbol("PrintI", STK_PrintI, 2);
-		PrsAddSymbol("PrintF", STK_PrintF, 2);
-		PrsAddSymbol("Round", STK_round, 1);
-		PrsAddSymbol("Ln", STK_log, 1);
-		PrsAddSymbol("Floor", STK_floor, 1);
-		PrsAddSymbol("Ceil", STK_ceil, 1);
-		PrsAddSymbol("Sqrt", STK_sqrt, 1);
-		PrsAddSymbol("MemCmp", STK_memcmp, 3);
-		PrsAddSymbol("Bt", STK_Misc_Bt, 2);
-		PrsAddSymbol("LBtc", STK_Misc_LBtc, 2);
-		PrsAddSymbol("LBts", STK_Misc_LBts, 2);
-		PrsAddSymbol("LBtr", STK_Misc_LBtr, 2);
-		PrsAddSymbol("Bts", STK_Misc_Bts, 2);
-		PrsAddSymbol("Btr", STK_Misc_Btr, 2);
-		PrsAddSymbol("Bsf", STK_Bsf, 1);
-		PrsAddSymbol("Bsr", STK_Bsr, 1);
-		PrsAddSymbol("DbgPutS", STK_PutS, 1);
-		PrsAddSymbol("PutS", STK_PutS, 1);
-		PrsAddSymbol("SetFs", STK_SetHolyFs, 1);
-		PrsAddSymbol("Fs", GetHolyFs, 0); // Gs just calls Thread local storage on linux(not mutations in saved registers)
-		PrsAddSymbol("SpawnCore", STK_SpawnCore, 3);
-		PrsAddSymbol("MPSleepHP", STK_MPSleepHP, 1);
-		PrsAddSymbol("MPAwake", STK_MPAwake, 1);
-		PrsAddSymbol("mp_cnt", STK_mp_cnt, 0);
-		PrsAddSymbol("Gs", GetHolyGs, 0); // Gs just calls Thread local storage on linux(not mutations in saved registers)
-		PrsAddSymbol("SetGs", STK_SetHolyGs, 1);
-		PrsAddSymbol("__GetTicks", STK___GetTicks, 0);
-		PrsAddSymbol("__Sleep", STK___Sleep, 1);
-		PrsAddSymbol("ImportSymbolsToHolyC", STK_ImportSymbolsToHolyC, 1);
-		// These dudes will expected to return to a location on the stack,SO DONT MUDDY THE STACK WITH ABI "translations"
-		PrsAddSymbolNaked("AIWNIOS_SetJmp", AIWNIOS_getcontext, 1);
-		PrsAddSymbolNaked("AIWNIOS_LongJmp", AIWNIOS_setcontext, 1);
-		PrsAddSymbolNaked("Call", TempleOS_CallN, 3);
-		PrsAddSymbol("__HC_ICAdd_GetVargsPtr",STK___HC_ICAdd_GetVargsPtr,1);
-		PrsAddSymbol("IsValidPtr", STK_IsValidPtr, 1);
-		PrsAddSymbol("__HC_CmpCtrl_SetAOT", STK___HC_CmpCtrl_SetAOT, 1);
-		PrsAddSymbol("__HC_ICAdd_Typecast", STK___HC_ICAdd_Typecast, 3);
-		PrsAddSymbol("__HC_ICAdd_SubCall", STK___HC_ICAdd_SubCall, 2);
-		PrsAddSymbol("__HC_ICAdd_SubProlog", STK___HC_ICAdd_SubProlog, 1);
-		PrsAddSymbol("__HC_ICAdd_SubRet", STK___HC_ICAdd_SubRet, 1);
-		PrsAddSymbol("__HC_ICAdd_BoundedSwitch", STK___HC_ICAdd_Switch, 3);
-		PrsAddSymbol("__HC_ICAdd_UnboundedSwitch", STK___HC_ICAdd_UnboundedSwitch, 2);
-		PrsAddSymbol("__HC_ICAdd_PreInc", STK___HC_ICAdd_PreInc, 2);
-		PrsAddSymbol("__HC_ICAdd_Call", STK___HC_ICAdd_Call, 4);
-		PrsAddSymbol("__HC_ICAdd_F64", STK___HC_ICAdd_F64, 2);
-		PrsAddSymbol("__HC_ICAdd_I64", STK___HC_ICAdd_I64, 2);
-		PrsAddSymbol("__HC_ICAdd_PreDec", STK___HC_ICAdd_PreDec, 2);
-		PrsAddSymbol("__HC_ICAdd_PostDec", STK___HC_ICAdd_PostDec, 2);
-		PrsAddSymbol("__HC_ICAdd_PostInc", STK___HC_ICAdd_PostInc, 2);
-		PrsAddSymbol("__HC_ICAdd_Pow", STK___HC_ICAdd_Pow, 1);
-		PrsAddSymbol("__HC_ICAdd_Eq", STK___HC_ICAdd_Eq, 1);
-		PrsAddSymbol("__HC_ICAdd_Div", STK___HC_ICAdd_Div, 1);
-		PrsAddSymbol("__HC_ICAdd_Sub", STK___HC_ICAdd_Sub, 1);
-		PrsAddSymbol("__HC_ICAdd_Mul", STK___HC_ICAdd_Mul, 1);
-		PrsAddSymbol("__HC_ICAdd_Add", STK___HC_ICAdd_Add, 1);
-		PrsAddSymbol("__HC_ICAdd_Deref", STK___HC_ICAdd_Deref, 3);
-		PrsAddSymbol("__HC_ICAdd_Comma", STK___HC_ICAdd_Comma, 1);
-		PrsAddSymbol("__HC_ICAdd_Addr", STK___HC_ICAdd_Addr, 1);
-		PrsAddSymbol("__HC_ICAdd_Xor", STK___HC_ICAdd_Xor, 1);
-		PrsAddSymbol("__HC_ICAdd_Mod", STK___HC_ICAdd_Mod, 1);
-		PrsAddSymbol("__HC_ICAdd_Or", STK___HC_ICAdd_Or, 1);
-		PrsAddSymbol("__HC_ICAdd_Lt", STK___HC_ICAdd_Lt, 1);
-		PrsAddSymbol("__HC_ICAdd_Gt", STK___HC_ICAdd_Gt, 1);
-		PrsAddSymbol("__HC_ICAdd_Le", STK___HC_ICAdd_Le, 1);
-		PrsAddSymbol("__HC_ICAdd_Ge", STK___HC_ICAdd_Ge, 1);
-		PrsAddSymbol("__HC_ICAdd_LNot", STK___HC_ICAdd_LNot, 1);
-		PrsAddSymbol("__HC_ICAdd_Vargs", STK___HC_ICAdd_Vargs, 2);
-		PrsAddSymbol("__HC_ICAdd_BNot", STK___HC_ICAdd_BNot, 1);
-		PrsAddSymbol("__HC_ICAdd_AndAnd", STK___HC_ICAdd_AndAnd, 1);
-		PrsAddSymbol("__HC_ICAdd_OrOr", STK___HC_ICAdd_OrOr, 1);
-		PrsAddSymbol("__HC_ICAdd_XorXor", STK___HC_ICAdd_XorXor, 1);
-		PrsAddSymbol("__HC_ICAdd_Ne", STK___HC_ICAdd_Ne, 1);
-		PrsAddSymbol("__HC_ICAdd_Lsh", STK___HC_ICAdd_Lsh, 1);
-		PrsAddSymbol("__HC_ICAdd_Rsh", STK___HC_ICAdd_Rsh, 1);
-		PrsAddSymbol("__HC_ICAdd_AddEq", STK___HC_ICAdd_AddEq, 1);
-		PrsAddSymbol("__HC_ICAdd_SubEq", STK___HC_ICAdd_SubEq, 1);
-		PrsAddSymbol("__HC_ICAdd_MulEq", STK___HC_ICAdd_MulEq, 1);
-		PrsAddSymbol("__HC_ICAdd_DivEq", STK___HC_ICAdd_DivEq, 1);
-		PrsAddSymbol("__HC_ICAdd_LshEq", STK___HC_ICAdd_LshEq, 1);
-		PrsAddSymbol("__HC_ICAdd_RshEq", STK___HC_ICAdd_RshEq, 1);
-		PrsAddSymbol("__HC_ICAdd_AndEq", STK___HC_ICAdd_AndEq, 1);
-		PrsAddSymbol("__HC_ICAdd_OrEq", STK___HC_ICAdd_OrEq, 1);
-		PrsAddSymbol("__HC_ICAdd_XorEq", STK___HC_ICAdd_XorEq, 1);
-		PrsAddSymbol("__HC_ICAdd_ModEq", STK___HC_ICAdd_ModEq, 1);
-		PrsAddSymbol("__HC_ICAdd_FReg", STK___HC_ICAdd_FReg, 2);
-		PrsAddSymbol("__HC_ICAdd_IReg", STK___HC_ICAdd_IReg, 4);
-		PrsAddSymbol("__HC_ICAdd_Frame", STK___HC_ICAdd_Frame, 4);
-		PrsAddSymbol("__HC_CodeMiscStrNew", STK___HC_CodeMiscStrNew, 3);
-		PrsAddSymbol("__HC_CodeMiscLabelNew", STK___HC_CodeMiscLabelNew, 2);
-		PrsAddSymbol("__HC_CmpCtrlNew", STK___HC_CmpCtrlNew, 0);
-		PrsAddSymbol("__HC_CodeCtrlPush", STK___HC_CodeCtrlPush, 1);
-		PrsAddSymbol("__HC_CodeCtrlPop", STK___HC_CodeCtrlPop, 1);
-		PrsAddSymbol("__HC_Compile", STK___HC_Compile, 3);
-		PrsAddSymbol("__HC_CodeMiscStrNew", STK___HC_CodeMiscStrNew, 3);
-		PrsAddSymbol("__HC_CodeMiscJmpTableNew", STK___HC_CodeMiscJmpTableNew, 4);
-		PrsAddSymbol("__HC_ICAdd_Label", STK___HC_ICAdd_Label, 2);
-		PrsAddSymbol("__HC_ICAdd_Goto", STK___HC_ICAdd_Goto, 2);
-		PrsAddSymbol("__HC_ICAdd_GotoIf", STK___HC_ICAdd_GotoIf, 2);
-		PrsAddSymbol("__HC_ICAdd_Str", STK___HC_ICAdd_Str, 2);
-		PrsAddSymbol("__HC_ICAdd_And", STK___HC_ICAdd_And, 1);
-		PrsAddSymbol("__HC_ICAdd_EqEq", STK___HC_ICAdd_EqEq, 1);
-		PrsAddSymbol("__HC_ICAdd_Neg", STK___HC_ICAdd_Neg, 1);
-		PrsAddSymbol("__HC_ICAdd_Ret", STK___HC_ICAdd_Ret, 1);
-		PrsAddSymbol("__HC_ICAdd_Arg", STK___HC_ICAdd_Arg, 2);
-		PrsAddSymbol("__HC_ICAdd_SetFrameSize", STK___HC_ICAdd_SetFrameSize, 2);
-		PrsAddSymbol("__HC_ICAdd_Reloc", STK___HC_ICAdd_Reloc, 6);
-		PrsAddSymbol("__HC_ICSetLine", STK___HC_ICSetLine, 2);
-		PrsAddSymbol("__HC_ICAdd_StaticRef", STK___HC_ICAdd_StaticRef, 4);
-		PrsAddSymbol("__HC_ICAdd_StaticData", STK___HC_ICAdd_StaticData, 5);
-		PrsAddSymbol("__HC_ICAdd_SetStaticsSize", STK___HC_ICAdd_SetStaticsSize, 2);
-		PrsAddSymbol("__HC_ICAdd_ToI64", STK___HC_ICAdd_ToI64, 1);
-		PrsAddSymbol("__HC_ICAdd_ToF64", STK___HC_ICAdd_ToF64, 1);
-		PrsAddSymbol("__HC_ICAdd_ShortAddr", STK___HC_ICAdd_ShortAddr, 4);
-		PrsAddSymbol("__HC_CodeMiscInterateThroughRefs", STK___HC_CodeMiscInterateThroughRefs, 3);
-		PrsAddSymbol("__HC_ICAdd_BT", STK___HC_ICAdd_BT, 1);
-		PrsAddSymbol("__HC_ICAdd_BTS", STK___HC_ICAdd_BTS, 1);
-		PrsAddSymbol("__HC_ICAdd_BTR", STK___HC_ICAdd_BTR, 1);
-		PrsAddSymbol("__HC_ICAdd_BTC", STK___HC_ICAdd_BTC, 1);
-		PrsAddSymbol("__HC_ICAdd_LBTS", STK___HC_ICAdd_LBTS, 1);
-		PrsAddSymbol("__HC_ICAdd_LBTR", STK___HC_ICAdd_LBTR, 1);
-		PrsAddSymbol("__HC_ICAdd_LBTC", STK___HC_ICAdd_LBTC, 1);
-		PrsAddSymbol("Caller", STK_Misc_Caller, 1);
-		PrsAddSymbol("VFsSetPwd", STK_VFsSetPwd, 1);
-		PrsAddSymbol("VFsExists", STK_VFsFileExists, 1);
-		PrsAddSymbol("VFsIsDir", STK_VFsIsDir, 1);
-		PrsAddSymbol("VFsFSize", STK_VFsFSize, 1);
-		PrsAddSymbol("VFsFRead", STK_VFsFileRead, 2);
-		PrsAddSymbol("VFsFWrite", STK_VFsFileWrite, 3);
-		PrsAddSymbol("VFsDel", STK_VFsDel, 1);
-		PrsAddSymbol("VFsDir", STK_VFsDir, 0);
-		PrsAddSymbol("VFsDirMk", STK_VFsDirMk, 1);
-		PrsAddSymbol("VFsFBlkRead", STK_VFsBlkRead, 4);
-		PrsAddSymbol("VFsFBlkWrite", STK_VFsBlkWrite, 4);
-		PrsAddSymbol("VFsFOpenW", STK_VFsFOpenW, 1);
-		PrsAddSymbol("VFsFOpenR", STK_VFsFOpenR, 1);
-		PrsAddSymbol("VFsFClose", STK_VFsFClose, 1);
-		PrsAddSymbol("VFsFSeek", STK_VFsFSeek, 2);
-		PrsAddSymbol("VFsSetDrv", STK_VFsSetDrv, 1);
-		PrsAddSymbol("FUnixTime", STK_VFsUnixTime, 1);
-		PrsAddSymbol("FSize", STK_VFsFSize, 1);
-		PrsAddSymbol("VFsFTrunc", STK_VFsTrunc, 2);
-		PrsAddSymbol("UnixNow", STK_UnixNow, 0);
-		PrsAddSymbol("__GrPaletteColorSet", STK_GrPaletteColorSet, 2);
-		PrsAddSymbol("DrawWindowNew", STK_DrawWindowNew, 0);
-		PrsAddSymbol("UpdateScreen", STK_UpdateScreen, 4);
-		PrsAddSymbol("SetKBCallback", STK_SetKBCallback, 1);
-		PrsAddSymbol("SndFreq", STK_SndFreq, 1);
-		PrsAddSymbol("SetMSCallback", STK_SetMSCallback, 1);
-		PrsAddSymbol("InteruptCore", STK_InteruptCore, 1);
-		PrsAddSymbol("ExitAiwnios",ExitAiwnios,0);
-		PrsAddSymbol("NetSocketNew",STK_NetSocketNew,0);
-		PrsAddSymbol("NetBindIn",STK_NetBindIn,2);
-		PrsAddSymbol("NetListen",STK_NetListen,2);
-		PrsAddSymbol("NetAccept",STK_NetAccept,2);
-		PrsAddSymbol("NetClose",STK_NetClose,1);
-		PrsAddSymbol("NetRead",STK_NetRead,3);
-		PrsAddSymbol("NetWrite",STK_NetWrite,3);
-		PrsAddSymbol("NetPollForHangup",STK_NetPollForHangup,2);
-		PrsAddSymbol("NetPollForRead",STK_NetPollForRead,2);
-		PrsAddSymbol("NetPollForWrite",STK_NetPollForWrite,2);
-		PrsAddSymbol("NetAddrDel",STK_NetAddrDel,1);
-		PrsAddSymbol("NetAddrNew",STK_NetAddrNew,2);
-	}
+void BootAiwnios(char *bootstrap_text) {
+  // Run a dummy expression to link the functions into the hash table
+  CLexer *lex = LexerNew("None", !bootstrap_text ? "1+1;" : bootstrap_text);
+  CCmpCtrl *ccmp = CmpCtrlNew(lex);
+  void (*to_run)();
+  CodeCtrlPush(ccmp);
+  Lex(lex);
+  while (PrsStmt(ccmp)) {
+    to_run = Compile(ccmp, NULL, NULL);
+    FFI_CALL_TOS_0(to_run);
+    A_FREE(to_run);
+    CodeCtrlPop(ccmp);
+    CodeCtrlPush(ccmp);
+    // TODO make a better way of doing this
+    PrsAddSymbol("MPSetProfilerInt", STK_MPSetProfilerInt, 3);
+    PrsAddSymbol("BoundsCheck", STK_BoundsCheck, 2);
+    PrsAddSymbol("TaskContextSetRIP", STK_TaskContextSetRIP, 2);
+    PrsAddSymbol("MakeContext", STK_AIWNIOS_makecontext, 3);
+    PrsAddSymbol("__HC_ICAdd_RawBytes", STK__HC_ICAdd_RawBytes, 3);
+    PrsAddSymbol("__HC_SetAOTRelocBeforeRIP", STK___HC_SetAOTRelocBeforeRIP, 2);
+    PrsAddSymbol("__HC_CodeMiscIsUsed", STK___HC_CodeMiscIsUsed, 1);
+    PrsAddSymbol("AiwniosSetClipboard", STK_AiwniosSetClipboard, 1);
+    PrsAddSymbol("AiwniosGetClipboard", STK_AiwniosGetClipboard, 0);
+    PrsAddSymbol("__HC_CmpCtrlDel", STK_CmpCtrlDel, 1);
+    PrsAddSymbol("Cos", STK_cos, 1);
+    PrsAddSymbol("Sin", STK_sin, 1);
+    PrsAddSymbol("Tan", STK_tan, 1);
+    PrsAddSymbol("Arg", STK_Arg, 2);
+    PrsAddSymbol("ACos", STK_acos, 1);
+    PrsAddSymbol("ASin", STK_asin, 1);
+    PrsAddSymbol("ATan", STK_atan, 1);
+    PrsAddSymbol("Exp", STK_exp, 1);
+    PrsAddSymbol("Btc", STK_Misc_Btc, 2);
+    PrsAddSymbol("HeapCtrlInit", STK_HeapCtrlInit, 3);
+    PrsAddSymbol("HeapCtrlDel", STK_HeapCtrlDel, 1);
+    PrsAddSymbol("__MAlloc", STK___AIWNIOS_MAlloc, 2);
+    PrsAddSymbol("__CAlloc", STK___AIWNIOS_CAlloc, 2);
+    PrsAddSymbol("Free", STK___AIWNIOS_Free, 1);
+    PrsAddSymbol("MSize", STK_MSize, 1);
+    PrsAddSymbol("__SleepHP", STK___SleepHP, 1);
+    PrsAddSymbol("__GetTicksHP", STK___GetTicksHP, 0);
+    PrsAddSymbol("__StrNew", STK___AIWNIOS_StrDup, 2);
+    PrsAddSymbol("MemCpy", STK_memcpy, 3);
+    PrsAddSymbol("MemSet", STK_memset, 3);
+    PrsAddSymbol("MemSetU16", STK_MemSetU16, 3);
+    PrsAddSymbol("MemSetU32", STK_MemSetU32, 3);
+    PrsAddSymbol("MemSetU64", STK_MemSetU64, 3);
+    PrsAddSymbol("StrLen", STK_strlen, 1);
+    PrsAddSymbol("StrCmp", STK_strcmp, 2);
+    PrsAddSymbol("ToUpper", STK_toupper, 1);
+    PrsAddSymbol("Log10", STK_log10, 1);
+    PrsAddSymbol("Log2", STK_log2, 1);
+    PrsAddSymbol("Pow10", STK_Pow10, 1);
+    PrsAddSymbol("Pow", STK_pow, 2);
+    PrsAddSymbol("PrintI", STK_PrintI, 2);
+    PrsAddSymbol("PrintF", STK_PrintF, 2);
+    PrsAddSymbol("Round", STK_round, 1);
+    PrsAddSymbol("Ln", STK_log, 1);
+    PrsAddSymbol("Floor", STK_floor, 1);
+    PrsAddSymbol("Ceil", STK_ceil, 1);
+    PrsAddSymbol("Sqrt", STK_sqrt, 1);
+    PrsAddSymbol("MemCmp", STK_memcmp, 3);
+    PrsAddSymbol("Bt", STK_Misc_Bt, 2);
+    PrsAddSymbol("LBtc", STK_Misc_LBtc, 2);
+    PrsAddSymbol("LBts", STK_Misc_LBts, 2);
+    PrsAddSymbol("LBtr", STK_Misc_LBtr, 2);
+    PrsAddSymbol("Bts", STK_Misc_Bts, 2);
+    PrsAddSymbol("Btr", STK_Misc_Btr, 2);
+    PrsAddSymbol("Bsf", STK_Bsf, 1);
+    PrsAddSymbol("Bsr", STK_Bsr, 1);
+    PrsAddSymbol("DbgPutS", STK_PutS, 1);
+    PrsAddSymbol("PutS", STK_PutS, 1);
+    PrsAddSymbol("SetFs", STK_SetHolyFs, 1);
+    PrsAddSymbol("Fs", GetHolyFs, 0); // Gs just calls Thread local storage on
+                                      // linux(not mutations in saved registers)
+    PrsAddSymbol("SpawnCore", STK_SpawnCore, 3);
+    PrsAddSymbol("MPSleepHP", STK_MPSleepHP, 1);
+    PrsAddSymbol("MPAwake", STK_MPAwake, 1);
+    PrsAddSymbol("mp_cnt", STK_mp_cnt, 0);
+    PrsAddSymbol("Gs", GetHolyGs, 0); // Gs just calls Thread local storage on
+                                      // linux(not mutations in saved registers)
+    PrsAddSymbol("SetGs", STK_SetHolyGs, 1);
+    PrsAddSymbol("__GetTicks", STK___GetTicks, 0);
+    PrsAddSymbol("__Sleep", STK___Sleep, 1);
+    PrsAddSymbol("ImportSymbolsToHolyC", STK_ImportSymbolsToHolyC, 1);
+    // These dudes will expected to return to a location on the stack,SO DONT
+    // MUDDY THE STACK WITH ABI "translations"
+    PrsAddSymbolNaked("AIWNIOS_SetJmp", AIWNIOS_getcontext, 1);
+    PrsAddSymbolNaked("AIWNIOS_LongJmp", AIWNIOS_setcontext, 1);
+    PrsAddSymbolNaked("Call", TempleOS_CallN, 3);
+    PrsAddSymbol("__HC_ICAdd_GetVargsPtr", STK___HC_ICAdd_GetVargsPtr, 1);
+    PrsAddSymbol("IsValidPtr", STK_IsValidPtr, 1);
+    PrsAddSymbol("__HC_CmpCtrl_SetAOT", STK___HC_CmpCtrl_SetAOT, 1);
+    PrsAddSymbol("__HC_ICAdd_Typecast", STK___HC_ICAdd_Typecast, 3);
+    PrsAddSymbol("__HC_ICAdd_SubCall", STK___HC_ICAdd_SubCall, 2);
+    PrsAddSymbol("__HC_ICAdd_SubProlog", STK___HC_ICAdd_SubProlog, 1);
+    PrsAddSymbol("__HC_ICAdd_SubRet", STK___HC_ICAdd_SubRet, 1);
+    PrsAddSymbol("__HC_ICAdd_BoundedSwitch", STK___HC_ICAdd_Switch, 3);
+    PrsAddSymbol("__HC_ICAdd_UnboundedSwitch", STK___HC_ICAdd_UnboundedSwitch,
+                 2);
+    PrsAddSymbol("__HC_ICAdd_PreInc", STK___HC_ICAdd_PreInc, 2);
+    PrsAddSymbol("__HC_ICAdd_Call", STK___HC_ICAdd_Call, 4);
+    PrsAddSymbol("__HC_ICAdd_F64", STK___HC_ICAdd_F64, 2);
+    PrsAddSymbol("__HC_ICAdd_I64", STK___HC_ICAdd_I64, 2);
+    PrsAddSymbol("__HC_ICAdd_PreDec", STK___HC_ICAdd_PreDec, 2);
+    PrsAddSymbol("__HC_ICAdd_PostDec", STK___HC_ICAdd_PostDec, 2);
+    PrsAddSymbol("__HC_ICAdd_PostInc", STK___HC_ICAdd_PostInc, 2);
+    PrsAddSymbol("__HC_ICAdd_Pow", STK___HC_ICAdd_Pow, 1);
+    PrsAddSymbol("__HC_ICAdd_Eq", STK___HC_ICAdd_Eq, 1);
+    PrsAddSymbol("__HC_ICAdd_Div", STK___HC_ICAdd_Div, 1);
+    PrsAddSymbol("__HC_ICAdd_Sub", STK___HC_ICAdd_Sub, 1);
+    PrsAddSymbol("__HC_ICAdd_Mul", STK___HC_ICAdd_Mul, 1);
+    PrsAddSymbol("__HC_ICAdd_Add", STK___HC_ICAdd_Add, 1);
+    PrsAddSymbol("__HC_ICAdd_Deref", STK___HC_ICAdd_Deref, 3);
+    PrsAddSymbol("__HC_ICAdd_Comma", STK___HC_ICAdd_Comma, 1);
+    PrsAddSymbol("__HC_ICAdd_Addr", STK___HC_ICAdd_Addr, 1);
+    PrsAddSymbol("__HC_ICAdd_Xor", STK___HC_ICAdd_Xor, 1);
+    PrsAddSymbol("__HC_ICAdd_Mod", STK___HC_ICAdd_Mod, 1);
+    PrsAddSymbol("__HC_ICAdd_Or", STK___HC_ICAdd_Or, 1);
+    PrsAddSymbol("__HC_ICAdd_Lt", STK___HC_ICAdd_Lt, 1);
+    PrsAddSymbol("__HC_ICAdd_Gt", STK___HC_ICAdd_Gt, 1);
+    PrsAddSymbol("__HC_ICAdd_Le", STK___HC_ICAdd_Le, 1);
+    PrsAddSymbol("__HC_ICAdd_Ge", STK___HC_ICAdd_Ge, 1);
+    PrsAddSymbol("__HC_ICAdd_LNot", STK___HC_ICAdd_LNot, 1);
+    PrsAddSymbol("__HC_ICAdd_Vargs", STK___HC_ICAdd_Vargs, 2);
+    PrsAddSymbol("__HC_ICAdd_BNot", STK___HC_ICAdd_BNot, 1);
+    PrsAddSymbol("__HC_ICAdd_AndAnd", STK___HC_ICAdd_AndAnd, 1);
+    PrsAddSymbol("__HC_ICAdd_OrOr", STK___HC_ICAdd_OrOr, 1);
+    PrsAddSymbol("__HC_ICAdd_XorXor", STK___HC_ICAdd_XorXor, 1);
+    PrsAddSymbol("__HC_ICAdd_Ne", STK___HC_ICAdd_Ne, 1);
+    PrsAddSymbol("__HC_ICAdd_Lsh", STK___HC_ICAdd_Lsh, 1);
+    PrsAddSymbol("__HC_ICAdd_Rsh", STK___HC_ICAdd_Rsh, 1);
+    PrsAddSymbol("__HC_ICAdd_AddEq", STK___HC_ICAdd_AddEq, 1);
+    PrsAddSymbol("__HC_ICAdd_SubEq", STK___HC_ICAdd_SubEq, 1);
+    PrsAddSymbol("__HC_ICAdd_MulEq", STK___HC_ICAdd_MulEq, 1);
+    PrsAddSymbol("__HC_ICAdd_DivEq", STK___HC_ICAdd_DivEq, 1);
+    PrsAddSymbol("__HC_ICAdd_LshEq", STK___HC_ICAdd_LshEq, 1);
+    PrsAddSymbol("__HC_ICAdd_RshEq", STK___HC_ICAdd_RshEq, 1);
+    PrsAddSymbol("__HC_ICAdd_AndEq", STK___HC_ICAdd_AndEq, 1);
+    PrsAddSymbol("__HC_ICAdd_OrEq", STK___HC_ICAdd_OrEq, 1);
+    PrsAddSymbol("__HC_ICAdd_XorEq", STK___HC_ICAdd_XorEq, 1);
+    PrsAddSymbol("__HC_ICAdd_ModEq", STK___HC_ICAdd_ModEq, 1);
+    PrsAddSymbol("__HC_ICAdd_FReg", STK___HC_ICAdd_FReg, 2);
+    PrsAddSymbol("__HC_ICAdd_IReg", STK___HC_ICAdd_IReg, 4);
+    PrsAddSymbol("__HC_ICAdd_Frame", STK___HC_ICAdd_Frame, 4);
+    PrsAddSymbol("__HC_CodeMiscStrNew", STK___HC_CodeMiscStrNew, 3);
+    PrsAddSymbol("__HC_CodeMiscLabelNew", STK___HC_CodeMiscLabelNew, 2);
+    PrsAddSymbol("__HC_CmpCtrlNew", STK___HC_CmpCtrlNew, 0);
+    PrsAddSymbol("__HC_CodeCtrlPush", STK___HC_CodeCtrlPush, 1);
+    PrsAddSymbol("__HC_CodeCtrlPop", STK___HC_CodeCtrlPop, 1);
+    PrsAddSymbol("__HC_Compile", STK___HC_Compile, 3);
+    PrsAddSymbol("__HC_CodeMiscStrNew", STK___HC_CodeMiscStrNew, 3);
+    PrsAddSymbol("__HC_CodeMiscJmpTableNew", STK___HC_CodeMiscJmpTableNew, 4);
+    PrsAddSymbol("__HC_ICAdd_Label", STK___HC_ICAdd_Label, 2);
+    PrsAddSymbol("__HC_ICAdd_Goto", STK___HC_ICAdd_Goto, 2);
+    PrsAddSymbol("__HC_ICAdd_GotoIf", STK___HC_ICAdd_GotoIf, 2);
+    PrsAddSymbol("__HC_ICAdd_Str", STK___HC_ICAdd_Str, 2);
+    PrsAddSymbol("__HC_ICAdd_And", STK___HC_ICAdd_And, 1);
+    PrsAddSymbol("__HC_ICAdd_EqEq", STK___HC_ICAdd_EqEq, 1);
+    PrsAddSymbol("__HC_ICAdd_Neg", STK___HC_ICAdd_Neg, 1);
+    PrsAddSymbol("__HC_ICAdd_Ret", STK___HC_ICAdd_Ret, 1);
+    PrsAddSymbol("__HC_ICAdd_Arg", STK___HC_ICAdd_Arg, 2);
+    PrsAddSymbol("__HC_ICAdd_SetFrameSize", STK___HC_ICAdd_SetFrameSize, 2);
+    PrsAddSymbol("__HC_ICAdd_Reloc", STK___HC_ICAdd_Reloc, 6);
+    PrsAddSymbol("__HC_ICSetLine", STK___HC_ICSetLine, 2);
+    PrsAddSymbol("__HC_ICAdd_StaticRef", STK___HC_ICAdd_StaticRef, 4);
+    PrsAddSymbol("__HC_ICAdd_StaticData", STK___HC_ICAdd_StaticData, 5);
+    PrsAddSymbol("__HC_ICAdd_SetStaticsSize", STK___HC_ICAdd_SetStaticsSize, 2);
+    PrsAddSymbol("__HC_ICAdd_ToI64", STK___HC_ICAdd_ToI64, 1);
+    PrsAddSymbol("__HC_ICAdd_ToF64", STK___HC_ICAdd_ToF64, 1);
+    PrsAddSymbol("__HC_ICAdd_ShortAddr", STK___HC_ICAdd_ShortAddr, 4);
+    PrsAddSymbol("__HC_CodeMiscInterateThroughRefs",
+                 STK___HC_CodeMiscInterateThroughRefs, 3);
+    PrsAddSymbol("__HC_ICAdd_BT", STK___HC_ICAdd_BT, 1);
+    PrsAddSymbol("__HC_ICAdd_BTS", STK___HC_ICAdd_BTS, 1);
+    PrsAddSymbol("__HC_ICAdd_BTR", STK___HC_ICAdd_BTR, 1);
+    PrsAddSymbol("__HC_ICAdd_BTC", STK___HC_ICAdd_BTC, 1);
+    PrsAddSymbol("__HC_ICAdd_LBTS", STK___HC_ICAdd_LBTS, 1);
+    PrsAddSymbol("__HC_ICAdd_LBTR", STK___HC_ICAdd_LBTR, 1);
+    PrsAddSymbol("__HC_ICAdd_LBTC", STK___HC_ICAdd_LBTC, 1);
+    PrsAddSymbol("Caller", STK_Misc_Caller, 1);
+    PrsAddSymbol("VFsSetPwd", STK_VFsSetPwd, 1);
+    PrsAddSymbol("VFsExists", STK_VFsFileExists, 1);
+    PrsAddSymbol("VFsIsDir", STK_VFsIsDir, 1);
+    PrsAddSymbol("VFsFSize", STK_VFsFSize, 1);
+    PrsAddSymbol("VFsFRead", STK_VFsFileRead, 2);
+    PrsAddSymbol("VFsFWrite", STK_VFsFileWrite, 3);
+    PrsAddSymbol("VFsDel", STK_VFsDel, 1);
+    PrsAddSymbol("VFsDir", STK_VFsDir, 0);
+    PrsAddSymbol("VFsDirMk", STK_VFsDirMk, 1);
+    PrsAddSymbol("VFsFBlkRead", STK_VFsBlkRead, 4);
+    PrsAddSymbol("VFsFBlkWrite", STK_VFsBlkWrite, 4);
+    PrsAddSymbol("VFsFOpenW", STK_VFsFOpenW, 1);
+    PrsAddSymbol("VFsFOpenR", STK_VFsFOpenR, 1);
+    PrsAddSymbol("VFsFClose", STK_VFsFClose, 1);
+    PrsAddSymbol("VFsFSeek", STK_VFsFSeek, 2);
+    PrsAddSymbol("VFsSetDrv", STK_VFsSetDrv, 1);
+    PrsAddSymbol("FUnixTime", STK_VFsUnixTime, 1);
+    PrsAddSymbol("FSize", STK_VFsFSize, 1);
+    PrsAddSymbol("VFsFTrunc", STK_VFsTrunc, 2);
+    PrsAddSymbol("UnixNow", STK_UnixNow, 0);
+    PrsAddSymbol("__GrPaletteColorSet", STK_GrPaletteColorSet, 2);
+    PrsAddSymbol("DrawWindowNew", STK_DrawWindowNew, 0);
+    PrsAddSymbol("UpdateScreen", STK_UpdateScreen, 4);
+    PrsAddSymbol("SetKBCallback", STK_SetKBCallback, 1);
+    PrsAddSymbol("SndFreq", STK_SndFreq, 1);
+    PrsAddSymbol("SetMSCallback", STK_SetMSCallback, 1);
+    PrsAddSymbol("InteruptCore", STK_InteruptCore, 1);
+    PrsAddSymbol("ExitAiwnios", ExitAiwnios, 0);
+    PrsAddSymbol("NetSocketNew", STK_NetSocketNew, 0);
+    PrsAddSymbol("NetBindIn", STK_NetBindIn, 2);
+    PrsAddSymbol("NetListen", STK_NetListen, 2);
+    PrsAddSymbol("NetAccept", STK_NetAccept, 2);
+    PrsAddSymbol("NetClose", STK_NetClose, 1);
+    PrsAddSymbol("NetRead", STK_NetRead, 3);
+    PrsAddSymbol("NetWrite", STK_NetWrite, 3);
+    PrsAddSymbol("NetPollForHangup", STK_NetPollForHangup, 2);
+    PrsAddSymbol("NetPollForRead", STK_NetPollForRead, 2);
+    PrsAddSymbol("NetPollForWrite", STK_NetPollForWrite, 2);
+    PrsAddSymbol("NetAddrDel", STK_NetAddrDel, 1);
+    PrsAddSymbol("NetAddrNew", STK_NetAddrNew, 2);
+  }
 }
 static const char *t_drive;
-static void Boot()
-{
-	int64_t len;
-	char bin[strlen("HCRT2.BIN")+strlen(t_drive)+1+1];
-	strcpy(bin,t_drive);
-	strcat(bin,"/HCRT2.BIN");
-	Fs = calloc(sizeof(CTask), 1);
-	InstallDbgSignalsForThread();
-	TaskInit(Fs, NULL, 0);
-	VFsMountDrive('T', t_drive);
-	/*FuzzTest1();
-	FuzzTest2();
-	FuzzTest3();*/
-	if(arg_bootstrap_bin->count) {
-		#define BOOTSTRAP_FMT \
-		"#define TARGET_%s \n" \
-		"#define lastclass \"U8\"\n" \
-		"#define public \n" \
-		"#define IMPORT_AIWNIOS_SYMS 1\n" \
-		"#define TEXT_MODE 1\n" \
-		"#define BOOTSTRAP 1\n" \
-		"#include \"Src/FULL_PACKAGE.HC\";;\n" 
-		#if defined(__aarch64__) || defined(_M_ARM64)
-		len=snprintf(NULL,0,BOOTSTRAP_FMT,"AARCH64");
-		char buf[len+1];
-		sprintf(buf,BOOTSTRAP_FMT,"AARCH64");
-		#elif defined(__x86_64__)
-		len=snprintf(NULL,0,BOOTSTRAP_FMT,"X86");
-		char buf[len+1];
-		sprintf(buf,BOOTSTRAP_FMT,"X86");
-		#else
-		#error "Arch not supported"
-		#endif
-		BootAiwnios(buf);
-	} else 
-		BootAiwnios(NULL);
-	glbl_table = Fs->hash_table;
-	if (bin)
-		Load(bin);
+static void Boot() {
+  int64_t len;
+  char bin[strlen("HCRT2.BIN") + strlen(t_drive) + 1 + 1];
+  strcpy(bin, t_drive);
+  strcat(bin, "/HCRT2.BIN");
+  Fs = calloc(sizeof(CTask), 1);
+  InstallDbgSignalsForThread();
+  TaskInit(Fs, NULL, 0);
+  VFsMountDrive('T', t_drive);
+  /*FuzzTest1();
+  FuzzTest2();
+  FuzzTest3();*/
+  if (arg_bootstrap_bin->count) {
+#define BOOTSTRAP_FMT                                                          \
+  "#define TARGET_%s \n"                                                       \
+  "#define lastclass \"U8\"\n"                                                 \
+  "#define public \n"                                                          \
+  "#define IMPORT_AIWNIOS_SYMS 1\n"                                            \
+  "#define TEXT_MODE 1\n"                                                      \
+  "#define BOOTSTRAP 1\n"                                                      \
+  "#include \"Src/FULL_PACKAGE.HC\";;\n"
+#if defined(__aarch64__) || defined(_M_ARM64)
+    len = snprintf(NULL, 0, BOOTSTRAP_FMT, "AARCH64");
+    char buf[len + 1];
+    sprintf(buf, BOOTSTRAP_FMT, "AARCH64");
+#elif defined(__x86_64__)
+    len = snprintf(NULL, 0, BOOTSTRAP_FMT, "X86");
+    char buf[len + 1];
+    sprintf(buf, BOOTSTRAP_FMT, "X86");
+#else
+  #error "Arch not supported"
+#endif
+    BootAiwnios(buf);
+  } else
+    BootAiwnios(NULL);
+  glbl_table = Fs->hash_table;
+  if (bin)
+    Load(bin);
 }
 static int64_t quit = 0;
 static void ExitAiwnios() {
-	quit=1;
-	SDL_Event q;
-	memset(&q,0,sizeof q);
-	while(1) {
-		SDL_PushEvent(&q);
-		__Sleep(1000);
-	}
+  quit = 1;
+  SDL_Event q;
+  memset(&q, 0, sizeof q);
+  while (1) {
+    SDL_PushEvent(&q);
+    __Sleep(1000);
+  }
 }
-int main(int argc, char* argv[])
-{
-	t_drive=NULL;
-	int64_t errors,idx;
-	void *argtable[]={
-		arg_help=arg_lit0("h","help","Show the help message"),
-		arg_overwrite=arg_lit0("o","overwrite","Overwrite the T directory with the installed T template."),
-		arg_t_dir=arg_file0("t",NULL,"Directory","Specify the boot drive(dft is current dir)."),
-		arg_bootstrap_bin=arg_lit0("b","bootstrap","Build a new binary with the \"slim\" compiler of aiwnios."),
-		arg_asan_enable=arg_lit0("a","address-sanitize","Enable bounds checking."),
-		arg_new_boot_dir=arg_lit0("n","new-boot-dir","Create a new boot directory(backs up old boot directory if present)."),
-		_arg_end=arg_end(20)
-	};
-	errors=arg_parse(argc,argv,argtable);
-	if(errors||arg_help->count) {
-		if(errors)
-			arg_print_errors(stdout,_arg_end,"aiwnios");
-		printf("Usage: aiwnios\n");
-		arg_print_glossary(stdout,argtable,"  %-25s %s\n");
-		exit(1);
-	}
-	if(arg_asan_enable->count)
-		InitBoundsChecker();
-	if(arg_t_dir->count)
-		t_drive=arg_t_dir->filename[0];
-	else if(arg_bootstrap_bin->count)
-		t_drive="."; //Bootstrap in current directory
-	if((!arg_t_dir->count||arg_overwrite->count)&&!arg_bootstrap_bin->count)
-		t_drive=ResolveBootDir(!t_drive?"T":t_drive,arg_overwrite->count,arg_new_boot_dir->count);
-	SDL_Init(SDL_INIT_TIMER);
-	SDL_Init(SDL_INIT_EVENTS);
-	InitSound();
-	user_ev_num = SDL_RegisterEvents(1);
-	SpawnCore(&Boot, NULL, 0);
-	InputLoop(&quit);
-	for(idx=0;idx!=mp_cnt();idx++)
-		__ShutdownCore(idx);
-	SDL_Quit();
-	arg_freetable(argtable,sizeof(argtable)/sizeof(*argtable));
-	return EXIT_SUCCESS;
+
+#ifdef main
+  #undef main
+#endif
+int main(int argc, char **argv) {
+  t_drive = NULL;
+  int64_t errors, idx;
+  void *argtable[] = {
+      arg_help = arg_lit0("h", "help", "Show the help message"),
+      arg_overwrite =
+          arg_lit0("o", "overwrite",
+                   "Overwrite the T directory with the installed T template."),
+      arg_t_dir = arg_file0("t", NULL, "Directory",
+                            "Specify the boot drive(dft is current dir)."),
+      arg_bootstrap_bin =
+          arg_lit0("b", "bootstrap",
+                   "Build a new binary with the \"slim\" compiler of aiwnios."),
+      arg_asan_enable =
+          arg_lit0("a", "address-sanitize", "Enable bounds checking."),
+      arg_new_boot_dir = arg_lit0("n", "new-boot-dir",
+                                  "Create a new boot directory(backs up old "
+                                  "boot directory if present)."),
+      _arg_end = arg_end(20)};
+  errors = arg_parse(argc, argv, argtable);
+  if (errors || arg_help->count) {
+    if (errors)
+      arg_print_errors(stdout, _arg_end, "aiwnios");
+    printf("Usage: aiwnios\n");
+    arg_print_glossary(stdout, argtable, "  %-25s %s\n");
+    exit(1);
+  }
+  if (arg_asan_enable->count)
+    InitBoundsChecker();
+  if (arg_t_dir->count)
+    t_drive = arg_t_dir->filename[0];
+  else if (arg_bootstrap_bin->count)
+    t_drive = "."; // Bootstrap in current directory
+  if ((!arg_t_dir->count || arg_overwrite->count) && !arg_bootstrap_bin->count)
+    t_drive = ResolveBootDir(!t_drive ? "T" : t_drive, arg_overwrite->count,
+                             arg_new_boot_dir->count);
+  SDL_Init(SDL_INIT_TIMER);
+  SDL_Init(SDL_INIT_EVENTS);
+  InitSound();
+  user_ev_num = SDL_RegisterEvents(1);
+  SpawnCore(&Boot, NULL, 0);
+  InputLoop(&quit);
+  for (idx = 0; idx != mp_cnt(); idx++)
+    __ShutdownCore(idx);
+  SDL_Quit();
+  arg_freetable(argtable, sizeof(argtable) / sizeof(*argtable));
+  return EXIT_SUCCESS;
 }

--- a/main.c
+++ b/main.c
@@ -7,7 +7,8 @@
 #include <stdio.h>
 #include <time.h>
 #include <unistd.h>
-struct arg_lit *arg_help, *arg_overwrite, *arg_new_boot_dir, *arg_asan_enable;
+struct arg_lit *arg_help, *arg_overwrite, *arg_new_boot_dir, *arg_asan_enable,
+    *sixty_fps;
 struct arg_file *arg_t_dir, *arg_bootstrap_bin;
 static struct arg_end *_arg_end;
 #ifdef AIWNIOS_TESTS
@@ -281,6 +282,9 @@ static void *MemSetU64(int64_t *dst, int64_t with, int64_t cnt) {
 }
 static void PutS(char *s) {
   printf("%s", s);
+}
+static uint64_t STK_60fps(uint64_t *stk) {
+  return sixty_fps->count != 0;
 }
 
 // This a "symbolic" Fs only used from the HolyC part
@@ -1308,6 +1312,7 @@ void BootAiwnios(char *bootstrap_text) {
     PrsAddSymbol("NetPollForWrite", STK_NetPollForWrite, 2);
     PrsAddSymbol("NetAddrDel", STK_NetAddrDel, 1);
     PrsAddSymbol("NetAddrNew", STK_NetAddrNew, 2);
+    PrsAddSymbol("_SixtyFPS", STK_60fps, 0);
   }
 }
 static const char *t_drive;
@@ -1382,7 +1387,9 @@ int main(int argc, char **argv) {
       arg_new_boot_dir = arg_lit0("n", "new-boot-dir",
                                   "Create a new boot directory(backs up old "
                                   "boot directory if present)."),
-      _arg_end = arg_end(20)};
+      sixty_fps = arg_lit0("6", "60fps", "Run in 60 fps mode."),
+      _arg_end = arg_end(20),
+  };
   errors = arg_parse(argc, argv, argtable);
   if (errors || arg_help->count) {
     if (errors)

--- a/mem.c
+++ b/mem.c
@@ -2,10 +2,10 @@
 #include "aiwn.h"
 #include <stdint.h>
 #if defined(_WIN32) || defined(WIN32)
-#include <memoryapi.h>
-#include <sysinfoapi.h>
+  #include <memoryapi.h>
+  #include <sysinfoapi.h>
 #else
-#include <sys/mman.h>
+  #include <sys/mman.h>
 #endif
 //
 // Dec 8, I volenterreed today
@@ -15,402 +15,405 @@ struct CTask;
 struct CMemBlk;
 struct CMemUnused;
 
-//Bounds checker works like this.
-//All allocations will be in first 32bits
-//There will be a bitmap of "good" 8bytes(this is ok as most accesses are 8 bytes wide)
-//Beacuse the address space will be 2 GB,we can have a fixed length bitmap of 2GB/8/64 int64_t's
-//and i can Misc_Bt it to check if it is valid
+// Bounds checker works like this.
+// All allocations will be in first 32bits
+// There will be a bitmap of "good" 8bytes(this is ok as most accesses are 8
+// bytes wide) Beacuse the address space will be 2 GB,we can have a fixed length
+// bitmap of 2GB/8/64 int64_t's and i can Misc_Bt it to check if it is valid
 //
-int64_t bc_enable=0;
+int64_t bc_enable = 0;
 static char *bc_good_bitmap;
 void InitBoundsChecker() {
-	int64_t want=(1ll<<31)/8;
-	bc_good_bitmap=calloc(want,1);
-	bc_enable=1;
+  int64_t want = (1ll << 31) / 8;
+  bc_good_bitmap = calloc(want, 1);
+  bc_enable = 1;
 }
-static void MemPagTaskFree(CMemBlk* blk, CHeapCtrl* hc)
-{
-	QueRem(blk);
-	hc->alloced_u8s -= blk->pags * MEM_PAG_SIZE;
+static void MemPagTaskFree(CMemBlk *blk, CHeapCtrl *hc) {
+  QueRem(blk);
+  hc->alloced_u8s -= blk->pags * MEM_PAG_SIZE;
 #if defined(_WIN32) || defined(WIN32)
-	VirtualFree(blk, 0, MEM_RELEASE);
+  VirtualFree(blk, 0, MEM_RELEASE);
 #else
-	static int64_t ps;
-	int64_t b;
-	if (!ps)
-		ps = sysconf(_SC_PAGE_SIZE);
-	b = blk->pags * MEM_PAG_SIZE;
-	if (b % ps)
-		b += ps;
-	b /= ps;
-	b *= ps;
-	munmap(blk, b);
+  static int64_t ps;
+  int64_t b;
+  if (!ps)
+    ps = sysconf(_SC_PAGE_SIZE);
+  b = blk->pags * MEM_PAG_SIZE;
+  if (b % ps)
+    b += ps;
+  b /= ps;
+  b *= ps;
+  munmap(blk, b);
 #endif
 }
-static int64_t Hex2I64(char* ptr, char** _res);
+static int64_t Hex2I64(char *ptr, char **_res);
 static void *GetAvailRegion32(int64_t b);
-static CMemBlk* MemPagTaskAlloc(int64_t pags, CHeapCtrl* hc)
-{
-	if (!hc)
-		hc = Fs->heap;
+static CMemBlk *MemPagTaskAlloc(int64_t pags, CHeapCtrl *hc) {
+  if (!hc)
+    hc = Fs->heap;
 #if defined(_WIN32) || defined(WIN32)
-	CMemBlk* ret = NULL;
-	static int64_t dwAllocationGranularity;
-	if (!dwAllocationGranularity) {
-		SYSTEM_INFO si;
-		GetSystemInfo(&si);
-		dwAllocationGranularity = si.dwAllocationGranularity;
-	}
-	int64_t b = (pags * MEM_PAG_SIZE) / dwAllocationGranularity * dwAllocationGranularity, _try, addr;
-	if ((pags * MEM_PAG_SIZE) % dwAllocationGranularity)
-		b += dwAllocationGranularity;
-	if(bc_enable) {
-		ret=VirtualAlloc(GetAvailRegion32(b),b,MEM_COMMIT|MEM_RESERVE,hc->is_code_heap?PAGE_EXECUTE_READWRITE:PAGE_READWRITE);
-	} else 
-		ret = VirtualAlloc(NULL, b, MEM_COMMIT | MEM_RESERVE, hc->is_code_heap?PAGE_EXECUTE_READWRITE:PAGE_READWRITE);
-	if (!ret)
-		return NULL;
+  CMemBlk *ret = NULL;
+  static int64_t dwAllocationGranularity;
+  if (!dwAllocationGranularity) {
+    SYSTEM_INFO si;
+    GetSystemInfo(&si);
+    dwAllocationGranularity = si.dwAllocationGranularity;
+  }
+  int64_t b = (pags * MEM_PAG_SIZE) / dwAllocationGranularity *
+              dwAllocationGranularity,
+          _try, addr;
+  if ((pags * MEM_PAG_SIZE) % dwAllocationGranularity)
+    b += dwAllocationGranularity;
+  if (bc_enable) {
+    ret = VirtualAlloc(GetAvailRegion32(b), b, MEM_COMMIT | MEM_RESERVE,
+                       hc->is_code_heap ? PAGE_EXECUTE_READWRITE
+                                        : PAGE_READWRITE);
+  } else
+    ret = VirtualAlloc(NULL, b, MEM_COMMIT | MEM_RESERVE,
+                       hc->is_code_heap ? PAGE_EXECUTE_READWRITE
+                                        : PAGE_READWRITE);
+  if (!ret)
+    return NULL;
 #else
-#if defined (__x86_64__)
-	int64_t add_flags = bc_enable||hc->is_code_heap ?MAP_32BIT:0;
-#else 
-	int64_t add_flags = 0;
+  #if defined(__x86_64__)
+  int64_t add_flags = bc_enable || hc->is_code_heap ? MAP_32BIT : 0;
+  #else
+  int64_t add_flags = 0;
+  #endif
+  static int64_t ps;
+  int64_t b;
+  if (!ps) {
+    ps = sysconf(_SC_PAGE_SIZE);
+  }
+  b = pags * MEM_PAG_SIZE;
+  if (b % ps)
+    b += ps;
+  b /= ps;
+  b *= ps;
+  CMemBlk *ret =
+      mmap(NULL, b, (hc->is_code_heap ? PROT_EXEC : 0) | PROT_READ | PROT_WRITE,
+           MAP_PRIVATE | MAP_ANONYMOUS | add_flags, -1, 0);
 #endif
-	static int64_t ps;
-	int64_t b;
-	if (!ps) {
-		ps = sysconf(_SC_PAGE_SIZE);
-	}
-	b = pags * MEM_PAG_SIZE;
-	if (b % ps)
-		b += ps;
-	b /= ps;
-	b *= ps;
-	CMemBlk* ret = mmap(NULL, b, (hc->is_code_heap?PROT_EXEC:0) | PROT_READ | PROT_WRITE,
-		MAP_PRIVATE | MAP_ANONYMOUS|add_flags, -1, 0);
-#endif
-	int64_t threshold = MEM_HEAP_HASH_SIZE >> 4, cnt;
-	CMemUnused **unm, *tmp, *tmp2;
-	QueIns(&ret->base, hc->mem_blks.last);
-	
-	ret->pags = pags;
-	// Move silly willies malloc_free_lst,in to the heap_hash
-	do {
-		cnt = 0;
-		unm = &hc->malloc_free_lst;
-		while (tmp = *unm) {
-			if (tmp->sz < threshold) {
-				*unm = tmp->next;
-				tmp->next = hc->heap_hash[tmp->sz / 8];
-				hc->heap_hash[tmp->sz / 8] = tmp;
-			} else {
-				cnt++;
-				unm = tmp;
-			}
-		}
-		threshold <<= 1;
-	} while (cnt > 8 && threshold <= MEM_HEAP_HASH_SIZE);
-	hc->alloced_u8s += pags * MEM_PAG_SIZE;
-	return ret;
+  int64_t threshold = MEM_HEAP_HASH_SIZE >> 4, cnt;
+  CMemUnused **unm, *tmp, *tmp2;
+  QueIns(&ret->base, hc->mem_blks.last);
+
+  ret->pags = pags;
+  // Move silly willies malloc_free_lst,in to the heap_hash
+  do {
+    cnt = 0;
+    unm = &hc->malloc_free_lst;
+    while (tmp = *unm) {
+      if (tmp->sz < threshold) {
+        *unm = tmp->next;
+        tmp->next = hc->heap_hash[tmp->sz / 8];
+        hc->heap_hash[tmp->sz / 8] = tmp;
+      } else {
+        cnt++;
+        unm = tmp;
+      }
+    }
+    threshold <<= 1;
+  } while (cnt > 8 && threshold <= MEM_HEAP_HASH_SIZE);
+  hc->alloced_u8s += pags * MEM_PAG_SIZE;
+  return ret;
 }
 
-void* GetFs()
-{
-	return Fs;
+void *GetFs() {
+  return Fs;
 }
-void* __AIWNIOS_MAlloc(int64_t cnt, void* t)
-{
-	if (!cnt)
-		return NULL;
-	if (!t)
-		t = Fs->heap;
-	int64_t orig=cnt;
-	cnt += 16;
-	CHeapCtrl* hc = t;
-	int64_t pags;
-	CMemUnused* ret;
-	if (hc->hc_signature != 'H')
-		hc = ((CTask*)hc)->heap;
-	if (hc->hc_signature != 'H')
-		throw('BadMAll');
-	// Rounnd up to 8
-	cnt += 7 + sizeof(CMemUnused);
-	cnt &= (int8_t)0xf8;
-	// HClF_LOCKED is 1
-	while (Misc_LBts(&hc->locked_flags, 1))
-		;
-	if (cnt > MEM_HEAP_HASH_SIZE)
-		goto big;
-	if (hc->heap_hash[cnt / 8]) {
-		ret = hc->heap_hash[cnt / 8];
-		hc->heap_hash[cnt / 8] = ret->next;
-		goto almost_done;
-	} else
-		ret = hc->malloc_free_lst;
-	if (!ret) {
-	new_lunk:
-		// Make a new lunk
-		ret = MemPagTaskAlloc(
-			(pags = ((cnt + 16 * MEM_PAG_SIZE - 1) >> MEM_PAG_BITS)) + 1, hc);
-		ret = (char*)ret + sizeof(CMemBlk);
-		ret->sz = (pags << MEM_PAG_BITS) - sizeof(CMemBlk);
-		hc->malloc_free_lst = ret;
-	}
-	// Chip off
-	//
-	// We must make sure there is room for another CMemUnused
-	//
-	if ((int64_t)(ret->sz - sizeof(CMemUnused)) >= cnt) {
-		hc->malloc_free_lst = (char*)ret + cnt;
-		hc->malloc_free_lst->sz = ret->sz - cnt;
-		ret->sz = cnt;
-		goto almost_done;
-	} else
-		goto new_lunk;
+void *__AIWNIOS_MAlloc(int64_t cnt, void *t) {
+  if (!cnt)
+    return NULL;
+  if (!t)
+    t = Fs->heap;
+  int64_t orig = cnt;
+  cnt += 16;
+  CHeapCtrl *hc = t;
+  int64_t pags;
+  CMemUnused *ret;
+  if (hc->hc_signature != 'H')
+    hc = ((CTask *)hc)->heap;
+  if (hc->hc_signature != 'H')
+    throw('BadMAll');
+  // Rounnd up to 8
+  cnt += 7 + sizeof(CMemUnused);
+  cnt &= (int8_t)0xf8;
+  // HClF_LOCKED is 1
+  while (Misc_LBts(&hc->locked_flags, 1))
+    ;
+  if (cnt > MEM_HEAP_HASH_SIZE)
+    goto big;
+  if (hc->heap_hash[cnt / 8]) {
+    ret = hc->heap_hash[cnt / 8];
+    hc->heap_hash[cnt / 8] = ret->next;
+    goto almost_done;
+  } else
+    ret = hc->malloc_free_lst;
+  if (!ret) {
+  new_lunk:
+    // Make a new lunk
+    ret = MemPagTaskAlloc(
+        (pags = ((cnt + 16 * MEM_PAG_SIZE - 1) >> MEM_PAG_BITS)) + 1, hc);
+    ret = (char *)ret + sizeof(CMemBlk);
+    ret->sz = (pags << MEM_PAG_BITS) - sizeof(CMemBlk);
+    hc->malloc_free_lst = ret;
+  }
+  // Chip off
+  //
+  // We must make sure there is room for another CMemUnused
+  //
+  if ((int64_t)(ret->sz - sizeof(CMemUnused)) >= cnt) {
+    hc->malloc_free_lst = (char *)ret + cnt;
+    hc->malloc_free_lst->sz = ret->sz - cnt;
+    ret->sz = cnt;
+    goto almost_done;
+  } else
+    goto new_lunk;
 big:
-	ret = MemPagTaskAlloc(1 + ((cnt + sizeof(CMemBlk)) >> MEM_PAG_BITS), hc);
-	ret = (char*)ret + sizeof(CMemBlk);
-	ret->sz = cnt;
-	goto almost_done;
+  ret = MemPagTaskAlloc(1 + ((cnt + sizeof(CMemBlk)) >> MEM_PAG_BITS), hc);
+  ret = (char *)ret + sizeof(CMemBlk);
+  ret->sz = cnt;
+  goto almost_done;
 almost_done:
-	hc->used_u8s += cnt;
-	Misc_LBtr(&hc->locked_flags, 1);
-	ret->hc = hc;
-	ret++;
-	if(bc_enable) {
-		assert((int64_t)ret<(1ll<<31));
-		if(orig<8) orig=8;
-		if(orig&7) orig=8+orig&~7ll;
-		memset(&bc_good_bitmap[(int64_t)ret/8],7,orig/8);
-	}
-	return ret;
+  hc->used_u8s += cnt;
+  Misc_LBtr(&hc->locked_flags, 1);
+  ret->hc = hc;
+  ret++;
+  if (bc_enable) {
+    assert((int64_t)ret < (1ll << 31));
+    if (orig < 8)
+      orig = 8;
+    if (orig & 7)
+      orig = 8 + orig & ~7ll;
+    memset(&bc_good_bitmap[(int64_t)ret / 8], 7, orig / 8);
+  }
+  return ret;
 }
 
-void __AIWNIOS_Free(void* ptr)
-{
-	CMemUnused *un = ptr, *hash;
-	CHeapCtrl* hc;
-	int64_t cnt;
-	if (!ptr)
-		return;
-	un--; // Area before ptr is CMemUnused*
-	if (!un->hc)
-		throw('BadFree');
-	if (un->hc->hc_signature != 'H')
-		throw('BadFree');
-	if (un->sz < 0) // Aligned chunks are negative and point to start
-		un = un->sz + (char*)un;
-	if(bc_enable) {
-		cnt=MSize(ptr);
-		assert((int64_t)ptr<(1ll<<31));
-		memset(&bc_good_bitmap[(int64_t)ptr/8],0,cnt/8);
-	}
-	hc = un->hc;
-	while (Misc_LBts(&hc->locked_flags, 1))
-		;
-	hc->used_u8s -= un->sz;
-	if (un->sz <= MEM_HEAP_HASH_SIZE) {
-		hash = hc->heap_hash[un->sz / 8];
-		un->next = hash;
-		hc->heap_hash[un->sz / 8] = un;
-		un->hc = NULL;
-	} else {
-		// CMemUnused
-		// CMemBlk
-		// page start
-		MemPagTaskFree((char*)(un) - sizeof(CMemBlk), hc);
-	}
+void __AIWNIOS_Free(void *ptr) {
+  CMemUnused *un = ptr, *hash;
+  CHeapCtrl *hc;
+  int64_t cnt;
+  if (!ptr)
+    return;
+  un--; // Area before ptr is CMemUnused*
+  if (!un->hc)
+    throw('BadFree');
+  if (un->hc->hc_signature != 'H')
+    throw('BadFree');
+  if (un->sz < 0) // Aligned chunks are negative and point to start
+    un = un->sz + (char *)un;
+  if (bc_enable) {
+    cnt = MSize(ptr);
+    assert((int64_t)ptr < (1ll << 31));
+    memset(&bc_good_bitmap[(int64_t)ptr / 8], 0, cnt / 8);
+  }
+  hc = un->hc;
+  while (Misc_LBts(&hc->locked_flags, 1))
+    ;
+  hc->used_u8s -= un->sz;
+  if (un->sz <= MEM_HEAP_HASH_SIZE) {
+    hash = hc->heap_hash[un->sz / 8];
+    un->next = hash;
+    hc->heap_hash[un->sz / 8] = un;
+    un->hc = NULL;
+  } else {
+    // CMemUnused
+    // CMemBlk
+    // page start
+    MemPagTaskFree((char *)(un) - sizeof(CMemBlk), hc);
+  }
 fin:
-	Misc_LBtr(&hc->locked_flags, 1);
+  Misc_LBtr(&hc->locked_flags, 1);
 }
 
-int64_t MSize(void* ptr)
-{
-	CMemUnused* un = ptr;
-	int64_t cnt;
-	if (!ptr)
-		return 0;
-	un--;
-	if (un->hc->hc_signature != 'H')
-		throw('BadFree');
-	if (un->sz < 0) // Aligned chunks are negative and point to start
-		un = un->sz + (char*)un;
-	return un->sz - sizeof(CMemUnused);
+int64_t MSize(void *ptr) {
+  CMemUnused *un = ptr;
+  int64_t cnt;
+  if (!ptr)
+    return 0;
+  un--;
+  if (un->hc->hc_signature != 'H')
+    throw('BadFree');
+  if (un->sz < 0) // Aligned chunks are negative and point to start
+    un = un->sz + (char *)un;
+  return un->sz - sizeof(CMemUnused);
 }
 
-void* __AIWNIOS_CAlloc(int64_t cnt, void* t)
-{
-	return memset(__AIWNIOS_MAlloc(cnt, t), 0, cnt);
+void *__AIWNIOS_CAlloc(int64_t cnt, void *t) {
+  return memset(__AIWNIOS_MAlloc(cnt, t), 0, cnt);
 }
 
-CHeapCtrl* HeapCtrlInit(CHeapCtrl* ct, CTask* task,int64_t is_code_heap)
-{
-	if (!ct)
-		ct = calloc(sizeof(CHeapCtrl), 1);
-	if (!task)
-		task = Fs;
-	ct->is_code_heap=is_code_heap;
-	ct->hc_signature = 'H';
-	ct->mem_task = task;
-	ct->malloc_free_lst = NULL;
-	QueInit(&ct->mem_blks);
-	return ct;
+CHeapCtrl *HeapCtrlInit(CHeapCtrl *ct, CTask *task, int64_t is_code_heap) {
+  if (!ct)
+    ct = calloc(sizeof(CHeapCtrl), 1);
+  if (!task)
+    task = Fs;
+  ct->is_code_heap = is_code_heap;
+  ct->hc_signature = 'H';
+  ct->mem_task = task;
+  ct->malloc_free_lst = NULL;
+  QueInit(&ct->mem_blks);
+  return ct;
 }
 
-void HeapCtrlDel(CHeapCtrl* ct)
-{
-	CMemBlk *next, *m;
-	// TODO atomic
-	while (Misc_Bt(&ct->locked_flags, 1))
-		;
-	for (m = ct->mem_blks.next; m != &ct->mem_blks; m = next) {
-		next = m->base.next;
+void HeapCtrlDel(CHeapCtrl *ct) {
+  CMemBlk *next, *m;
+  // TODO atomic
+  while (Misc_Bt(&ct->locked_flags, 1))
+    ;
+  for (m = ct->mem_blks.next; m != &ct->mem_blks; m = next) {
+    next = m->base.next;
 #if defined(_WIN32) || defined(WIN32)
-		VirtualFree(m, 0, MEM_RELEASE);
+    VirtualFree(m, 0, MEM_RELEASE);
 #else
-		static int64_t ps;
-		int64_t b;
-		if (!ps)
-			ps = sysconf(_SC_PAGE_SIZE);
-		b = m->pags * MEM_PAG_SIZE;
-		if (b % ps)
-			b += ps;
-		b /= ps;
-		b *= ps;
-		munmap(m, b);
+    static int64_t ps;
+    int64_t b;
+    if (!ps)
+      ps = sysconf(_SC_PAGE_SIZE);
+    b = m->pags * MEM_PAG_SIZE;
+    if (b % ps)
+      b += ps;
+    b /= ps;
+    b *= ps;
+    munmap(m, b);
 #endif
-	}
-	free(ct);
+  }
+  free(ct);
 }
 
-char* __AIWNIOS_StrDup(char* str, void* t)
-{
-	if (!str)
-		return NULL;
-	int64_t cnt = strlen(str);
-	char* ret = A_MALLOC(cnt + 1, t);
-	memcpy(ret, str, cnt + 1);
-	return ret;
+char *__AIWNIOS_StrDup(char *str, void *t) {
+  if (!str)
+    return NULL;
+  int64_t cnt = strlen(str);
+  char *ret = A_MALLOC(cnt + 1, t);
+  memcpy(ret, str, cnt + 1);
+  return ret;
 }
 #if defined(_WIN32) || defined(WIN32)
-int64_t IsValidPtr(char* chk)
-{
-	MEMORY_BASIC_INFORMATION mbi;
-	memset(&mbi, 0, sizeof mbi);
-	if (VirtualQuery(chk, &mbi, sizeof(mbi))) {
-		// https://stackoverflow.com/questions/496034/most-efficient-replacement-for-isbadreadptr
-		DWORD mask = (PAGE_READONLY | PAGE_READWRITE | PAGE_WRITECOPY | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY);
-		int64_t b = !!(mbi.Protect & mask);
-		return b;
-	}
-	return 0;
+int64_t IsValidPtr(char *chk) {
+  MEMORY_BASIC_INFORMATION mbi;
+  memset(&mbi, 0, sizeof mbi);
+  if (VirtualQuery(chk, &mbi, sizeof(mbi))) {
+    // https://stackoverflow.com/questions/496034/most-efficient-replacement-for-isbadreadptr
+    DWORD mask =
+        (PAGE_READONLY | PAGE_READWRITE | PAGE_WRITECOPY | PAGE_EXECUTE_READ |
+         PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY);
+    int64_t b = !!(mbi.Protect & mask);
+    return b;
+  }
+  return 0;
 }
 
 static void *GetAvailRegion32(int64_t len) {
-	static int64_t dwAllocationGranularity;
-	static void *try_page=0x100000;
-	void *start_page=try_page;
-	int64_t wrapped_around=0,sz;
-	if (!dwAllocationGranularity) {
-		SYSTEM_INFO si;
-		GetSystemInfo(&si);
-		dwAllocationGranularity = si.dwAllocationGranularity;
-	}
+  static int64_t dwAllocationGranularity;
+  static void *try_page = 0x100000;
+  void *start_page = try_page;
+  int64_t wrapped_around = 0, sz;
+  if (!dwAllocationGranularity) {
+    SYSTEM_INFO si;
+    GetSystemInfo(&si);
+    dwAllocationGranularity = si.dwAllocationGranularity;
+  }
 
-	MEMORY_BASIC_INFORMATION mbi;
-	while(!(!wrapped_around&&start_page>try_page)) {
-		memset(&mbi, 0, sizeof mbi);
-		if (sz=VirtualQuery(try_page, &mbi, sizeof(mbi))) {
-			if(mbi.State&MEM_FREE&&mbi.RegionSize>len) {
-				return try_page;
-			}
-			next:
-			if(mbi.State&MEM_FREE)
-				try_page+=mbi.RegionSize;
-			else
-				try_page=(char*)mbi.BaseAddress+mbi.RegionSize;
-			if(try_page>(void*)(1ll<<31)) {
-				try_page=0x100000;
-				wrapped_around=1;
-			}
-		} else abort();
-	}
-	return NULL;
+  MEMORY_BASIC_INFORMATION mbi;
+  while (!(!wrapped_around && start_page > try_page)) {
+    memset(&mbi, 0, sizeof mbi);
+    if (sz = VirtualQuery(try_page, &mbi, sizeof(mbi))) {
+      if (mbi.State & MEM_FREE && mbi.RegionSize > len) {
+        return try_page;
+      }
+    next:
+      if (mbi.State & MEM_FREE)
+        try_page += mbi.RegionSize;
+      else
+        try_page = (char *)mbi.BaseAddress + mbi.RegionSize;
+      if (try_page > (void *)(1ll << 31)) {
+        try_page = 0x100000;
+        wrapped_around = 1;
+      }
+    } else
+      abort();
+  }
+  return NULL;
 }
 #else
-static int64_t Hex2I64(char* s, char** end)
-{
-	int64_t ret = 0;
-	while (isxdigit(*s)) {
-		ret <<= 4;
-		if (isdigit(*s))
-			ret += *s - '0';
-		else
-			ret += toupper(*s) - 'A' + 10;
-		s++;
-	}
-	if (end)
-		*end = s;
-	return ret;
+static int64_t Hex2I64(char *s, char **end) {
+  int64_t ret = 0;
+  while (isxdigit(*s)) {
+    ret <<= 4;
+    if (isdigit(*s))
+      ret += *s - '0';
+    else
+      ret += toupper(*s) - 'A' + 10;
+    s++;
+  }
+  if (end)
+    *end = s;
+  return ret;
 }
-int64_t IsValidPtr(char* chk)
-{
-	static int64_t ps;
-	int64_t mptr = chk;
-	if (!ps)
-		ps = getpagesize();
-	mptr /= ps;
-	mptr *= ps;
-	// https://renatocunha.com/2015/12/msync-pointer-validity/
-	return -1 != msync(mptr, ps, MS_ASYNC);
-	int64_t ok = 0, sz = 0x1000;
-	char buffer[0x1000];
-	char* ptr = buffer;
-	char *start, *end;
-	FILE* f = fopen("/proc/self/maps", "rb");
-	while (-1 != getline(&ptr, &sz, f)) {
-		start = Hex2I64(ptr, &ptr);
-		if (*ptr++ != '-')
-			break;
-		end = Hex2I64(ptr, &ptr);
-		if (start <= chk) {
-			if (chk < end) {
-				if (*ptr++ != ' ')
-					break;
-				while (*ptr++ != ' ')
-					if (*ptr == 'w') {
-						ok = 1;
-						break;
-					}
-				break;
-			}
-		} else if (start > chk) // These appear to be sorted
-			break;
-		ptr = buffer;
-		sz = 0x1000;
-	}
-	fclose(f);
-	return ok;
+int64_t IsValidPtr(char *chk) {
+  static int64_t ps;
+  int64_t mptr = chk;
+  if (!ps)
+    ps = getpagesize();
+  mptr /= ps;
+  mptr *= ps;
+  // https://renatocunha.com/2015/12/msync-pointer-validity/
+  return -1 != msync(mptr, ps, MS_ASYNC);
+  int64_t ok = 0, sz = 0x1000;
+  char buffer[0x1000];
+  char *ptr = buffer;
+  char *start, *end;
+  FILE *f = fopen("/proc/self/maps", "rb");
+  while (-1 != getline(&ptr, &sz, f)) {
+    start = Hex2I64(ptr, &ptr);
+    if (*ptr++ != '-')
+      break;
+    end = Hex2I64(ptr, &ptr);
+    if (start <= chk) {
+      if (chk < end) {
+        if (*ptr++ != ' ')
+          break;
+        while (*ptr++ != ' ')
+          if (*ptr == 'w') {
+            ok = 1;
+            break;
+          }
+        break;
+      }
+    } else if (start > chk) // These appear to be sorted
+      break;
+    ptr = buffer;
+    sz = 0x1000;
+  }
+  fclose(f);
+  return ok;
 }
 
 #endif
-//Returns good region if good,else NULL and after is set how many bytes OOB
-//Returns INVALID_PTR on error
-void *BoundsCheck(void *ptr,int64_t *after) {
-	if(!bc_enable) return INVALID_PTR;
-	int64_t waste=0;
-	int64_t optr=ptr;
-	ptr=((int64_t)ptr)&~7ll;
-	if(after) *after=0;
-	//TOO big
-	if((int64_t)ptr>1ll<<31)
-		return ptr;
-	while((int64_t)ptr+waste>=0) {
-		if(bc_good_bitmap[(int64_t)(ptr+waste)/8])
-			break;
-		waste-=8;
-	}
-	if(!waste||(optr-(int64_t)(ptr+waste))==0) return ptr;
-	if(after) *after=optr-(int64_t)(ptr+waste);
- 	return NULL;
+// Returns good region if good,else NULL and after is set how many bytes OOB
+// Returns INVALID_PTR on error
+void *BoundsCheck(void *ptr, int64_t *after) {
+  if (!bc_enable)
+    return INVALID_PTR;
+  int64_t waste = 0;
+  int64_t optr = ptr;
+  ptr = ((int64_t)ptr) & ~7ll;
+  if (after)
+    *after = 0;
+  // TOO big
+  if ((int64_t)ptr > 1ll << 31)
+    return ptr;
+  while ((int64_t)ptr + waste >= 0) {
+    if (bc_good_bitmap[(int64_t)(ptr + waste) / 8])
+      break;
+    waste -= 8;
+  }
+  if (!waste || (optr - (int64_t)(ptr + waste)) == 0)
+    return ptr;
+  if (after)
+    *after = optr - (int64_t)(ptr + waste);
+  return NULL;
 }

--- a/misc.c
+++ b/misc.c
@@ -1,63 +1,59 @@
 #pragma once
 #include "aiwn.h"
 #include <ctype.h>
-uint64_t ToUpper(uint64_t ch)
-{
-	char arr[8];
-	int64_t i;
-	memcpy(arr, &ch, 8);
-	for (i = 0; i != 8; i++)
-		arr[i] = toupper(arr[i]);
-	memcpy(&ch, arr, 8);
-	return ch;
+uint64_t ToUpper(uint64_t ch) {
+  char arr[8];
+  int64_t i;
+  memcpy(arr, &ch, 8);
+  for (i = 0; i != 8; i++)
+    arr[i] = toupper(arr[i]);
+  memcpy(&ch, arr, 8);
+  return ch;
 }
-int64_t Bsf(int64_t v)
-{
+int64_t Bsf(int64_t v) {
 #if defined(_WIN32) || defined(WIN32)
-	return __builtin_ffsll(v) - 1;
+  return __builtin_ffsll(v) - 1;
 #else
-	return __builtin_ffsl(v) - 1;
+  return __builtin_ffsl(v) - 1;
 #endif
 }
-int64_t Bsr(int64_t v)
-{
-	if (!v)
-		return -1;
+int64_t Bsr(int64_t v) {
+  if (!v)
+    return -1;
 #if defined(_WIN32) || defined(WIN32)
-	return 63 - __builtin_clzll(v);
+  return 63 - __builtin_clzll(v);
 #else
-	return 63 - __builtin_clzl(v);
+  return 63 - __builtin_clzl(v);
 #endif
 }
-char* WhichFun(char* fptr)
-{
-	int64_t idx, best_dist = 0x1000000, dist;
-	CHashFun *fun, *best = NULL;
-	CHashExport* exp;
-	for (idx = 0; idx <= Fs->hash_table->mask; idx++) {
-		for (fun = Fs->hash_table->body[idx]; fun; fun = fun->base.base.next) {
-			if (fun->base.base.type & HTT_FUN) {
-				if ((char*)fun->fun_ptr <= fptr) {
-					dist = fptr - (char*)fun->fun_ptr;
-					if (dist < best_dist) {
-						best = fun;
-						best_dist = dist;
-					}
-				}
-			}
-			exp = fun;
-			if (fun->base.base.type & HTT_EXPORT_SYS_SYM) {
-				if ((char*)exp->val <= fptr) {
-					dist = fptr - (char*)exp->val;
-					if (dist < best_dist) {
-						best = exp;
-						best_dist = dist;
-					}
-				}
-			}
-		}
-	}
-	if (best)
-		return best->base.base.str;
-	return NULL;
+char *WhichFun(char *fptr) {
+  int64_t idx, best_dist = 0x1000000, dist;
+  CHashFun *fun, *best = NULL;
+  CHashExport *exp;
+  for (idx = 0; idx <= Fs->hash_table->mask; idx++) {
+    for (fun = Fs->hash_table->body[idx]; fun; fun = fun->base.base.next) {
+      if (fun->base.base.type & HTT_FUN) {
+        if ((char *)fun->fun_ptr <= fptr) {
+          dist = fptr - (char *)fun->fun_ptr;
+          if (dist < best_dist) {
+            best = fun;
+            best_dist = dist;
+          }
+        }
+      }
+      exp = fun;
+      if (fun->base.base.type & HTT_EXPORT_SYS_SYM) {
+        if ((char *)exp->val <= fptr) {
+          dist = fptr - (char *)exp->val;
+          if (dist < best_dist) {
+            best = exp;
+            best_dist = dist;
+          }
+        }
+      }
+    }
+  }
+  if (best)
+    return best->base.base.str;
+  return NULL;
 }

--- a/miscTOSX86.s
+++ b/miscTOSX86.s
@@ -1,21 +1,22 @@
-SECTION .text
-GLOBAL TempleOS_CallN
-; I64 CallN(fptr,argc,argv)
+.intel_syntax noprefix
+
+.global TempleOS_CallN
+# I64 CallN(fptr,argc,argv)
 TempleOS_CallN:
-	PUSH RBP
-	MOV RBP,RSP
-	MOV RDX,[RBP+4*8] ;argv 
-	MOV RCX,0
-	SHL QWORD[RBP+3*8],3
-	SUB RSP,QWORD [RBP+3*8]
-_loop:
-	CMP RCX,[RBP+3*8] ;argc
-	JZ en
-	MOV RAX,QWORD [RDX+RCX]
-	MOV QWORD[RSP+RCX],RAX
-	ADD RCX,8
-	JMP _loop
-en:
-	CALL QWORD [RBP+2*8] ;fptr
-	LEAVE
-	RET 3*8
+  push rbp
+  mov rbp,rsp
+  mov rdx,[rbp+4*8] #argv 
+  mov rcx,0
+  shl qword ptr [rbp+3*8],3
+  sub rsp,qword ptr [rbp+3*8]
+.L_loop:
+  cmp rcx,[rbp+3*8] #argc
+  jz .L_en
+  mov rax,qword ptr [rdx+rcx]
+  mov qword ptr [rsp+rcx],rax
+  add rcx,8
+  jmp .L_loop
+.L_en:
+  call qword ptr [rbp+2*8] #fptr
+  leave
+  ret 3*8

--- a/miscWIN.s
+++ b/miscWIN.s
@@ -1,67 +1,74 @@
-SECTION .text
-GLOBAL Misc_Btc
-Misc_Btc:
-	BTC QWORD [RCX],RSI
-	SETC AL
-	MOVZX RAX,AL
-	RET 
-GLOBAL Misc_LBtc
-Misc_LBtc:
-	LOCK BTC QWORD [RCX],RDX
-	SETC AL
-	MOVZX RAX,AL
-	RET 
+.intel_syntax noprefix
+.global Misc_Btc
+.global Misc_LBtc
+.global Misc_Bt
+.global Misc_Bts
+.global Misc_Btr
+.global Misc_LBtr
+.global Misc_LBts
+.global Misc_Caller
 
-GLOBAL Misc_Bt
+Misc_Btc:
+  btc qword ptr [rcx],rsi
+  setc al
+  movzx rax,al
+  ret 
+
+Misc_LBtc:
+  lock btc qword ptr [rcx],rdx
+  setc al
+  movzx rax,al
+  ret 
+
 Misc_Bt:
-	BT QWORD [RCX],RDX
-	SETC AL
-	MOVZX RAX,AL
-	RET 
-GLOBAL Misc_Bts
+  bt qword ptr [rcx],rdx
+  setc al
+  movzx rax,al
+  ret 
+
 Misc_Bts:
-	BTS QWORD [RCX],RDX
-	SETC AL
-	MOVZX RAX,AL
-	RET 
-GLOBAL Misc_Btr
+  bts qword ptr [rcx],rdx
+  setc al
+  movzx rax,al
+  ret 
+
 Misc_Btr:
-	BTR QWORD [RCX],RDX
-	SETC AL
-	MOVZX RAX,AL
-	RET 
-GLOBAL Misc_LBtr
+  btr qword ptr [rcx],rdx
+  setc al
+  movzx rax,al
+  ret 
+
 Misc_LBtr:
-	LOCK BTR QWORD [RCX],RDX
-	SETC AL
-	MOVZX RAX,AL
-	RET
-GLOBAL Misc_LBts
+  lock btr qword ptr [rcx],rdx
+  setc al
+  movzx rax,al
+  ret
+
 Misc_LBts:
-	LOCK BTS QWORD [RCX],RDX
-	SETC AL
-	MOVZX RAX,AL
-	RET 
-GLOBAL Misc_Caller
+  lock bts qword ptr [rcx],rdx
+  setc al
+  movzx rax,al
+  ret 
+
 Misc_Caller:
-	PUSH RBP
-	MOV RBP,RSP
-	MOV RAX,RBP
-_loop:
-	TEST RCX,RCX
-	JZ fin
-	TEST RAX,RAX 
-	JZ fail
-	MOV RAX,QWORD [RAX]
-	DEC RCX
-	JMP _loop
-fin:
-	TEST RAX,RAX
-	JZ fail
-	MOV RAX,QWORD[RAX+8]
-	LEAVE
-	RET
-fail:
-	MOV RAX,0
-	LEAVE
-	RET
+  push rbp
+  mov rbp,rsp
+  mov rax,rbp
+.L_loop:
+  test rcx,rcx
+  jz .L_fin
+  test rax,rax 
+  jz .L_fail
+  mov rax,qword ptr [rax]
+  dec rcx
+  jmp .L_loop
+.L_fin:
+  test rax,rax
+  jz .L_fail
+  mov rax,qword ptr[rax+8]
+  leave
+  ret
+.L_fail:
+  mov rax,0
+  leave
+  ret

--- a/miscX86.s
+++ b/miscX86.s
@@ -1,68 +1,75 @@
-SECTION .text
-GLOBAL Misc_Btc
-Misc_Btc:
-	BTC QWORD [RDI],RSI
-	SETC AL
-	MOVZX RAX,AL
-	RET 
-GLOBAL Misc_LBtc
-Misc_LBtc:
-	LOCK BTC QWORD [RDI],RSI
-	SETC AL
-	MOVZX RAX,AL
-	RET 
+.intel_syntax noprefix
+.global Misc_Btc
+.global Misc_LBtc
+.global Misc_Caller
+.global Misc_Bt
+.global Misc_Bts
+.global Misc_Btr
+.global Misc_LBtr
+.global Misc_LBts
 
-GLOBAL Misc_Bt
+Misc_Btc:
+  btc qword ptr [rdi],rsi
+  setc al
+  movzx rax,al
+  ret 
+
+Misc_LBtc:
+  lock btc qword ptr [rdi],rsi
+  setc al
+  movzx rax,al
+  ret 
+
 Misc_Bt:
-	BT QWORD [RDI],RSI
-	SETC AL
-	MOVZX RAX,AL
-	RET 
-GLOBAL Misc_Bts
+  bt qword ptr [rdi],rsi
+  setc al
+  movzx rax,al
+  ret 
+
 Misc_Bts:
-	BTS QWORD [RDI],RSI
-	SETC AL
-	MOVZX RAX,AL
-	RET 
-GLOBAL Misc_Btr
+  bts qword ptr [rdi],rsi
+  setc al
+  movzx rax,al
+  ret 
+
 Misc_Btr:
-	BTR QWORD [RDI],RSI
-	SETC AL
-	MOVZX RAX,AL
-	RET 
-GLOBAL Misc_LBtr
+  btr qword ptr [rdi],rsi
+  setc al
+  movzx rax,al
+  ret 
+
 Misc_LBtr:
-	LOCK BTR QWORD [RDI],RSI
-	SETC AL
-	MOVZX RAX,AL
-	RET
-GLOBAL Misc_LBts
+  lock btr qword ptr [rdi],rsi
+  setc al
+  movzx rax,al
+  ret
+
 Misc_LBts:
-	LOCK BTS QWORD [RDI],RSI
-	SETC AL
-	MOVZX RAX,AL
-	RET 
-GLOBAL Misc_Caller
+  lock bts qword ptr [rdi],rsi
+  setc al
+  movzx rax,al
+  ret 
+
 Misc_Caller:
-	PUSH RBP
-	MOV RBP,RSP
-	MOV RCX,RDI
-	MOV RAX,RBP
-_loop:
-	TEST RCX,RCX
-	JZ fin
-	TEST RAX,RAX 
-	JZ fail
-	MOV RAX,QWORD [RAX]
-	DEC RCX
-	JMP _loop
-fin:
-	TEST RAX,RAX
-	JZ fail
-	MOV RAX,QWORD[RAX+8]
-	LEAVE
-	RET
-fail:
-	MOV RAX,0
-	LEAVE
-	RET
+  push rbp
+  mov rbp,rsp
+  mov rcx,rdi
+  mov rax,rbp
+.L_loop: # .L means local label
+  test rcx,rcx
+  jz .L_fin
+  test rax,rax 
+  jz .L_fail
+  mov rax,qword ptr [rax]
+  dec rcx
+  jmp .L_loop
+.L_fin:
+  test rax,rax
+  jz .L_fail
+  mov rax,qword ptr[rax+8]
+  leave
+  ret
+.L_fail:
+  mov rax,0
+  leave
+  ret

--- a/multic.c
+++ b/multic.c
@@ -1,286 +1,270 @@
 #include "aiwn.h"
 #include <SDL2/SDL.h>
 typedef struct {
-	void (*fp)(), *gs;
-	int64_t num;
-	void (*profiler_int)(void *fs);
+  void (*fp)(), *gs;
+  int64_t num;
+  void (*profiler_int)(void *fs);
 } CorePair;
 #if defined(__linux__)
-#include <linux/futex.h>
+  #include <linux/futex.h>
 #endif
 #if defined(__FreeBSD__)
-#include <sys/types.h>
-#include <sys/umtx.h>
+  #include <sys/types.h>
+  #include <sys/umtx.h>
 #endif
 #if defined(__linux__) || defined(__FreeBSD__)
-#include <pthread.h>
-#include <sys/syscall.h>
-#include <sys/time.h>
-#include <unistd.h>
+  #include <pthread.h>
+  #include <sys/syscall.h>
+  #include <sys/time.h>
+  #include <unistd.h>
 typedef struct {
-	pthread_t pt;
-	int wake_futex;
-	void (*profiler_int)(void *fs);
-	int64_t profiler_freq;
-	struct itimerval profile_timer;
+  pthread_t pt;
+  int wake_futex;
+  void (*profiler_int)(void *fs);
+  int64_t profiler_freq;
+  struct itimerval profile_timer;
 } CCPU;
 #elif defined(_WIN32) || defined(WIN32)
-#include <windows.h>
-#include <processthreadsapi.h>
-#include <synchapi.h>
-#include <sysinfoapi.h>
-#include <time.h>
-#include <windows.h>
+  #include <processthreadsapi.h>
+  #include <synchapi.h>
+  #include <sysinfoapi.h>
+  #include <time.h>
+  #include <windows.h>
 typedef struct {
-	HANDLE thread;
-	HANDLE event;
-	HANDLE restore_ctx_event;
-	HANDLE mtx;
-	CONTEXT ctx;
-	int64_t awake_at;
-	void (*profiler_int)(void *fs);
-	int64_t profiler_freq,profiler_last_tick;
-	char profile_poop_stk[0x1000];
+  HANDLE thread;
+  HANDLE event;
+  HANDLE restore_ctx_event;
+  HANDLE mtx;
+  CONTEXT ctx;
+  int64_t awake_at;
+  void (*profiler_int)(void *fs);
+  int64_t profiler_freq, profiler_last_tick;
+  char profile_poop_stk[0x1000];
 } CCPU;
 #endif
 static __thread core_num = 0;
-static void threadrt(CorePair* pair)
-{
-	Fs = calloc(sizeof(CTask), 1);
-	VFsThrdInit();
-	TaskInit(Fs, NULL, 0);
-	SetHolyGs(pair->gs);
-	core_num = pair->num;
-	void (*fp)();
-	fp = pair->fp;
-	free(pair);
-	fp();
+static void threadrt(CorePair *pair) {
+  Fs = calloc(sizeof(CTask), 1);
+  VFsThrdInit();
+  TaskInit(Fs, NULL, 0);
+  SetHolyGs(pair->gs);
+  core_num = pair->num;
+  void (*fp)();
+  fp = pair->fp;
+  free(pair);
+  fp();
 }
 #if defined(__linux__) || defined(__FreeBSD__)
 static CCPU cores[128];
-CHashTable* glbl_table;
-void InteruptCore(int64_t core)
-{
-	pthread_kill(cores[core].pt, SIGUSR1);
+CHashTable *glbl_table;
+void InteruptCore(int64_t core) {
+  pthread_kill(cores[core].pt, SIGUSR1);
 }
-static void InteruptRt(int ul)
-{
-	sigset_t set;
-	sigemptyset(&set);
-	sigaddset(&set, SIGUSR1);
-	pthread_sigmask(SIG_UNBLOCK, &set, NULL);
-	CHashExport* y = HashFind("Yield", glbl_table, HTT_EXPORT_SYS_SYM, 1);
-	void (*fp)();
-	if (y) {
-		fp = y->val;
-		(*fp)();
-	}
+static void InteruptRt(int ul) {
+  sigset_t set;
+  sigemptyset(&set);
+  sigaddset(&set, SIGUSR1);
+  pthread_sigmask(SIG_UNBLOCK, &set, NULL);
+  CHashExport *y = HashFind("Yield", glbl_table, HTT_EXPORT_SYS_SYM, 1);
+  void (*fp)();
+  if (y) {
+    fp = y->val;
+    (*fp)();
+  }
 }
 static void ExitCoreRt(int s) {
-	pthread_exit(0);
+  pthread_exit(0);
 }
 
-static void ProfRt(int64_t sig, siginfo_t* info, ucontext_t* _ctx) {
-	int64_t c=core_num;
-	sigset_t set;
-	sigemptyset(&set);
-	sigaddset(&set, SIGPROF);
-	pthread_sigmask(SIG_UNBLOCK, &set, NULL);
-	if(!pthread_equal(pthread_self(),cores[c].pt))
-		return;
-	if(cores[c].profiler_int) {
-		#if defined(__x86_64__)
-			#if defined (__FreeBSD__)
-			FFI_CALL_TOS_1(cores[c].profiler_int,_ctx->uc_mcontext.mc_rip);
-			#elif defined (__linux__)
-	//See /usr/include/x86_64-linux-gnu/sys/ucontext.h
-enum
-{
-  REG_R8 = 0,
-  REG_R9,
-  REG_R10,
-  REG_R11,
-  REG_R12,
-  REG_R13,
-  REG_R14,
-  REG_R15,
-  REG_RDI,
-  REG_RSI,
-  REG_RBP,
-  REG_RBX,
-  REG_RDX,
-  REG_RAX,
-  REG_RCX,
-  REG_RSP,
-  REG_RIP,
-};
-			FFI_CALL_TOS_1(cores[c].profiler_int,_ctx->uc_mcontext.gregs[REG_RIP]);
-			#endif
-		#endif
-		cores[c].profile_timer.it_value.tv_usec=cores[c].profiler_freq;
-		cores[c].profile_timer.it_interval.tv_usec=cores[c].profiler_freq;
-	}
-	
+static void ProfRt(int64_t sig, siginfo_t *info, ucontext_t *_ctx) {
+  int64_t c = core_num;
+  sigset_t set;
+  sigemptyset(&set);
+  sigaddset(&set, SIGPROF);
+  pthread_sigmask(SIG_UNBLOCK, &set, NULL);
+  if (!pthread_equal(pthread_self(), cores[c].pt))
+    return;
+  if (cores[c].profiler_int) {
+  #if defined(__x86_64__)
+    #if defined(__FreeBSD__)
+    FFI_CALL_TOS_1(cores[c].profiler_int, _ctx->uc_mcontext.mc_rip);
+    #elif defined(__linux__)
+    // See /usr/include/x86_64-linux-gnu/sys/ucontext.h
+    enum {
+      REG_R8 = 0,
+      REG_R9,
+      REG_R10,
+      REG_R11,
+      REG_R12,
+      REG_R13,
+      REG_R14,
+      REG_R15,
+      REG_RDI,
+      REG_RSI,
+      REG_RBP,
+      REG_RBX,
+      REG_RDX,
+      REG_RAX,
+      REG_RCX,
+      REG_RSP,
+      REG_RIP,
+    };
+    FFI_CALL_TOS_1(cores[c].profiler_int, _ctx->uc_mcontext.gregs[REG_RIP]);
+    #endif
+  #endif
+    cores[c].profile_timer.it_value.tv_usec = cores[c].profiler_freq;
+    cores[c].profile_timer.it_interval.tv_usec = cores[c].profiler_freq;
+  }
 }
 
-void SpawnCore(void (*fp)(), void* gs, int64_t core)
-{
-	struct sigaction sa;
-	char buf[144];
-	CorePair pair = { fp, gs, core }, *ptr = malloc(sizeof(CorePair));
-	*ptr = pair;
-	pthread_create(&cores[core].pt, NULL, threadrt, ptr);
-	signal(SIGUSR1, InteruptRt);
-	signal(SIGUSR2, ExitCoreRt);
-	memset(&sa, 0, sizeof(struct sigaction));
-	sa.sa_handler = SIG_IGN;
-	sa.sa_flags = SA_SIGINFO;
-	sa.sa_sigaction = ProfRt;
-	sigaction(SIGPROF,&sa,NULL);
+void SpawnCore(void (*fp)(), void *gs, int64_t core) {
+  struct sigaction sa;
+  char buf[144];
+  CorePair pair = {fp, gs, core}, *ptr = malloc(sizeof(CorePair));
+  *ptr = pair;
+  pthread_create(&cores[core].pt, NULL, threadrt, ptr);
+  signal(SIGUSR1, InteruptRt);
+  signal(SIGUSR2, ExitCoreRt);
+  memset(&sa, 0, sizeof(struct sigaction));
+  sa.sa_handler = SIG_IGN;
+  sa.sa_flags = SA_SIGINFO;
+  sa.sa_sigaction = ProfRt;
+  sigaction(SIGPROF, &sa, NULL);
 }
-int64_t mp_cnt()
-{
-	static int64_t ret = 0;
-	if (!ret)
-		ret = sysconf(_SC_NPROCESSORS_ONLN);
-	return ret;
+int64_t mp_cnt() {
+  static int64_t ret = 0;
+  if (!ret)
+    ret = sysconf(_SC_NPROCESSORS_ONLN);
+  return ret;
 }
 
-void MPSleepHP(int64_t ns)
-{
-	struct timespec ts = { 0 };
-	ts.tv_nsec += ns * 1000U;
-	Misc_LBts(&cores[core_num].wake_futex, 0);
-	#if defined(__linux__)
-	syscall(SYS_futex, &cores[core_num].wake_futex, FUTEX_WAIT, 1, &ts, NULL, 0);
-	#endif
-	#if defined(__FreeBSD__)
-	_umtx_op(&cores[core_num].wake_futex,UMTX_OP_WAIT,1,NULL,&ts);
-	#endif
-	Misc_LBtr(&cores[core_num].wake_futex, 0);
+void MPSleepHP(int64_t ns) {
+  struct timespec ts = {0};
+  ts.tv_nsec += ns * 1000U;
+  Misc_LBts(&cores[core_num].wake_futex, 0);
+  #if defined(__linux__)
+  syscall(SYS_futex, &cores[core_num].wake_futex, FUTEX_WAIT, 1, &ts, NULL, 0);
+  #endif
+  #if defined(__FreeBSD__)
+  _umtx_op(&cores[core_num].wake_futex, UMTX_OP_WAIT, 1, NULL, &ts);
+  #endif
+  Misc_LBtr(&cores[core_num].wake_futex, 0);
 }
 
-void MPAwake(int64_t core)
-{
-	
-	if (Misc_Bt(&cores[core].wake_futex, 0)) {
-		#if defined(__linux__)
-		syscall(SYS_futex, &cores[core].wake_futex, 1, FUTEX_WAKE, NULL, NULL, 0);
-		#elif defined(__FreeBSD__)
-		_umtx_op(&cores[core].wake_futex,UMTX_OP_WAKE,1,NULL,NULL);
-		#endif
-	}
+void MPAwake(int64_t core) {
+
+  if (Misc_Bt(&cores[core].wake_futex, 0)) {
+  #if defined(__linux__)
+    syscall(SYS_futex, &cores[core].wake_futex, 1, FUTEX_WAKE, NULL, NULL, 0);
+  #elif defined(__FreeBSD__)
+    _umtx_op(&cores[core].wake_futex, UMTX_OP_WAKE, 1, NULL, NULL);
+  #endif
+  }
 }
 void __ShutdownCore(int core) {
   pthread_kill(cores[core].pt, SIGUSR2);
   pthread_join(cores[core].pt, NULL);
 }
 
-//Freq in microseconds
-void MPSetProfilerInt(void *fp,int c,int64_t f) {
-	if(!fp) {
-		struct itimerval none;
-		none.it_value.tv_sec=0;
-		none.it_value.tv_usec=0;
-		setitimer(ITIMER_PROF,&none,NULL);
-	} else {
-		cores[c].profiler_int=fp;
-		cores[c].profiler_freq=f;
-		cores[c].profile_timer.it_value.tv_sec=0;
-		cores[c].profile_timer.it_value.tv_usec=f;
-		cores[c].profile_timer.it_interval.tv_sec=0;
-		cores[c].profile_timer.it_interval.tv_usec=f;
-		setitimer(ITIMER_PROF,&cores[c].profile_timer,NULL);
-	}
+// Freq in microseconds
+void MPSetProfilerInt(void *fp, int c, int64_t f) {
+  if (!fp) {
+    struct itimerval none;
+    none.it_value.tv_sec = 0;
+    none.it_value.tv_usec = 0;
+    setitimer(ITIMER_PROF, &none, NULL);
+  } else {
+    cores[c].profiler_int = fp;
+    cores[c].profiler_freq = f;
+    cores[c].profile_timer.it_value.tv_sec = 0;
+    cores[c].profile_timer.it_value.tv_usec = f;
+    cores[c].profile_timer.it_interval.tv_sec = 0;
+    cores[c].profile_timer.it_interval.tv_usec = f;
+    setitimer(ITIMER_PROF, &cores[c].profile_timer, NULL);
+  }
 }
 #else
 static CCPU cores[128];
-CHashTable* glbl_table;
+CHashTable *glbl_table;
 static int64_t ticks = 0;
 static int64_t tick_inc = 1;
 static void WindowsProfileCode(int c);
-static void update_ticks(UINT tid, UINT msg, DWORD_PTR dw_user, void* ul,
-	void* ul2)
-{
-	int64_t period;
-	ticks += tick_inc;
-	for (int64_t idx = 0; idx < mp_cnt(NULL); ++idx) {
-		WaitForSingleObject(cores[idx].mtx, INFINITE);
-		if (cores[idx].awake_at && ticks >= cores[idx].awake_at) {
-			SetEvent(cores[idx].event);
-			cores[idx].awake_at = 0;
-		}
-		ReleaseMutex(cores[idx].mtx);
-	}
+static void update_ticks(UINT tid, UINT msg, DWORD_PTR dw_user, void *ul,
+                         void *ul2) {
+  int64_t period;
+  ticks += tick_inc;
+  for (int64_t idx = 0; idx < mp_cnt(NULL); ++idx) {
+    WaitForSingleObject(cores[idx].mtx, INFINITE);
+    if (cores[idx].awake_at && ticks >= cores[idx].awake_at) {
+      SetEvent(cores[idx].event);
+      cores[idx].awake_at = 0;
+    }
+    ReleaseMutex(cores[idx].mtx);
+  }
 }
-int64_t GetTicksHP()
-{
-	static int64_t init;
-	TIMECAPS tc;
-	if (!init) {
-		init = 1;
-		timeGetDevCaps(&tc, sizeof tc);
-		tick_inc = tc.wPeriodMin;
-		timeSetEvent(tick_inc, tick_inc, &update_ticks, NULL, TIME_PERIODIC);
-	}
-	return ticks*1000;
+int64_t GetTicksHP() {
+  static int64_t init;
+  TIMECAPS tc;
+  if (!init) {
+    init = 1;
+    timeGetDevCaps(&tc, sizeof tc);
+    tick_inc = tc.wPeriodMin;
+    timeSetEvent(tick_inc, tick_inc, &update_ticks, NULL, TIME_PERIODIC);
+  }
+  return ticks * 1000;
 }
-void SpawnCore(void (*fp)(), void* gs, int64_t core)
-{
-	CorePair pair = { fp, gs, core }, *ptr = malloc(sizeof(CorePair));
-	*ptr = pair;
-	cores[core].mtx = CreateMutex(NULL, FALSE, NULL);
-	cores[core].event = CreateEvent(NULL, 0, 0, NULL);
-	cores[core].restore_ctx_event = CreateEvent(NULL, 0, 0, NULL);
-	cores[core].thread = CreateThread(NULL, 0, threadrt, ptr, 0, NULL);
-	SetThreadPriority(cores[core].thread, THREAD_PRIORITY_HIGHEST);
+void SpawnCore(void (*fp)(), void *gs, int64_t core) {
+  CorePair pair = {fp, gs, core}, *ptr = malloc(sizeof(CorePair));
+  *ptr = pair;
+  cores[core].mtx = CreateMutex(NULL, FALSE, NULL);
+  cores[core].event = CreateEvent(NULL, 0, 0, NULL);
+  cores[core].restore_ctx_event = CreateEvent(NULL, 0, 0, NULL);
+  cores[core].thread = CreateThread(NULL, 0, threadrt, ptr, 0, NULL);
+  SetThreadPriority(cores[core].thread, THREAD_PRIORITY_HIGHEST);
 }
-void MPSleepHP(int64_t us)
-{
-	int64_t s, e;
-	s = GetTicksHP()/1000;
-	WaitForSingleObject(cores[core_num].mtx, INFINITE);
-	cores[core_num].awake_at = s + us / 1000;
-	ReleaseMutex(cores[core_num].mtx);
-	WaitForSingleObject(cores[core_num].event, INFINITE);
+void MPSleepHP(int64_t us) {
+  int64_t s, e;
+  s = GetTicksHP() / 1000;
+  WaitForSingleObject(cores[core_num].mtx, INFINITE);
+  cores[core_num].awake_at = s + us / 1000;
+  ReleaseMutex(cores[core_num].mtx);
+  WaitForSingleObject(cores[core_num].event, INFINITE);
 }
-void InteruptCore(int64_t core)
-{
-	CHashExport* y = HashFind("Yield", glbl_table, HTT_EXPORT_SYS_SYM, 1);
-	CONTEXT ctx;
-	memset(&ctx, 0, sizeof ctx);
-	ctx.ContextFlags = CONTEXT_FULL;
-	SuspendThread(cores[core].thread);
-	GetThreadContext(cores[core].thread, &ctx);
-	ctx.Rsp -= 8;
-	((int64_t *)ctx.Rsp)[0] = ctx.Rip;
-	ctx.Rip = y;
-	SetThreadContext(cores[core].thread, &ctx);
-	ResumeThread(cores[core].thread);
+void InteruptCore(int64_t core) {
+  CHashExport *y = HashFind("Yield", glbl_table, HTT_EXPORT_SYS_SYM, 1);
+  CONTEXT ctx;
+  memset(&ctx, 0, sizeof ctx);
+  ctx.ContextFlags = CONTEXT_FULL;
+  SuspendThread(cores[core].thread);
+  GetThreadContext(cores[core].thread, &ctx);
+  ctx.Rsp -= 8;
+  ((int64_t *)ctx.Rsp)[0] = ctx.Rip;
+  ctx.Rip = y;
+  SetThreadContext(cores[core].thread, &ctx);
+  ResumeThread(cores[core].thread);
 }
 
-int64_t mp_cnt()
-{
-	SYSTEM_INFO info;
-	GetSystemInfo(&info);
-	return info.dwNumberOfProcessors;
+int64_t mp_cnt() {
+  SYSTEM_INFO info;
+  GetSystemInfo(&info);
+  return info.dwNumberOfProcessors;
 }
-void MPAwake(int64_t c)
-{
-	WaitForSingleObject(cores[c].mtx, INFINITE);
-	cores[c].awake_at = 0;
-	SetEvent(cores[c].event);
-	ReleaseMutex(cores[c].mtx);
+void MPAwake(int64_t c) {
+  WaitForSingleObject(cores[c].mtx, INFINITE);
+  cores[c].awake_at = 0;
+  SetEvent(cores[c].event);
+  ReleaseMutex(cores[c].mtx);
 }
 void __ShutdownCore(int core) {
   TerminateThread(cores[core].thread, 0);
 }
-void MPSetProfilerInt(void *fp,int c,int64_t f) {
-	WaitForSingleObject(cores[c].mtx, INFINITE);
-	cores[c].profiler_int=fp;
-	cores[c].profiler_freq=f*1000./1000000.;
-	if(!cores[c].profiler_freq) cores[c].profiler_freq=1; 
-	cores[c] .profiler_last_tick=ticks;
-	ReleaseMutex(cores[c].mtx);
+void MPSetProfilerInt(void *fp, int c, int64_t f) {
+  WaitForSingleObject(cores[c].mtx, INFINITE);
+  cores[c].profiler_int = fp;
+  cores[c].profiler_freq = f * 1000. / 1000000.;
+  if (!cores[c].profiler_freq)
+    cores[c].profiler_freq = 1;
+  cores[c].profiler_last_tick = ticks;
+  ReleaseMutex(cores[c].mtx);
 }
 #endif

--- a/optpass.c
+++ b/optpass.c
@@ -1,110 +1,108 @@
 #pragma once
 #include "aiwn.h"
-static int64_t IsConst(CRPN* rpn)
-{
-	switch (rpn->type) {
-	case IC_CHR:
-	case IC_F64:
-	case IC_I64:
-		return 1;
-	}
-	return 0;
+static int64_t IsConst(CRPN *rpn) {
+  switch (rpn->type) {
+  case IC_CHR:
+  case IC_F64:
+  case IC_I64:
+    return 1;
+  }
+  return 0;
 }
 
-static int64_t PtrWidthOfRPN(CRPN* rpn)
-{
-	int64_t r = 1;
-	if (rpn->ic_dim) {
-		if (rpn->ic_dim->next)
-			r *= rpn->ic_dim->next->total_cnt;
-		r *= rpn->ic_class->sz;
-	} else
-		r *= rpn->ic_class[-1].sz;
+static int64_t PtrWidthOfRPN(CRPN *rpn) {
+  int64_t r = 1;
+  if (rpn->ic_dim) {
+    if (rpn->ic_dim->next)
+      r *= rpn->ic_dim->next->total_cnt;
+    r *= rpn->ic_class->sz;
+  } else
+    r *= rpn->ic_class[-1].sz;
 
-	return r;
+  return r;
 }
 
-static void FixFunArgs(CCmpCtrl* cctrl, CRPN* rpn)
-{
-	int64_t cnt, cnt2, vargc;
-	CRPN *rpn2 = rpn->base.next, *ic, *last;
-	CHashFun* ic_fun;
-	CMemberLst *arg, *args_lst_rev;
-	for (cnt = 0; cnt != rpn->length; cnt++)
-		rpn2 = ICFwd(rpn2);
-	AssignRawTypeToNode(cctrl, rpn2);
-	ic_fun = rpn2->ic_fun;
-	rpn2 = rpn->base.next;
-	arg = ic_fun->base.members_lst;
-	cnt2 = ic_fun->argc;
-	if (ic_fun->base.flags & CLSF_VARGS)
-		cnt2 -= 2;
-	for (cnt = 0; cnt != rpn->length; cnt++) {
-		if (cnt >= cnt2)
-			break;
-		rpn2 = ICArgN(rpn, rpn->length - cnt - 1); // REVERSE polish notation
-		if (rpn2->type == IC_NOP) {
-			if (arg->member_class->raw_type == RT_F64) {
-				rpn2->type = IC_F64;
-				rpn2->flt = ((double*)&arg->dft_val)[0];
-				AssignRawTypeToNode(cctrl, rpn2);
-			} else {
-				rpn2->type = IC_I64;
-				rpn2->integer = arg->dft_val;
-				AssignRawTypeToNode(cctrl, rpn2);
-			}
-		} else {
-			// If we are passing an F64 to an I64 argument,be sure to convert the F64 to a I64
-			if ((arg->member_class->raw_type == RT_F64) ^ // Check for difference
-				(AssignRawTypeToNode(cctrl, rpn2) == RT_F64)) {
-				if (arg->member_class->raw_type == RT_F64) {
-					ic = A_CALLOC(sizeof(CRPN), cctrl->hc);
-					ic->type = IC_TO_F64;
-					QueIns(ic, rpn2->base.last);
-					AssignRawTypeToNode(cctrl, ic);
-				} else {
-					ic = A_CALLOC(sizeof(CRPN), cctrl->hc);
-					ic->type = IC_TO_I64;
-					AssignRawTypeToNode(cctrl, ic);
-					QueIns(ic, rpn2->base.last);
-				}
-			}
-		}
-		arg = arg->next;
-	}
-	for (; cnt < cnt2; cnt++) {
-		ic = A_CALLOC(sizeof(CRPN), cctrl->hc);
-		rpn->length++;
-		if (arg->member_class->raw_type == RT_F64) {
-			ic->type = IC_F64;
-			ic->flt = ((double*)&arg->dft_val)[0];
-			AssignRawTypeToNode(cctrl, ic);
-		} else {
-			ic->type = IC_I64;
-			ic->integer = arg->dft_val;
-			AssignRawTypeToNode(cctrl, ic);
-		}
-		QueIns(ic, rpn);
-		arg = arg->next;
-	}
-	if (ic_fun->base.flags & CLSF_VARGS) {
-		rpn2 = ICArgN(rpn, rpn->length - cnt2 - 1 + 1);
-		last = rpn;
-		vargc = rpn->length - cnt2;
-		// Pass argv
-		ic = A_CALLOC(sizeof(CRPN), cctrl->hc);
-		ic->type = __IC_VARGS;
-		ic->length = vargc;
-		ic->raw_type = RT_I64i;
-		QueIns(ic, last);
-		// Pass argc
-		ic = A_CALLOC(sizeof(CRPN), cctrl->hc);
-		ic->type = IC_I64;
-		ic->integer = vargc;
-		AssignRawTypeToNode(cctrl, ic);
-		QueIns(ic, ICFwd(last->base.next)->base.last);
-		rpn->length = cnt2 + 2;
-	}
+static void FixFunArgs(CCmpCtrl *cctrl, CRPN *rpn) {
+  int64_t cnt, cnt2, vargc;
+  CRPN *rpn2 = rpn->base.next, *ic, *last;
+  CHashFun *ic_fun;
+  CMemberLst *arg, *args_lst_rev;
+  for (cnt = 0; cnt != rpn->length; cnt++)
+    rpn2 = ICFwd(rpn2);
+  AssignRawTypeToNode(cctrl, rpn2);
+  ic_fun = rpn2->ic_fun;
+  rpn2 = rpn->base.next;
+  arg = ic_fun->base.members_lst;
+  cnt2 = ic_fun->argc;
+  if (ic_fun->base.flags & CLSF_VARGS)
+    cnt2 -= 2;
+  for (cnt = 0; cnt != rpn->length; cnt++) {
+    if (cnt >= cnt2)
+      break;
+    rpn2 = ICArgN(rpn, rpn->length - cnt - 1); // REVERSE polish notation
+    if (rpn2->type == IC_NOP) {
+      if (arg->member_class->raw_type == RT_F64) {
+        rpn2->type = IC_F64;
+        rpn2->flt = ((double *)&arg->dft_val)[0];
+        AssignRawTypeToNode(cctrl, rpn2);
+      } else {
+        rpn2->type = IC_I64;
+        rpn2->integer = arg->dft_val;
+        AssignRawTypeToNode(cctrl, rpn2);
+      }
+    } else {
+      // If we are passing an F64 to an I64 argument,be sure to convert the F64
+      // to a I64
+      if ((arg->member_class->raw_type == RT_F64) ^ // Check for difference
+          (AssignRawTypeToNode(cctrl, rpn2) == RT_F64)) {
+        if (arg->member_class->raw_type == RT_F64) {
+          ic = A_CALLOC(sizeof(CRPN), cctrl->hc);
+          ic->type = IC_TO_F64;
+          QueIns(ic, rpn2->base.last);
+          AssignRawTypeToNode(cctrl, ic);
+        } else {
+          ic = A_CALLOC(sizeof(CRPN), cctrl->hc);
+          ic->type = IC_TO_I64;
+          AssignRawTypeToNode(cctrl, ic);
+          QueIns(ic, rpn2->base.last);
+        }
+      }
+    }
+    arg = arg->next;
+  }
+  for (; cnt < cnt2; cnt++) {
+    ic = A_CALLOC(sizeof(CRPN), cctrl->hc);
+    rpn->length++;
+    if (arg->member_class->raw_type == RT_F64) {
+      ic->type = IC_F64;
+      ic->flt = ((double *)&arg->dft_val)[0];
+      AssignRawTypeToNode(cctrl, ic);
+    } else {
+      ic->type = IC_I64;
+      ic->integer = arg->dft_val;
+      AssignRawTypeToNode(cctrl, ic);
+    }
+    QueIns(ic, rpn);
+    arg = arg->next;
+  }
+  if (ic_fun->base.flags & CLSF_VARGS) {
+    rpn2 = ICArgN(rpn, rpn->length - cnt2 - 1 + 1);
+    last = rpn;
+    vargc = rpn->length - cnt2;
+    // Pass argv
+    ic = A_CALLOC(sizeof(CRPN), cctrl->hc);
+    ic->type = __IC_VARGS;
+    ic->length = vargc;
+    ic->raw_type = RT_I64i;
+    QueIns(ic, last);
+    // Pass argc
+    ic = A_CALLOC(sizeof(CRPN), cctrl->hc);
+    ic->type = IC_I64;
+    ic->integer = vargc;
+    AssignRawTypeToNode(cctrl, ic);
+    QueIns(ic, ICFwd(last->base.next)->base.last);
+    rpn->length = cnt2 + 2;
+  }
 }
 
 // This one takes into acount the default arguments of function calls(either)
@@ -112,17 +110,16 @@ static void FixFunArgs(CCmpCtrl* cctrl, CRPN* rpn)
 //
 // Lone function's without arguments will be turned into calls
 //
-void OptPassFixFunArgs(CCmpCtrl* cctrl)
-{
-	CRPN *rpn, *rpn2, *last;
-	for (rpn = cctrl->code_ctrl->ir_code->next; rpn != cctrl->code_ctrl->ir_code;
-		 rpn = rpn->base.next) {
-		switch (rpn->type) {
-			break;
-		case IC_CALL:
-			FixFunArgs(cctrl, rpn);
-		}
-	}
+void OptPassFixFunArgs(CCmpCtrl *cctrl) {
+  CRPN *rpn, *rpn2, *last;
+  for (rpn = cctrl->code_ctrl->ir_code->next; rpn != cctrl->code_ctrl->ir_code;
+       rpn = rpn->base.next) {
+    switch (rpn->type) {
+      break;
+    case IC_CALL:
+      FixFunArgs(cctrl, rpn);
+    }
+  }
 }
 
 // This one makes takes into account the array dimensions of accessed arrays
@@ -130,308 +127,308 @@ void OptPassFixFunArgs(CCmpCtrl* cctrl)
 //
 // THIS WILL ALSO REMOVE "derefencing function pointers"
 //
-void OptPassExpandPtrs(CCmpCtrl* cctrl)
-{
-	CRPN *rpn, *new, *lit, *new2, *new3, *a, *b, **list;
-	CArrayDim* dim;
-	int64_t cnt = 0, cnt2, total_off, raw_type;
-	for (rpn = cctrl->code_ctrl->ir_code->next; rpn != cctrl->code_ctrl->ir_code;
-		 rpn = rpn->base.next) {
-		switch (rpn->type) {
-		case IC_SUB:
-		case IC_ADD:
-		case IC_ARRAY_ACC:
-		case IC_ARROW:
-		case IC_DOT:
-		case IC_STATIC:
-		case IC_LOCAL:
-		case IC_GLOBAL:
-		case IC_SUB_EQ:
-		case IC_ADD_EQ:
-		case IC_DEREF:
-			cnt++;
-		}
-	}
-	list = A_CALLOC(sizeof(CRPN*) * cnt, cctrl->hc);
-	cnt = 0;
-	for (rpn = cctrl->code_ctrl->ir_code->next; rpn != cctrl->code_ctrl->ir_code;
-		 rpn = rpn->base.next) {
-		switch (rpn->type) {
-		case IC_SUB:
-		case IC_ADD:
-		case IC_ARRAY_ACC:
-		case IC_ARROW:
-		case IC_DOT:
-		case IC_LOCAL:
-		case IC_STATIC:
-		case IC_GLOBAL:
-		case IC_SUB_EQ:
-		case IC_ADD_EQ:
-		case IC_DEREF:
-			list[cnt++] = rpn;
-		}
-	}
-	for (cnt2 = 0; cnt2 != cnt; cnt2++) {
-		rpn = list[cnt2];
-		switch (rpn->type) {
-			break;
-		case IC_DEREF:
-			b = rpn->base.next;
-			if (b->raw_type == RT_FUNC)
-				ICFree(rpn);
-			break;
-		case IC_SUB_EQ:
-		case IC_SUB:
-			b = rpn->base.next;
-			a = ICFwd(b);
-			if (a->ic_class->ptr_star_cnt || a->ic_dim) {
-				if (b->ic_class->ptr_star_cnt || b->ic_dim) {
-					new = A_CALLOC(sizeof(CRPN), cctrl->hc);
-					new->type = IC_DIV;
-					QueIns(new, rpn->base.last);
-					lit = A_CALLOC(sizeof(CRPN), cctrl->hc);
-					lit->type = IC_I64;
-					lit->integer = PtrWidthOfRPN(a);
-					QueIns(lit, new);
-					AssignRawTypeToNode(cctrl, new);
-				} else {
-					new = A_CALLOC(sizeof(CRPN), cctrl->hc);
-					new->type = IC_MUL;
-					QueIns(new, b->base.last);
-					lit = A_CALLOC(sizeof(CRPN), cctrl->hc);
-					lit->type = IC_I64;
-					lit->integer = PtrWidthOfRPN(a);
-					QueIns(lit, new);
-					AssignRawTypeToNode(cctrl, new);
-				}
-			}
-			break;
-		case IC_ADD_EQ:
-		case IC_ADD:
-			b = rpn->base.next;
-			a = ICFwd(b);
-			if (a->ic_class->ptr_star_cnt || a->ic_dim) {
-				new = A_CALLOC(sizeof(CRPN), cctrl->hc);
-				new->type = IC_MUL;
-				QueIns(new, b->base.last);
-				lit = A_CALLOC(sizeof(CRPN), cctrl->hc);
-				lit->type = IC_I64;
-				lit->integer = PtrWidthOfRPN(a);
-				QueIns(lit, new);
-				AssignRawTypeToNode(cctrl, new);
-			} else if ((b->ic_class->ptr_star_cnt || b->ic_dim) && rpn->type != IC_ADD_EQ) {
-				new = A_CALLOC(sizeof(CRPN), cctrl->hc);
-				new->type = IC_MUL;
-				QueIns(new, a->base.last);
-				lit = A_CALLOC(sizeof(CRPN), cctrl->hc);
-				lit->type = IC_I64;
-				lit->integer = PtrWidthOfRPN(b);
-				QueIns(lit, new);
-				AssignRawTypeToNode(cctrl, new);
-			}
-			break;
-		case IC_ARRAY_ACC:
-			b = rpn->base.next;
-			a = ICFwd(b);
-			dim = rpn->ic_dim;
-			if (!dim)
-				goto aderef;
-			if (dim->next) {
-				new = A_CALLOC(sizeof(CRPN), cctrl->hc);
-				new->type = IC_MUL;
-				new->raw_type = RT_I64i;
-				new->ic_class = HashFind("I64i", Fs->hash_table, HTT_CLASS, 1);
-				QueIns(new, rpn);
-				lit = A_CALLOC(sizeof(CRPN), cctrl->hc);
-				lit->type = IC_I64;
-				lit->raw_type = new->raw_type;
-				lit->ic_class = new->ic_class;
-				lit->integer = PtrWidthOfRPN(a);
-				QueIns(lit, new);
-				AssignRawTypeToNode(cctrl, new);
-				dim = dim->next;
-				rpn->type = IC_ADD;
-			} else {
-			aderef:
-				new2 = A_CALLOC(sizeof(CRPN), cctrl->hc);
-				new2->type = IC_ADD;
-				QueIns(new2, rpn);
-				new = A_CALLOC(sizeof(CRPN), cctrl->hc);
-				new->type = IC_MUL;
-				QueIns(new, new2);
-				lit = A_CALLOC(sizeof(CRPN), cctrl->hc);
-				lit->type = IC_I64;
-				lit->integer = PtrWidthOfRPN(a);
-				QueIns(lit, new);
-				rpn->type = IC_DEREF;
-				AssignRawTypeToNode(cctrl, new2);
-			}
-			break;
-		case IC_ARROW:
-		addrof_arr:
-			// If we already have a addrof,no need to do it twice
-			if (rpn->base.last != cctrl->code_ctrl->ir_code) {
-				b = rpn->base.last;
-				if (b->type == IC_ADDR_OF) {
-					break;
-				}
-			}
-			if (rpn->local_mem->dim.next) {
-				new = A_CALLOC(sizeof(CRPN), cctrl->hc);
-				new->type = IC_ADDR_OF;
-				QueIns(new, rpn->base.last);
-				AssignRawTypeToNode(cctrl, new);
-			}
-			break;
-		case IC_DOT:
-			goto addrof_arr;
-			break;
-		case IC_STATIC:
-			goto addrof_arr;
-		case IC_LOCAL:
-			goto addrof_arr;
-			break;
-		case IC_GLOBAL:
-			if (rpn->global_var->base.type & HTT_GLBL_VAR)
-				if (rpn->global_var->dim.next) {
-					//
-					// Do not get address of thing if we are already getting the address of it
-					//
-					b = rpn->base.last;
-					if (b->type != IC_ADDR_OF) {
-						new = A_CALLOC(sizeof(CRPN), cctrl->hc);
-						new->type = IC_ADDR_OF;
-						QueIns(new, rpn->base.last);
-						AssignRawTypeToNode(cctrl, new);
-					}
-				}
-			break;
-		default:
-			dim = NULL;
-		}
-	}
-	for (rpn = cctrl->code_ctrl->ir_code->next; rpn != cctrl->code_ctrl->ir_code;
-		 rpn = rpn->base.next) {
-		switch (rpn->type) {
-			break;
-		case IC_DOT:
-			raw_type = rpn->raw_type;
-			a = rpn->base.next;
-			total_off = rpn->local_mem->off;
-			for (; a->type == IC_DOT; a = b) {
-				b = a->base.next;
-				raw_type = a->raw_type;
-				total_off += a->local_mem->off;
-				ICFree(a);
-			}
-			new = A_CALLOC(sizeof(CRPN), cctrl->hc);
-			new->type = IC_ADDR_OF;
-			new->raw_type = RT_PTR;
-			QueIns(new, a->base.last);
-			new2 = A_CALLOC(sizeof(CRPN), cctrl->hc);
-			new2->type = IC_ADD;
-			new2->raw_type = RT_PTR;
-			QueIns(new2, rpn);
-			new3 = A_CALLOC(sizeof(CRPN), cctrl->hc);
-			new3->type = IC_I64;
-			new3->integer = total_off;
-			new3->raw_type = RT_I64i;
-			QueIns(new3, new2);
-			rpn->type = IC_DEREF;
-			rpn->raw_type = raw_type;
-			break;
-		case IC_ARROW:
-			new = A_CALLOC(sizeof(CRPN), cctrl->hc);
-			new->type = IC_DEREF;
-			new->raw_type = rpn->raw_type;
-			new->ic_fun = rpn->ic_fun;
-			new->ic_dim = rpn->ic_dim;
-			new2 = A_CALLOC(sizeof(CRPN), cctrl->hc);
-			new2->type = IC_I64;
-			new2->integer = rpn->local_mem->off;
-			new2->raw_type = RT_I64i;
-			QueIns(new2, rpn);
-			QueIns(new, rpn->base.last);
-			rpn->type = IC_ADD;
-			rpn->raw_type = RT_PTR;
-		}
-	}
-	// Remove addresses of dereferences
-	for (rpn = cctrl->code_ctrl->ir_code->next;
-		 rpn != cctrl->code_ctrl->ir_code;) {
-		a = rpn;
-		b = rpn->base.next;
-		if (a->type == IC_ADDR_OF) {
-			if (b->type == IC_DEREF) {
-				rpn = b->base.next;
-				ICFree(a);
-				ICFree(b);
-				continue;
-			}
-		}
-		rpn = a->base.next;
-	}
-	A_FREE(list);
+void OptPassExpandPtrs(CCmpCtrl *cctrl) {
+  CRPN *rpn, *new, *lit, *new2, *new3, *a, *b, **list;
+  CArrayDim *dim;
+  int64_t cnt = 0, cnt2, total_off, raw_type;
+  for (rpn = cctrl->code_ctrl->ir_code->next; rpn != cctrl->code_ctrl->ir_code;
+       rpn = rpn->base.next) {
+    switch (rpn->type) {
+    case IC_SUB:
+    case IC_ADD:
+    case IC_ARRAY_ACC:
+    case IC_ARROW:
+    case IC_DOT:
+    case IC_STATIC:
+    case IC_LOCAL:
+    case IC_GLOBAL:
+    case IC_SUB_EQ:
+    case IC_ADD_EQ:
+    case IC_DEREF:
+      cnt++;
+    }
+  }
+  list = A_CALLOC(sizeof(CRPN *) * cnt, cctrl->hc);
+  cnt = 0;
+  for (rpn = cctrl->code_ctrl->ir_code->next; rpn != cctrl->code_ctrl->ir_code;
+       rpn = rpn->base.next) {
+    switch (rpn->type) {
+    case IC_SUB:
+    case IC_ADD:
+    case IC_ARRAY_ACC:
+    case IC_ARROW:
+    case IC_DOT:
+    case IC_LOCAL:
+    case IC_STATIC:
+    case IC_GLOBAL:
+    case IC_SUB_EQ:
+    case IC_ADD_EQ:
+    case IC_DEREF:
+      list[cnt++] = rpn;
+    }
+  }
+  for (cnt2 = 0; cnt2 != cnt; cnt2++) {
+    rpn = list[cnt2];
+    switch (rpn->type) {
+      break;
+    case IC_DEREF:
+      b = rpn->base.next;
+      if (b->raw_type == RT_FUNC)
+        ICFree(rpn);
+      break;
+    case IC_SUB_EQ:
+    case IC_SUB:
+      b = rpn->base.next;
+      a = ICFwd(b);
+      if (a->ic_class->ptr_star_cnt || a->ic_dim) {
+        if (b->ic_class->ptr_star_cnt || b->ic_dim) {
+          new = A_CALLOC(sizeof(CRPN), cctrl->hc);
+          new->type = IC_DIV;
+          QueIns(new, rpn->base.last);
+          lit = A_CALLOC(sizeof(CRPN), cctrl->hc);
+          lit->type = IC_I64;
+          lit->integer = PtrWidthOfRPN(a);
+          QueIns(lit, new);
+          AssignRawTypeToNode(cctrl, new);
+        } else {
+          new = A_CALLOC(sizeof(CRPN), cctrl->hc);
+          new->type = IC_MUL;
+          QueIns(new, b->base.last);
+          lit = A_CALLOC(sizeof(CRPN), cctrl->hc);
+          lit->type = IC_I64;
+          lit->integer = PtrWidthOfRPN(a);
+          QueIns(lit, new);
+          AssignRawTypeToNode(cctrl, new);
+        }
+      }
+      break;
+    case IC_ADD_EQ:
+    case IC_ADD:
+      b = rpn->base.next;
+      a = ICFwd(b);
+      if (a->ic_class->ptr_star_cnt || a->ic_dim) {
+        new = A_CALLOC(sizeof(CRPN), cctrl->hc);
+        new->type = IC_MUL;
+        QueIns(new, b->base.last);
+        lit = A_CALLOC(sizeof(CRPN), cctrl->hc);
+        lit->type = IC_I64;
+        lit->integer = PtrWidthOfRPN(a);
+        QueIns(lit, new);
+        AssignRawTypeToNode(cctrl, new);
+      } else if ((b->ic_class->ptr_star_cnt || b->ic_dim) &&
+                 rpn->type != IC_ADD_EQ) {
+        new = A_CALLOC(sizeof(CRPN), cctrl->hc);
+        new->type = IC_MUL;
+        QueIns(new, a->base.last);
+        lit = A_CALLOC(sizeof(CRPN), cctrl->hc);
+        lit->type = IC_I64;
+        lit->integer = PtrWidthOfRPN(b);
+        QueIns(lit, new);
+        AssignRawTypeToNode(cctrl, new);
+      }
+      break;
+    case IC_ARRAY_ACC:
+      b = rpn->base.next;
+      a = ICFwd(b);
+      dim = rpn->ic_dim;
+      if (!dim)
+        goto aderef;
+      if (dim->next) {
+        new = A_CALLOC(sizeof(CRPN), cctrl->hc);
+        new->type = IC_MUL;
+        new->raw_type = RT_I64i;
+        new->ic_class = HashFind("I64i", Fs->hash_table, HTT_CLASS, 1);
+        QueIns(new, rpn);
+        lit = A_CALLOC(sizeof(CRPN), cctrl->hc);
+        lit->type = IC_I64;
+        lit->raw_type = new->raw_type;
+        lit->ic_class = new->ic_class;
+        lit->integer = PtrWidthOfRPN(a);
+        QueIns(lit, new);
+        AssignRawTypeToNode(cctrl, new);
+        dim = dim->next;
+        rpn->type = IC_ADD;
+      } else {
+      aderef:
+        new2 = A_CALLOC(sizeof(CRPN), cctrl->hc);
+        new2->type = IC_ADD;
+        QueIns(new2, rpn);
+        new = A_CALLOC(sizeof(CRPN), cctrl->hc);
+        new->type = IC_MUL;
+        QueIns(new, new2);
+        lit = A_CALLOC(sizeof(CRPN), cctrl->hc);
+        lit->type = IC_I64;
+        lit->integer = PtrWidthOfRPN(a);
+        QueIns(lit, new);
+        rpn->type = IC_DEREF;
+        AssignRawTypeToNode(cctrl, new2);
+      }
+      break;
+    case IC_ARROW:
+    addrof_arr:
+      // If we already have a addrof,no need to do it twice
+      if (rpn->base.last != cctrl->code_ctrl->ir_code) {
+        b = rpn->base.last;
+        if (b->type == IC_ADDR_OF) {
+          break;
+        }
+      }
+      if (rpn->local_mem->dim.next) {
+        new = A_CALLOC(sizeof(CRPN), cctrl->hc);
+        new->type = IC_ADDR_OF;
+        QueIns(new, rpn->base.last);
+        AssignRawTypeToNode(cctrl, new);
+      }
+      break;
+    case IC_DOT:
+      goto addrof_arr;
+      break;
+    case IC_STATIC:
+      goto addrof_arr;
+    case IC_LOCAL:
+      goto addrof_arr;
+      break;
+    case IC_GLOBAL:
+      if (rpn->global_var->base.type & HTT_GLBL_VAR)
+        if (rpn->global_var->dim.next) {
+          //
+          // Do not get address of thing if we are already getting the address
+          // of it
+          //
+          b = rpn->base.last;
+          if (b->type != IC_ADDR_OF) {
+            new = A_CALLOC(sizeof(CRPN), cctrl->hc);
+            new->type = IC_ADDR_OF;
+            QueIns(new, rpn->base.last);
+            AssignRawTypeToNode(cctrl, new);
+          }
+        }
+      break;
+    default:
+      dim = NULL;
+    }
+  }
+  for (rpn = cctrl->code_ctrl->ir_code->next; rpn != cctrl->code_ctrl->ir_code;
+       rpn = rpn->base.next) {
+    switch (rpn->type) {
+      break;
+    case IC_DOT:
+      raw_type = rpn->raw_type;
+      a = rpn->base.next;
+      total_off = rpn->local_mem->off;
+      for (; a->type == IC_DOT; a = b) {
+        b = a->base.next;
+        raw_type = a->raw_type;
+        total_off += a->local_mem->off;
+        ICFree(a);
+      }
+      new = A_CALLOC(sizeof(CRPN), cctrl->hc);
+      new->type = IC_ADDR_OF;
+      new->raw_type = RT_PTR;
+      QueIns(new, a->base.last);
+      new2 = A_CALLOC(sizeof(CRPN), cctrl->hc);
+      new2->type = IC_ADD;
+      new2->raw_type = RT_PTR;
+      QueIns(new2, rpn);
+      new3 = A_CALLOC(sizeof(CRPN), cctrl->hc);
+      new3->type = IC_I64;
+      new3->integer = total_off;
+      new3->raw_type = RT_I64i;
+      QueIns(new3, new2);
+      rpn->type = IC_DEREF;
+      rpn->raw_type = raw_type;
+      break;
+    case IC_ARROW:
+      new = A_CALLOC(sizeof(CRPN), cctrl->hc);
+      new->type = IC_DEREF;
+      new->raw_type = rpn->raw_type;
+      new->ic_fun = rpn->ic_fun;
+      new->ic_dim = rpn->ic_dim;
+      new2 = A_CALLOC(sizeof(CRPN), cctrl->hc);
+      new2->type = IC_I64;
+      new2->integer = rpn->local_mem->off;
+      new2->raw_type = RT_I64i;
+      QueIns(new2, rpn);
+      QueIns(new, rpn->base.last);
+      rpn->type = IC_ADD;
+      rpn->raw_type = RT_PTR;
+    }
+  }
+  // Remove addresses of dereferences
+  for (rpn = cctrl->code_ctrl->ir_code->next;
+       rpn != cctrl->code_ctrl->ir_code;) {
+    a = rpn;
+    b = rpn->base.next;
+    if (a->type == IC_ADDR_OF) {
+      if (b->type == IC_DEREF) {
+        rpn = b->base.next;
+        ICFree(a);
+        ICFree(b);
+        continue;
+      }
+    }
+    rpn = a->base.next;
+  }
+  A_FREE(list);
 }
 
-#define COMM_ACCUMULATE_FUN(name, __type, oper, is_i64, only_rightside) \
-	static __type name(CCmpCtrl* cctrl, CRPN* rpn, int64_t operator,    \
-		__type cur, int64_t first)                                      \
-	{                                                                   \
-		if (rpn->type != operator)                                      \
-			return cur;                                                 \
-		CRPN *b = rpn->base.next, *a;                                   \
-		a = ICFwd(b);                                                   \
-		if (IsConst(a) && !first && !only_rightside) {                  \
-			if (a->type != IC_F64)                                      \
-				cur oper a->integer;                                    \
-			else                                                        \
-				cur oper a->flt;                                        \
-			ICFree(rpn);                                                \
-			ICFree(a);                                                  \
-			return name(cctrl, b, operator, cur, 0);                    \
-		}                                                               \
-		if (IsConst(b) && !first) {                                     \
-			if (b->type != IC_F64)                                      \
-				cur oper b->integer;                                    \
-			else                                                        \
-				cur oper b->flt;                                        \
-			ICFree(rpn);                                                \
-			ICFree(b);                                                  \
-			return name(cctrl, a, operator, cur, 0);                    \
-		}                                                               \
-		if (first) {                                                    \
-			if (IsConst(a) && !only_rightside) {                        \
-				if (a->type != IC_F64)                                  \
-					cur oper a->integer;                                \
-				else                                                    \
-					cur oper a->flt;                                    \
-				cur = name(cctrl, b, operator, cur, 0);                 \
-				if (!is_i64) {                                          \
-					a->type = IC_F64;                                   \
-					a->flt = cur;                                       \
-				} else {                                                \
-					a->type = IC_I64;                                   \
-					a->integer = cur;                                   \
-				}                                                       \
-			} else if (IsConst(b)) {                                    \
-				if (b->type != IC_F64)                                  \
-					cur oper b->integer;                                \
-				else                                                    \
-					cur oper b->flt;                                    \
-				cur = name(cctrl, a, operator, cur, 0);                 \
-				if (!is_i64) {                                          \
-					b->type = IC_F64;                                   \
-					b->flt = cur;                                       \
-				} else {                                                \
-					b->type = IC_I64;                                   \
-					b->integer = cur;                                   \
-				}                                                       \
-			}                                                           \
-			return 0;                                                   \
-		}                                                               \
-		return cur;                                                     \
-	}
+#define COMM_ACCUMULATE_FUN(name, __type, oper, is_i64, only_rightside)        \
+  static __type name(CCmpCtrl *cctrl, CRPN *rpn, int64_t operator, __type cur, \
+                     int64_t first) {                                          \
+    if (rpn->type != operator)                                                 \
+      return cur;                                                              \
+    CRPN *b = rpn->base.next, *a;                                              \
+    a = ICFwd(b);                                                              \
+    if (IsConst(a) && !first && !only_rightside) {                             \
+      if (a->type != IC_F64)                                                   \
+        cur oper a->integer;                                                   \
+      else                                                                     \
+        cur oper a->flt;                                                       \
+      ICFree(rpn);                                                             \
+      ICFree(a);                                                               \
+      return name(cctrl, b, operator, cur, 0);                                 \
+    }                                                                          \
+    if (IsConst(b) && !first) {                                                \
+      if (b->type != IC_F64)                                                   \
+        cur oper b->integer;                                                   \
+      else                                                                     \
+        cur oper b->flt;                                                       \
+      ICFree(rpn);                                                             \
+      ICFree(b);                                                               \
+      return name(cctrl, a, operator, cur, 0);                                 \
+    }                                                                          \
+    if (first) {                                                               \
+      if (IsConst(a) && !only_rightside) {                                     \
+        if (a->type != IC_F64)                                                 \
+          cur oper a->integer;                                                 \
+        else                                                                   \
+          cur oper a->flt;                                                     \
+        cur = name(cctrl, b, operator, cur, 0);                                \
+        if (!is_i64) {                                                         \
+          a->type = IC_F64;                                                    \
+          a->flt = cur;                                                        \
+        } else {                                                               \
+          a->type = IC_I64;                                                    \
+          a->integer = cur;                                                    \
+        }                                                                      \
+      } else if (IsConst(b)) {                                                 \
+        if (b->type != IC_F64)                                                 \
+          cur oper b->integer;                                                 \
+        else                                                                   \
+          cur oper b->flt;                                                     \
+        cur = name(cctrl, a, operator, cur, 0);                                \
+        if (!is_i64) {                                                         \
+          b->type = IC_F64;                                                    \
+          b->flt = cur;                                                        \
+        } else {                                                               \
+          b->type = IC_I64;                                                    \
+          b->integer = cur;                                                    \
+        }                                                                      \
+      }                                                                        \
+      return 0;                                                                \
+    }                                                                          \
+    return cur;                                                                \
+  }
 
 COMM_ACCUMULATE_FUN(SumComConstsF64, double, +=, 0, 0);
 COMM_ACCUMULATE_FUN(SumComConstsI64, int64_t, +=, 1, 0);
@@ -442,1109 +439,1103 @@ COMM_ACCUMULATE_FUN(SumComConstsI642, int64_t, +=, 1, 1);
 COMM_ACCUMULATE_FUN(MulComConstsF642, double, *=, 0, 1);
 COMM_ACCUMULATE_FUN(MulComConstsI642, int64_t, *=, 1, 1);
 
-void OptPassMergeCommunitives(CCmpCtrl* cctrl)
-{
-	CRPN* rpn;
-	for (rpn = cctrl->code_ctrl->ir_code->next; rpn != cctrl->code_ctrl->ir_code;
-		 rpn = rpn->base.next) {
-		switch (rpn->type) {
-			break;
-		case IC_SUB:
-			if (rpn->raw_type == RT_F64)
-				SumComConstsF642(cctrl, rpn, rpn->type, 0, 1);
-			else
-				SumComConstsI642(cctrl, rpn, rpn->type, 0, 1);
-			break;
-		case IC_ADD:
-			if (rpn->raw_type == RT_F64)
-				SumComConstsF64(cctrl, rpn, rpn->type, 0, 1);
-			else
-				SumComConstsI64(cctrl, rpn, rpn->type, 0, 1);
-			break;
-		case IC_MUL:
-			if (rpn->raw_type == RT_F64)
-				MulComConstsF64(cctrl, rpn, rpn->type, 1, 1);
-			else
-				MulComConstsI64(cctrl, rpn, rpn->type, 1, 1);
-			break;
-		case IC_DIV:
-			if (rpn->raw_type == RT_F64)
-				MulComConstsF642(cctrl, rpn, rpn->type, 1, 1);
-			else
-				MulComConstsI642(cctrl, rpn, rpn->type, 1, 1);
-		}
-	}
+void OptPassMergeCommunitives(CCmpCtrl *cctrl) {
+  CRPN *rpn;
+  for (rpn = cctrl->code_ctrl->ir_code->next; rpn != cctrl->code_ctrl->ir_code;
+       rpn = rpn->base.next) {
+    switch (rpn->type) {
+      break;
+    case IC_SUB:
+      if (rpn->raw_type == RT_F64)
+        SumComConstsF642(cctrl, rpn, rpn->type, 0, 1);
+      else
+        SumComConstsI642(cctrl, rpn, rpn->type, 0, 1);
+      break;
+    case IC_ADD:
+      if (rpn->raw_type == RT_F64)
+        SumComConstsF64(cctrl, rpn, rpn->type, 0, 1);
+      else
+        SumComConstsI64(cctrl, rpn, rpn->type, 0, 1);
+      break;
+    case IC_MUL:
+      if (rpn->raw_type == RT_F64)
+        MulComConstsF64(cctrl, rpn, rpn->type, 1, 1);
+      else
+        MulComConstsI64(cctrl, rpn, rpn->type, 1, 1);
+      break;
+    case IC_DIV:
+      if (rpn->raw_type == RT_F64)
+        MulComConstsF642(cctrl, rpn, rpn->type, 1, 1);
+      else
+        MulComConstsI642(cctrl, rpn, rpn->type, 1, 1);
+    }
+  }
 }
 
-void OptPassConstFold(CCmpCtrl* cctrl)
-{
-#define SET_AB                \
-	if (next->type == IC_F64) \
-		b = next->flt;        \
-	else                      \
-		b = next->integer;    \
-	next = ICFwd(next);       \
-	if (next->type == IC_F64) \
-		a = next->flt;        \
-	else                      \
-		a = next->integer;
-#define SET_A2B2              \
-	if (next->type == IC_F64) \
-		b2 = next->flt;       \
-	else                      \
-		b2 = next->integer;   \
-	next = ICFwd(next);       \
-	if (next->type == IC_F64) \
-		a2 = next->flt;       \
-	else                      \
-		a2 = next->integer;
-	CRPN *rpn, *next, next2;
-	double a, b;
-	int64_t i, a2, b2, changed;
+void OptPassConstFold(CCmpCtrl *cctrl) {
+#define SET_AB                                                                 \
+  if (next->type == IC_F64)                                                    \
+    b = next->flt;                                                             \
+  else                                                                         \
+    b = next->integer;                                                         \
+  next = ICFwd(next);                                                          \
+  if (next->type == IC_F64)                                                    \
+    a = next->flt;                                                             \
+  else                                                                         \
+    a = next->integer;
+#define SET_A2B2                                                               \
+  if (next->type == IC_F64)                                                    \
+    b2 = next->flt;                                                            \
+  else                                                                         \
+    b2 = next->integer;                                                        \
+  next = ICFwd(next);                                                          \
+  if (next->type == IC_F64)                                                    \
+    a2 = next->flt;                                                            \
+  else                                                                         \
+    a2 = next->integer;
+  CRPN *rpn, *next, next2;
+  double a, b;
+  int64_t i, a2, b2, changed;
 loop:
-	changed = 0;
-	for (rpn = cctrl->code_ctrl->ir_code->next;
-		 cctrl->code_ctrl->ir_code != rpn;) {
-		switch (rpn->type) {
-			break;
-		case IC_GOTO:
-		skip:
-			rpn = ICFwd(rpn);
-			break;
-		case IC_LABEL:
-			goto next1;
-			break;
-		next1:
-			rpn = rpn->base.next;
-			break;
-		case IC_STATIC:
-		case IC_LOCAL:
-			goto next1;
-			break;
-		case IC_GLOBAL:
-			goto next1;
-			break;
-		case IC_NOP:
-			goto next1;
-			break;
-		case IC_PAREN:
-			abort();
-			break;
-		case IC_TYPECAST:
-			if(IsConst(next = rpn->base.next)) {
-				if(rpn->raw_type==RT_F64) {
-					switch(rpn->type) {
-						default:
-							rpn->flt=*(double*)&next->integer;
-						break;
-						case IC_F64:
-							rpn->flt=next->flt;
-					}
-					rpn->type=IC_F64;
-				} else {
-					switch(rpn->type) {
-						case IC_F64:
-							rpn->integer=*(int64_t*)&next->flt;
-						break;
-						default:
-							rpn->integer=next->integer;
-					}
-					rpn->type=IC_I64;
-				}
-				changed=1;
-				ICFree(next);
-				break;
-			} else
-				goto next1;
-		case IC_NEG:
-			if (IsConst(next = rpn->base.next)) {
-				rpn->raw_type = next->raw_type;
-				rpn->ic_class = next->ic_class;
-				if (next->type == IC_F64) {
-					rpn->type = IC_F64;
-					rpn->flt = -next->flt;
-					ICFree(next);
-					changed = 1;
-				} else {
-					rpn->type = next->type;
-					rpn->integer = -next->integer;
-					ICFree(next);
-					changed = 1;
-				}
-			}
-			rpn = rpn->base.next;
-			break;
-		case IC_POS:
-			if (IsConst(next = rpn->base.next)) {
-				rpn->raw_type = next->raw_type;
-				rpn->ic_class = next->ic_class;
-				if (next->type == IC_F64) {
-					rpn->type = IC_F64;
-					rpn->flt = +next->flt;
-					ICFree(next);
-					changed = 1;
-				} else {
-					rpn->type = next->type;
-					rpn->integer = +next->integer;
-					ICFree(next);
-					changed = 1;
-				}
-				rpn = rpn->base.next;
-			} else
-				goto next1;
-			break;
-		case IC_NAME:
-			goto next1;
-			break;
-		case IC_STR:
-			goto next1;
-			break;
-		case IC_CHR:
-			goto next1;
-			break;
-		case IC_POW:
-			if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
-				SET_AB;
-				rpn->type = IC_F64;
-				rpn->flt = pow(a, b);
-			} else
-				goto next1;
-		binop_next:
-			ICFree(ICFwd(rpn->base.next));
-			ICFree(rpn->base.next);
-			changed = 1;
-			rpn = rpn->base.next;
-			break;
-		case IC_ADD:
-			if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
-				if (rpn->raw_type == RT_F64) {
-					SET_AB;
-					rpn->type = IC_F64;
-					rpn->flt = a + b;
-				} else {
-					SET_A2B2;
-					rpn->type = IC_I64;
-					rpn->integer = a2 + b2;
-				}
-			} else
-				goto next1;
-			goto binop_next;
-			break;
-		case IC_EQ:
-			goto next1;
-			break;
-		case IC_SUB:
-			if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
-				if (rpn->raw_type == RT_F64) {
-					SET_AB;
-					rpn->type = IC_F64;
-					rpn->flt = a - b;
-				} else {
-					SET_A2B2;
-					rpn->type = IC_I64;
-					rpn->integer = a2 - b2;
-				}
-			} else
-				goto next1;
-			goto binop_next;
-			break;
-		case IC_DIV:
-			if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
-				if (rpn->raw_type == RT_F64) {
-					SET_AB;
-					rpn->type = IC_F64;
-					if (b)
-						rpn->flt = a / b;
-					else
-						rpn->integer = 0; //???
-				} else {
-					SET_A2B2;
-					rpn->type = IC_I64;
-					if (b2)
-						rpn->integer = a2 / b2;
-					else
-						rpn->integer = 0; //???
-				}
-			} else
-				goto next1;
-			goto binop_next;
-			break;
-		case IC_MUL:
-			if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
-				if (rpn->raw_type == RT_F64) {
-					SET_AB;
-					rpn->type = IC_F64;
-					rpn->flt = a * b;
-				} else {
-					SET_A2B2;
-					rpn->type = IC_I64;
-					rpn->integer = a2 * b2;
-				}
-			} else
-				goto next1;
-			goto binop_next;
-			break;
-		case IC_DEREF:
-			goto next1;
-			break;
-		case IC_AND:
-			if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
-				if (rpn->raw_type == RT_F64) {
-					SET_AB;
-					rpn->type = IC_F64;
-					rpn->flt = ((int64_t*)&a)[0] & ((int64_t*)&b)[0];
-				} else {
-					SET_A2B2;
-					rpn->type = IC_I64;
-					rpn->integer = a2 & b2;
-				}
-			} else
-				goto next1;
-			goto binop_next;
-			break;
-		case IC_ADDR_OF:
-			goto next1;
-			break;
-		case IC_XOR:
-			if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
-				if (rpn->raw_type == RT_F64) {
-					SET_AB;
-					rpn->type = IC_F64;
-					rpn->flt = ((int64_t*)&a)[0] ^ ((int64_t*)&b)[0];
-				} else {
-					SET_A2B2;
-					rpn->type = IC_I64;
-					rpn->integer = a2 ^ b2;
-				}
-			} else
-				goto next1;
-			goto binop_next;
-			break;
-		case IC_MOD:
-			if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
-				if (rpn->raw_type == RT_F64) {
-					SET_AB;
-					if (!b)
-						goto next1;
-					rpn->type = IC_F64;
-					rpn->flt = fmod(a, b);
-				} else {
-					SET_A2B2;
-					if (!b2)
-						goto next1;
-					rpn->type = IC_I64;
-					rpn->integer = a2 % b2;
-				}
-			} else
-				goto next1;
-			goto binop_next;
-			break;
-		case IC_OR:
-			if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
-				if (rpn->raw_type == RT_F64) {
-					SET_AB;
-					rpn->type = IC_F64;
-					rpn->flt = ((int64_t*)&a)[0] | ((int64_t*)&b)[0];
-				} else {
-					SET_A2B2;
-					rpn->type = IC_I64;
-					rpn->integer = a2 | b2;
-				}
-			} else
-				goto next1;
-			goto binop_next;
-			break;
-		case IC_LT:
-			if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
-				if (rpn->raw_type == RT_F64) {
-					SET_AB;
-					rpn->type = IC_F64;
-					rpn->flt = a < b;
-				} else {
-					SET_A2B2;
-					rpn->type = IC_I64;
-					rpn->integer = a2 < b2;
-				}
-			} else
-				goto next1;
-			goto binop_next;
-			break;
-		case IC_GT:
-			if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
-				if (rpn->raw_type == RT_F64) {
-					SET_AB;
-					rpn->type = IC_F64;
-					rpn->flt = a > b;
-				} else {
-					SET_A2B2;
-					rpn->type = IC_I64;
-					rpn->integer = a2 > b2;
-				}
-			} else
-				goto next1;
-			goto binop_next;
-			break;
-		case IC_LNOT:
-			if (IsConst(next = rpn->base.next)) {
-				rpn->type = IC_I64;
-				if (next->type == IC_F64)
-					rpn->integer = !next->flt;
-				else
-					rpn->integer = !next->integer;
-				ICFree(next);
-				changed = 1;
-			}
-			goto next1;
-			break;
-		case IC_BNOT:
-			if (IsConst(next = rpn->base.next)) {
-				rpn->type = IC_I64;
-				if (next->type == IC_F64)
-					rpn->integer = ~next->integer; // Type punning
-				else
-					rpn->integer = ~next->integer;
-				ICFree(next);
-				changed = 1;
-			}
-			goto next1;
-			break;
-		case IC_POST_INC:
-			goto next1;
-			break;
-		case IC_POST_DEC:
-			goto next1;
-			break;
-		case IC_PRE_INC:
-			goto next1;
-			break;
-		case IC_PRE_DEC:
-			goto next1;
-			break;
-		case IC_AND_AND:
-			if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
-				if (next->type == IC_F64)
-					b2 = !!next->flt;
-				else
-					b2 = next->integer;
-				next = ICFwd(next);
-				if (next->type == IC_F64)
-					a2 = !!next->flt;
-				else
-					a2 = next->integer;
-				rpn->type = IC_I64;
-				rpn->integer = a2 && b2;
-				goto binop_next;
-			} else
-				goto next1;
-			break;
-		case IC_OR_OR:
-			if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
-				if (next->type == IC_F64)
-					b2 = !!next->flt;
-				else
-					b2 = next->integer;
-				next = ICFwd(next);
-				if (next->type == IC_F64)
-					a2 = !!next->flt;
-				else
-					a2 = next->integer;
-				rpn->type = IC_I64;
-				rpn->integer = a2 || b2;
-				goto binop_next;
-			} else
-				goto next1;
-			break;
-		case IC_XOR_XOR:
-			if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
-				if (next->type == IC_F64)
-					b2 = !!next->flt;
-				else
-					b2 = next->integer;
-				next = ICFwd(next);
-				if (next->type == IC_F64)
-					a2 = !!next->flt;
-				else
-					a2 = next->integer;
-				rpn->type = IC_I64;
-				rpn->integer = !!a2 ^ !!b2;
-				goto binop_next;
-			} else
-				goto next1;
-			break;
-		case IC_EQ_EQ:
-			if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
-				if (rpn->raw_type == RT_F64) {
-					SET_AB;
-					rpn->type = IC_F64;
-					rpn->flt = a == b;
-				} else {
-					SET_A2B2;
-					rpn->type = IC_I64;
-					rpn->integer = a2 == b2;
-				}
-			} else
-				goto next1;
-			goto binop_next;
-			break;
-		case IC_NE:
-			if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
-				if (rpn->raw_type == RT_F64) {
-					SET_AB;
-					rpn->type = IC_F64;
-					rpn->flt = a != b;
-				} else {
-					SET_A2B2;
-					rpn->type = IC_I64;
-					rpn->integer = a2 != b2;
-				}
-			} else
-				goto next1;
-			goto binop_next;
-			break;
-		case IC_LE:
-			if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
-				if (rpn->raw_type == RT_F64) {
-					SET_AB;
-					rpn->type = IC_F64;
-					rpn->flt = a <= b;
-				} else {
-					SET_A2B2;
-					rpn->type = IC_I64;
-					rpn->integer = a2 <= b2;
-				}
-			} else
-				goto next1;
-			goto binop_next;
-			break;
-		case IC_GE:
-			if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
-				if (rpn->raw_type == RT_F64) {
-					SET_AB;
-					rpn->type = IC_F64;
-					rpn->flt = a >= b;
-				} else {
-					SET_A2B2;
-					rpn->type = IC_I64;
-					rpn->integer = a2 >= b2;
-				}
-			} else
-				goto next1;
-			goto binop_next;
-			break;
-		case IC_LSH:
-			if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
-				if (rpn->raw_type == RT_F64) {
-					SET_AB;
-					rpn->type = IC_F64;
-					rpn->integer = ((int64_t*)&a)[0]
-						<< ((int64_t*)&b)[0]; // Type punning
-				} else {
-					SET_A2B2;
-					rpn->type = IC_I64;
-					rpn->integer = a2 << b2;
-				}
-			} else
-				goto next1;
-			goto binop_next;
-			break;
-		case IC_RSH:
-			if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
-				if (rpn->raw_type == RT_F64) {
-					SET_AB;
-					rpn->type = IC_F64;
-					rpn->integer = ((int64_t*)&a)[0] >> ((int64_t*)&b)[0]; // Type punning
-				} else {
-					SET_A2B2;
-					rpn->type = IC_I64;
-					rpn->integer = a2 >> b2; // TODO arithmetic or logical
-				}
-			} else
-				goto next1;
-			goto binop_next;
-			break;
-		case IC_ADD_EQ:
-			goto next1;
-			break;
-		case IC_SUB_EQ:
-			goto next1;
-			break;
-		case IC_MUL_EQ:
-			goto next1;
-			break;
-		case IC_DIV_EQ:
-			goto next1;
-			break;
-		case IC_LSH_EQ:
-			goto next1;
-			break;
-		case IC_RSH_EQ:
-			goto next1;
-			break;
-		case IC_AND_EQ:
-			goto next1;
-			break;
-		case IC_OR_EQ:
-			goto next1;
-			break;
-		case IC_XOR_EQ:
-			goto next1;
-			break;
-		case IC_ARROW:
-			goto next1;
-			break;
-		case IC_MOD_EQ:
-			goto next1;
-			break;
-		case IC_I64:
-			goto next1;
-			break;
-		case IC_F64:
-			goto next1;
-			break;
-		case IC_ARRAY_ACC:
-			goto next1;
-			break;
-		default:
-			goto next1;
-		}
-	}
-	if (changed)
-		goto loop;
+  changed = 0;
+  for (rpn = cctrl->code_ctrl->ir_code->next;
+       cctrl->code_ctrl->ir_code != rpn;) {
+    switch (rpn->type) {
+      break;
+    case IC_GOTO:
+    skip:
+      rpn = ICFwd(rpn);
+      break;
+    case IC_LABEL:
+      goto next1;
+      break;
+    next1:
+      rpn = rpn->base.next;
+      break;
+    case IC_STATIC:
+    case IC_LOCAL:
+      goto next1;
+      break;
+    case IC_GLOBAL:
+      goto next1;
+      break;
+    case IC_NOP:
+      goto next1;
+      break;
+    case IC_PAREN:
+      abort();
+      break;
+    case IC_TYPECAST:
+      if (IsConst(next = rpn->base.next)) {
+        if (rpn->raw_type == RT_F64) {
+          switch (rpn->type) {
+          default:
+            rpn->flt = *(double *)&next->integer;
+            break;
+          case IC_F64:
+            rpn->flt = next->flt;
+          }
+          rpn->type = IC_F64;
+        } else {
+          switch (rpn->type) {
+          case IC_F64:
+            rpn->integer = *(int64_t *)&next->flt;
+            break;
+          default:
+            rpn->integer = next->integer;
+          }
+          rpn->type = IC_I64;
+        }
+        changed = 1;
+        ICFree(next);
+        break;
+      } else
+        goto next1;
+    case IC_NEG:
+      if (IsConst(next = rpn->base.next)) {
+        rpn->raw_type = next->raw_type;
+        rpn->ic_class = next->ic_class;
+        if (next->type == IC_F64) {
+          rpn->type = IC_F64;
+          rpn->flt = -next->flt;
+          ICFree(next);
+          changed = 1;
+        } else {
+          rpn->type = next->type;
+          rpn->integer = -next->integer;
+          ICFree(next);
+          changed = 1;
+        }
+      }
+      rpn = rpn->base.next;
+      break;
+    case IC_POS:
+      if (IsConst(next = rpn->base.next)) {
+        rpn->raw_type = next->raw_type;
+        rpn->ic_class = next->ic_class;
+        if (next->type == IC_F64) {
+          rpn->type = IC_F64;
+          rpn->flt = +next->flt;
+          ICFree(next);
+          changed = 1;
+        } else {
+          rpn->type = next->type;
+          rpn->integer = +next->integer;
+          ICFree(next);
+          changed = 1;
+        }
+        rpn = rpn->base.next;
+      } else
+        goto next1;
+      break;
+    case IC_NAME:
+      goto next1;
+      break;
+    case IC_STR:
+      goto next1;
+      break;
+    case IC_CHR:
+      goto next1;
+      break;
+    case IC_POW:
+      if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
+        SET_AB;
+        rpn->type = IC_F64;
+        rpn->flt = pow(a, b);
+      } else
+        goto next1;
+    binop_next:
+      ICFree(ICFwd(rpn->base.next));
+      ICFree(rpn->base.next);
+      changed = 1;
+      rpn = rpn->base.next;
+      break;
+    case IC_ADD:
+      if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
+        if (rpn->raw_type == RT_F64) {
+          SET_AB;
+          rpn->type = IC_F64;
+          rpn->flt = a + b;
+        } else {
+          SET_A2B2;
+          rpn->type = IC_I64;
+          rpn->integer = a2 + b2;
+        }
+      } else
+        goto next1;
+      goto binop_next;
+      break;
+    case IC_EQ:
+      goto next1;
+      break;
+    case IC_SUB:
+      if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
+        if (rpn->raw_type == RT_F64) {
+          SET_AB;
+          rpn->type = IC_F64;
+          rpn->flt = a - b;
+        } else {
+          SET_A2B2;
+          rpn->type = IC_I64;
+          rpn->integer = a2 - b2;
+        }
+      } else
+        goto next1;
+      goto binop_next;
+      break;
+    case IC_DIV:
+      if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
+        if (rpn->raw_type == RT_F64) {
+          SET_AB;
+          rpn->type = IC_F64;
+          if (b)
+            rpn->flt = a / b;
+          else
+            rpn->integer = 0; //???
+        } else {
+          SET_A2B2;
+          rpn->type = IC_I64;
+          if (b2)
+            rpn->integer = a2 / b2;
+          else
+            rpn->integer = 0; //???
+        }
+      } else
+        goto next1;
+      goto binop_next;
+      break;
+    case IC_MUL:
+      if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
+        if (rpn->raw_type == RT_F64) {
+          SET_AB;
+          rpn->type = IC_F64;
+          rpn->flt = a * b;
+        } else {
+          SET_A2B2;
+          rpn->type = IC_I64;
+          rpn->integer = a2 * b2;
+        }
+      } else
+        goto next1;
+      goto binop_next;
+      break;
+    case IC_DEREF:
+      goto next1;
+      break;
+    case IC_AND:
+      if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
+        if (rpn->raw_type == RT_F64) {
+          SET_AB;
+          rpn->type = IC_F64;
+          rpn->flt = ((int64_t *)&a)[0] & ((int64_t *)&b)[0];
+        } else {
+          SET_A2B2;
+          rpn->type = IC_I64;
+          rpn->integer = a2 & b2;
+        }
+      } else
+        goto next1;
+      goto binop_next;
+      break;
+    case IC_ADDR_OF:
+      goto next1;
+      break;
+    case IC_XOR:
+      if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
+        if (rpn->raw_type == RT_F64) {
+          SET_AB;
+          rpn->type = IC_F64;
+          rpn->flt = ((int64_t *)&a)[0] ^ ((int64_t *)&b)[0];
+        } else {
+          SET_A2B2;
+          rpn->type = IC_I64;
+          rpn->integer = a2 ^ b2;
+        }
+      } else
+        goto next1;
+      goto binop_next;
+      break;
+    case IC_MOD:
+      if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
+        if (rpn->raw_type == RT_F64) {
+          SET_AB;
+          if (!b)
+            goto next1;
+          rpn->type = IC_F64;
+          rpn->flt = fmod(a, b);
+        } else {
+          SET_A2B2;
+          if (!b2)
+            goto next1;
+          rpn->type = IC_I64;
+          rpn->integer = a2 % b2;
+        }
+      } else
+        goto next1;
+      goto binop_next;
+      break;
+    case IC_OR:
+      if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
+        if (rpn->raw_type == RT_F64) {
+          SET_AB;
+          rpn->type = IC_F64;
+          rpn->flt = ((int64_t *)&a)[0] | ((int64_t *)&b)[0];
+        } else {
+          SET_A2B2;
+          rpn->type = IC_I64;
+          rpn->integer = a2 | b2;
+        }
+      } else
+        goto next1;
+      goto binop_next;
+      break;
+    case IC_LT:
+      if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
+        if (rpn->raw_type == RT_F64) {
+          SET_AB;
+          rpn->type = IC_F64;
+          rpn->flt = a < b;
+        } else {
+          SET_A2B2;
+          rpn->type = IC_I64;
+          rpn->integer = a2 < b2;
+        }
+      } else
+        goto next1;
+      goto binop_next;
+      break;
+    case IC_GT:
+      if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
+        if (rpn->raw_type == RT_F64) {
+          SET_AB;
+          rpn->type = IC_F64;
+          rpn->flt = a > b;
+        } else {
+          SET_A2B2;
+          rpn->type = IC_I64;
+          rpn->integer = a2 > b2;
+        }
+      } else
+        goto next1;
+      goto binop_next;
+      break;
+    case IC_LNOT:
+      if (IsConst(next = rpn->base.next)) {
+        rpn->type = IC_I64;
+        if (next->type == IC_F64)
+          rpn->integer = !next->flt;
+        else
+          rpn->integer = !next->integer;
+        ICFree(next);
+        changed = 1;
+      }
+      goto next1;
+      break;
+    case IC_BNOT:
+      if (IsConst(next = rpn->base.next)) {
+        rpn->type = IC_I64;
+        if (next->type == IC_F64)
+          rpn->integer = ~next->integer; // Type punning
+        else
+          rpn->integer = ~next->integer;
+        ICFree(next);
+        changed = 1;
+      }
+      goto next1;
+      break;
+    case IC_POST_INC:
+      goto next1;
+      break;
+    case IC_POST_DEC:
+      goto next1;
+      break;
+    case IC_PRE_INC:
+      goto next1;
+      break;
+    case IC_PRE_DEC:
+      goto next1;
+      break;
+    case IC_AND_AND:
+      if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
+        if (next->type == IC_F64)
+          b2 = !!next->flt;
+        else
+          b2 = next->integer;
+        next = ICFwd(next);
+        if (next->type == IC_F64)
+          a2 = !!next->flt;
+        else
+          a2 = next->integer;
+        rpn->type = IC_I64;
+        rpn->integer = a2 && b2;
+        goto binop_next;
+      } else
+        goto next1;
+      break;
+    case IC_OR_OR:
+      if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
+        if (next->type == IC_F64)
+          b2 = !!next->flt;
+        else
+          b2 = next->integer;
+        next = ICFwd(next);
+        if (next->type == IC_F64)
+          a2 = !!next->flt;
+        else
+          a2 = next->integer;
+        rpn->type = IC_I64;
+        rpn->integer = a2 || b2;
+        goto binop_next;
+      } else
+        goto next1;
+      break;
+    case IC_XOR_XOR:
+      if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
+        if (next->type == IC_F64)
+          b2 = !!next->flt;
+        else
+          b2 = next->integer;
+        next = ICFwd(next);
+        if (next->type == IC_F64)
+          a2 = !!next->flt;
+        else
+          a2 = next->integer;
+        rpn->type = IC_I64;
+        rpn->integer = !!a2 ^ !!b2;
+        goto binop_next;
+      } else
+        goto next1;
+      break;
+    case IC_EQ_EQ:
+      if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
+        if (rpn->raw_type == RT_F64) {
+          SET_AB;
+          rpn->type = IC_F64;
+          rpn->flt = a == b;
+        } else {
+          SET_A2B2;
+          rpn->type = IC_I64;
+          rpn->integer = a2 == b2;
+        }
+      } else
+        goto next1;
+      goto binop_next;
+      break;
+    case IC_NE:
+      if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
+        if (rpn->raw_type == RT_F64) {
+          SET_AB;
+          rpn->type = IC_F64;
+          rpn->flt = a != b;
+        } else {
+          SET_A2B2;
+          rpn->type = IC_I64;
+          rpn->integer = a2 != b2;
+        }
+      } else
+        goto next1;
+      goto binop_next;
+      break;
+    case IC_LE:
+      if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
+        if (rpn->raw_type == RT_F64) {
+          SET_AB;
+          rpn->type = IC_F64;
+          rpn->flt = a <= b;
+        } else {
+          SET_A2B2;
+          rpn->type = IC_I64;
+          rpn->integer = a2 <= b2;
+        }
+      } else
+        goto next1;
+      goto binop_next;
+      break;
+    case IC_GE:
+      if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
+        if (rpn->raw_type == RT_F64) {
+          SET_AB;
+          rpn->type = IC_F64;
+          rpn->flt = a >= b;
+        } else {
+          SET_A2B2;
+          rpn->type = IC_I64;
+          rpn->integer = a2 >= b2;
+        }
+      } else
+        goto next1;
+      goto binop_next;
+      break;
+    case IC_LSH:
+      if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
+        if (rpn->raw_type == RT_F64) {
+          SET_AB;
+          rpn->type = IC_F64;
+          rpn->integer = ((int64_t *)&a)[0]
+                         << ((int64_t *)&b)[0]; // Type punning
+        } else {
+          SET_A2B2;
+          rpn->type = IC_I64;
+          rpn->integer = a2 << b2;
+        }
+      } else
+        goto next1;
+      goto binop_next;
+      break;
+    case IC_RSH:
+      if (IsConst(next = rpn->base.next) && IsConst(ICFwd(rpn->base.next))) {
+        if (rpn->raw_type == RT_F64) {
+          SET_AB;
+          rpn->type = IC_F64;
+          rpn->integer =
+              ((int64_t *)&a)[0] >> ((int64_t *)&b)[0]; // Type punning
+        } else {
+          SET_A2B2;
+          rpn->type = IC_I64;
+          rpn->integer = a2 >> b2; // TODO arithmetic or logical
+        }
+      } else
+        goto next1;
+      goto binop_next;
+      break;
+    case IC_ADD_EQ:
+      goto next1;
+      break;
+    case IC_SUB_EQ:
+      goto next1;
+      break;
+    case IC_MUL_EQ:
+      goto next1;
+      break;
+    case IC_DIV_EQ:
+      goto next1;
+      break;
+    case IC_LSH_EQ:
+      goto next1;
+      break;
+    case IC_RSH_EQ:
+      goto next1;
+      break;
+    case IC_AND_EQ:
+      goto next1;
+      break;
+    case IC_OR_EQ:
+      goto next1;
+      break;
+    case IC_XOR_EQ:
+      goto next1;
+      break;
+    case IC_ARROW:
+      goto next1;
+      break;
+    case IC_MOD_EQ:
+      goto next1;
+      break;
+    case IC_I64:
+      goto next1;
+      break;
+    case IC_F64:
+      goto next1;
+      break;
+    case IC_ARRAY_ACC:
+      goto next1;
+      break;
+    default:
+      goto next1;
+    }
+  }
+  if (changed)
+    goto loop;
 }
 
 typedef struct {
-	int64_t score;
-	CMemberLst* m;
+  int64_t score;
+  CMemberLst *m;
 } COptMemberVar;
-static int64_t OptMemberVarSort(COptMemberVar* a, COptMemberVar* b)
-{
-	return a->score - b->score;
+static int64_t OptMemberVarSort(COptMemberVar *a, COptMemberVar *b) {
+  return a->score - b->score;
 }
 
-static int64_t OptMemberVarSortSz(COptMemberVar* a, COptMemberVar* b)
-{
-	int64_t asz = a->m->member_class->sz * a->m->dim.total_cnt;
-	int64_t bsz = b->m->member_class->sz * b->m->dim.total_cnt;
-	return asz - bsz;
+static int64_t OptMemberVarSortSz(COptMemberVar *a, COptMemberVar *b) {
+  int64_t asz = a->m->member_class->sz * a->m->dim.total_cnt;
+  int64_t bsz = b->m->member_class->sz * b->m->dim.total_cnt;
+  return asz - bsz;
 }
 
-void OptPassRegAlloc(CCmpCtrl* cctrl)
-{
-	/*
-	 * Heres the deal. AIWNIOS will not do fancy register allocation
-	 * shenanigins. We will get a score for REG_MAYBE|REG_ALLOC(bigger
-	 * score means more chance of getting put in a register).
-	 * If we dereference a variable with IC_ADDR,it will be turned into
-	 * REG_NONE(can't get pointer of register)
-	 */
-	COptMemberVar* mv;
-	CMemberLst* tmpm;
-	CRPN *rpn, *next;
-	int64_t i, cnt, ireg, freg, off, align, sz;
-	if (!cctrl->cur_fun)
-		return;
-	mv = A_CALLOC(sizeof(COptMemberVar) * cctrl->cur_fun->base.member_cnt, NULL);
-	i = 0;
-	for (tmpm = cctrl->cur_fun->base.members_lst; tmpm; tmpm = tmpm->next) {
-		mv[i].m = tmpm;
-		if (tmpm->flags & MLF_STATIC)
-			mv[i].m->reg = REG_NONE;
-		mv[i++].score = 1;
-	}
-	for (rpn = cctrl->code_ctrl->ir_code->next; rpn != cctrl->code_ctrl->ir_code;
-		 rpn = rpn->base.next) {
-		switch (rpn->type) {
-			break;
-		case IC_GOTO:
-			continue;
-			break;
-		case IC_STATIC:
-		case IC_LABEL:
-			continue;
-			break;
-			break;
-		case IC_LOCAL:
-			for (i = 0; i != cctrl->cur_fun->base.member_cnt; i++) {
-				if (mv[i].m == rpn->local_mem) {
-					mv[i].score++;
-					break;
-				}
-			}
-			break;
-		case IC_GLOBAL:
-			continue;
-			break;
-		case IC_NOP:
-			continue;
-			break;
-		case IC_PAREN:
-			abort();
-			break;
-		case IC_NEG:
-			continue;
-			break;
-		case IC_POS:
-			continue;
-			break;
-		case IC_NAME:
-			abort();
-			break;
-		case IC_STR:
-			continue;
-			break;
-		case IC_CHR:
-			continue;
-			break;
-		case IC_POW:
-			continue;
-			break;
-		case IC_ADD:
-			continue;
-			break;
-		case IC_EQ:
-			continue;
-			break;
-		case IC_SUB:
-			continue;
-			break;
-		case IC_DIV:
-			continue;
-			break;
-		case IC_MUL:
-			continue;
-			break;
-		case IC_DEREF:
-			continue;
-			break;
-		case IC_AND:
-			continue;
-			break;
-		case IC_ADDR_OF:
-			next = rpn->base.next;
-			if (next->type == IC_LOCAL) {
-				for (i = 0; i != cctrl->cur_fun->base.member_cnt; i++) {
-					if (mv[i].m == next->local_mem) {
-						mv[i].score = 0;
-						mv[i].m->reg = REG_NONE;
-						break;
-					}
-				}
-			}
-			continue;
-			break;
-		case IC_XOR:
-			continue;
-			break;
-		case IC_MOD:
-			continue;
-			break;
-		case IC_OR:
-			continue;
-			break;
-		case IC_LT:
-			continue;
-			break;
-		case IC_GT:
-			continue;
-			break;
-		case IC_LNOT:
-			continue;
-			break;
-		case IC_BNOT:
-			continue;
-			break;
-		case IC_POST_INC:
-			continue;
-			break;
-		case IC_POST_DEC:
-			continue;
-			break;
-		case IC_PRE_INC:
-			continue;
-			break;
-		case IC_PRE_DEC:
-			continue;
-			break;
-		case IC_AND_AND:
-			continue;
-			break;
-		case IC_OR_OR:
-			continue;
-			break;
-		case IC_XOR_XOR:
-			continue;
-			break;
-		case IC_EQ_EQ:
-			continue;
-			break;
-		case IC_NE:
-			continue;
-			break;
-		case IC_LE:
-			continue;
-			break;
-		case IC_GE:
-			continue;
-			break;
-		case IC_LSH:
-			continue;
-			break;
-		case IC_RSH:
-			continue;
-			break;
-		case IC_ADD_EQ:
-			continue;
-			break;
-		case IC_SUB_EQ:
-			continue;
-			break;
-		case IC_MUL_EQ:
-			continue;
-			break;
-		case IC_DIV_EQ:
-			continue;
-			break;
-		case IC_LSH_EQ:
-			continue;
-			break;
-		case IC_RSH_EQ:
-			continue;
-			break;
-		case IC_AND_EQ:
-			continue;
-			break;
-		case IC_OR_EQ:
-			continue;
-			break;
-		case IC_XOR_EQ:
-			continue;
-			break;
-		case IC_ARROW:
-			continue;
-			break;
-		case IC_MOD_EQ:
-			continue;
-			break;
-		case IC_I64:
-			continue;
-			break;
-		case IC_F64:
-			continue;
-			break;
-		case IC_ARRAY_ACC:
-			continue;
-			break;
-		}
-	}
-	qsort(mv, cnt = cctrl->cur_fun->base.member_cnt, sizeof(COptMemberVar),
-		OptMemberVarSort);
-	ireg = AIWNIOS_IREG_START;
-	freg = AIWNIOS_FREG_START;
-	for (i = cnt - 1; i >= 0; i--) {
-		if (mv[i].m->reg == REG_MAYBE || mv[i].m->reg == REG_ALLOC) {
-			if (mv[i].m->member_class->raw_type == RT_F64) {
-				if (freg - AIWNIOS_FREG_START < AIWNIOS_FREG_CNT) {
-					mv[i].m->reg = freg++;
-				} else
-					mv[i].m->reg = REG_NONE;
-			} else if (RT_I8i <= mv[i].m->member_class->raw_type && mv[i].m->member_class->raw_type <= RT_PTR && !mv[i].m->dim.next) {
-				if (ireg - AIWNIOS_IREG_START < AIWNIOS_IREG_CNT) {
+void OptPassRegAlloc(CCmpCtrl *cctrl) {
+  /*
+   * Heres the deal. AIWNIOS will not do fancy register allocation
+   * shenanigins. We will get a score for REG_MAYBE|REG_ALLOC(bigger
+   * score means more chance of getting put in a register).
+   * If we dereference a variable with IC_ADDR,it will be turned into
+   * REG_NONE(can't get pointer of register)
+   */
+  COptMemberVar *mv;
+  CMemberLst *tmpm;
+  CRPN *rpn, *next;
+  int64_t i, cnt, ireg, freg, off, align, sz;
+  if (!cctrl->cur_fun)
+    return;
+  mv = A_CALLOC(sizeof(COptMemberVar) * cctrl->cur_fun->base.member_cnt, NULL);
+  i = 0;
+  for (tmpm = cctrl->cur_fun->base.members_lst; tmpm; tmpm = tmpm->next) {
+    mv[i].m = tmpm;
+    if (tmpm->flags & MLF_STATIC)
+      mv[i].m->reg = REG_NONE;
+    mv[i++].score = 1;
+  }
+  for (rpn = cctrl->code_ctrl->ir_code->next; rpn != cctrl->code_ctrl->ir_code;
+       rpn = rpn->base.next) {
+    switch (rpn->type) {
+      break;
+    case IC_GOTO:
+      continue;
+      break;
+    case IC_STATIC:
+    case IC_LABEL:
+      continue;
+      break;
+      break;
+    case IC_LOCAL:
+      for (i = 0; i != cctrl->cur_fun->base.member_cnt; i++) {
+        if (mv[i].m == rpn->local_mem) {
+          mv[i].score++;
+          break;
+        }
+      }
+      break;
+    case IC_GLOBAL:
+      continue;
+      break;
+    case IC_NOP:
+      continue;
+      break;
+    case IC_PAREN:
+      abort();
+      break;
+    case IC_NEG:
+      continue;
+      break;
+    case IC_POS:
+      continue;
+      break;
+    case IC_NAME:
+      abort();
+      break;
+    case IC_STR:
+      continue;
+      break;
+    case IC_CHR:
+      continue;
+      break;
+    case IC_POW:
+      continue;
+      break;
+    case IC_ADD:
+      continue;
+      break;
+    case IC_EQ:
+      continue;
+      break;
+    case IC_SUB:
+      continue;
+      break;
+    case IC_DIV:
+      continue;
+      break;
+    case IC_MUL:
+      continue;
+      break;
+    case IC_DEREF:
+      continue;
+      break;
+    case IC_AND:
+      continue;
+      break;
+    case IC_ADDR_OF:
+      next = rpn->base.next;
+      if (next->type == IC_LOCAL) {
+        for (i = 0; i != cctrl->cur_fun->base.member_cnt; i++) {
+          if (mv[i].m == next->local_mem) {
+            mv[i].score = 0;
+            mv[i].m->reg = REG_NONE;
+            break;
+          }
+        }
+      }
+      continue;
+      break;
+    case IC_XOR:
+      continue;
+      break;
+    case IC_MOD:
+      continue;
+      break;
+    case IC_OR:
+      continue;
+      break;
+    case IC_LT:
+      continue;
+      break;
+    case IC_GT:
+      continue;
+      break;
+    case IC_LNOT:
+      continue;
+      break;
+    case IC_BNOT:
+      continue;
+      break;
+    case IC_POST_INC:
+      continue;
+      break;
+    case IC_POST_DEC:
+      continue;
+      break;
+    case IC_PRE_INC:
+      continue;
+      break;
+    case IC_PRE_DEC:
+      continue;
+      break;
+    case IC_AND_AND:
+      continue;
+      break;
+    case IC_OR_OR:
+      continue;
+      break;
+    case IC_XOR_XOR:
+      continue;
+      break;
+    case IC_EQ_EQ:
+      continue;
+      break;
+    case IC_NE:
+      continue;
+      break;
+    case IC_LE:
+      continue;
+      break;
+    case IC_GE:
+      continue;
+      break;
+    case IC_LSH:
+      continue;
+      break;
+    case IC_RSH:
+      continue;
+      break;
+    case IC_ADD_EQ:
+      continue;
+      break;
+    case IC_SUB_EQ:
+      continue;
+      break;
+    case IC_MUL_EQ:
+      continue;
+      break;
+    case IC_DIV_EQ:
+      continue;
+      break;
+    case IC_LSH_EQ:
+      continue;
+      break;
+    case IC_RSH_EQ:
+      continue;
+      break;
+    case IC_AND_EQ:
+      continue;
+      break;
+    case IC_OR_EQ:
+      continue;
+      break;
+    case IC_XOR_EQ:
+      continue;
+      break;
+    case IC_ARROW:
+      continue;
+      break;
+    case IC_MOD_EQ:
+      continue;
+      break;
+    case IC_I64:
+      continue;
+      break;
+    case IC_F64:
+      continue;
+      break;
+    case IC_ARRAY_ACC:
+      continue;
+      break;
+    }
+  }
+  qsort(mv, cnt = cctrl->cur_fun->base.member_cnt, sizeof(COptMemberVar),
+        OptMemberVarSort);
+  ireg = AIWNIOS_IREG_START;
+  freg = AIWNIOS_FREG_START;
+  for (i = cnt - 1; i >= 0; i--) {
+    if (mv[i].m->reg == REG_MAYBE || mv[i].m->reg == REG_ALLOC) {
+      if (mv[i].m->member_class->raw_type == RT_F64) {
+        if (freg - AIWNIOS_FREG_START < AIWNIOS_FREG_CNT) {
+          mv[i].m->reg = freg++;
+        } else
+          mv[i].m->reg = REG_NONE;
+      } else if (RT_I8i <= mv[i].m->member_class->raw_type &&
+                 mv[i].m->member_class->raw_type <= RT_PTR &&
+                 !mv[i].m->dim.next) {
+        if (ireg - AIWNIOS_IREG_START < AIWNIOS_IREG_CNT) {
 #if defined(__x86_64__)
-					switch (ireg++ - AIWNIOS_IREG_START) {
-						break;
-					case 0:
-						mv[i].m->reg = RDI;
-						break;
-					case 1:
-						mv[i].m->reg = RSI;
-						break;
-					case 2:
-						mv[i].m->reg = R10;
-						break;
-					case 3:
-						mv[i].m->reg = R11;
-						break;
-					case 4:
-						mv[i].m->reg = R12;
-						break;
-					case 5:
-					//TODO something with R13
-						mv[i].m->reg = R14;
-						break;
-					case 6:
-						mv[i].m->reg = R15;
-						break;
-					default:
-						abort();
-					}
+          switch (ireg++ - AIWNIOS_IREG_START) {
+            break;
+          case 0:
+            mv[i].m->reg = RDI;
+            break;
+          case 1:
+            mv[i].m->reg = RSI;
+            break;
+          case 2:
+            mv[i].m->reg = R10;
+            break;
+          case 3:
+            mv[i].m->reg = R11;
+            break;
+          case 4:
+            mv[i].m->reg = R12;
+            break;
+          case 5:
+            // TODO something with R13
+            mv[i].m->reg = R14;
+            break;
+          case 6:
+            mv[i].m->reg = R15;
+            break;
+          default:
+            abort();
+          }
 #endif
 #if defined(__aarch64__) || defined(_M_ARM64)
-					mv[i].m->reg = ireg++;
+          mv[i].m->reg = ireg++;
 #endif
-				} else
-					mv[i].m->reg = REG_NONE;
-			} else
-				mv[i].m->reg = REG_NONE;
-		}
-	}
-	// Time to assign the rest of the function members to the base pointer
-	qsort(mv, cnt, sizeof(COptMemberVar), OptMemberVarSortSz);
-	off = 0;
-	for (i = 0; i != cnt; i++) {
-		if (mv[i].m->reg == REG_NONE && !(mv[i].m->flags & MLF_STATIC)) {
-			switch (mv[i].m->member_class->raw_type) {
-				break;
-			case RT_U0:
-				align = 1;
-				break;
-			case RT_U8i:
-				align = 1;
-				break;
-			case RT_I8i:
-				align = 1;
-				break;
-			case RT_I16i:
-				align = 2;
-				break;
-			case RT_U16i:
-				align = 2;
-				break;
-			case RT_I32i:
-				align = 4;
-				break;
-			case RT_U32i:
-				align = 4;
-				break;
-			default:
-				align = 8;
-			}
-			off += (align - off % align) % align;
-			sz = mv[i].m->member_class->sz;
-			sz *= mv[i].m->dim.total_cnt;
-			mv[i].m->off = off;
+        } else
+          mv[i].m->reg = REG_NONE;
+      } else
+        mv[i].m->reg = REG_NONE;
+    }
+  }
+  // Time to assign the rest of the function members to the base pointer
+  qsort(mv, cnt, sizeof(COptMemberVar), OptMemberVarSortSz);
+  off = 0;
+  for (i = 0; i != cnt; i++) {
+    if (mv[i].m->reg == REG_NONE && !(mv[i].m->flags & MLF_STATIC)) {
+      switch (mv[i].m->member_class->raw_type) {
+        break;
+      case RT_U0:
+        align = 1;
+        break;
+      case RT_U8i:
+        align = 1;
+        break;
+      case RT_I8i:
+        align = 1;
+        break;
+      case RT_I16i:
+        align = 2;
+        break;
+      case RT_U16i:
+        align = 2;
+        break;
+      case RT_I32i:
+        align = 4;
+        break;
+      case RT_U32i:
+        align = 4;
+        break;
+      default:
+        align = 8;
+      }
+      off += (align - off % align) % align;
+      sz = mv[i].m->member_class->sz;
+      sz *= mv[i].m->dim.total_cnt;
+      mv[i].m->off = off;
 #if defined(__x86_64__)
-			// In X86_64 the base pointer above of the  stack's bottom,
-			// I will move the items down by thier size so they are at the bottom
-			//
-			//  RBP<===base ptr+0
-			//  I64 x(local_mem->off+=8) //Move x to be 8 bytes below RBP
-			//  RSP<=== -8 //Move x down here
-			mv[i].m->off += mv[i].m->member_class->sz * mv[i].m->dim.total_cnt;
+      // In X86_64 the base pointer above of the  stack's bottom,
+      // I will move the items down by thier size so they are at the bottom
+      //
+      //  RBP<===base ptr+0
+      //  I64 x(local_mem->off+=8) //Move x to be 8 bytes below RBP
+      //  RSP<=== -8 //Move x down here
+      mv[i].m->off += mv[i].m->member_class->sz * mv[i].m->dim.total_cnt;
 #endif
-			off += sz;
-		}
-	}
-	if (cctrl->cur_fun)
-		cctrl->cur_fun->base.sz = off; // Stack size
-	// Replace references of function members to IC_LOCAL/IREG/FREG
-	for (rpn = cctrl->code_ctrl->ir_code->next; rpn != cctrl->code_ctrl->ir_code;
-		 rpn = rpn->base.next) {
-		if (rpn->type == IC_LOCAL) {
-			if (rpn->local_mem->flags & MLF_STATIC) {
-				rpn->type = IC_STATIC;
-				rpn->integer = rpn->local_mem->static_bytes;
-			} else if (rpn->local_mem->reg != REG_NONE) {
-				i = rpn->local_mem->reg;
-				if (rpn->local_mem->member_class->raw_type == RT_F64) {
-					rpn->type = IC_FREG;
-				} else
-					rpn->type = IC_IREG;
-				rpn->integer = i;
-			} else {
-				i = rpn->local_mem->off;
-				rpn->type = IC_BASE_PTR;
-				rpn->integer = i;
-			}
-		}
-	}
-	A_FREE(mv);
+      off += sz;
+    }
+  }
+  if (cctrl->cur_fun)
+    cctrl->cur_fun->base.sz = off; // Stack size
+  // Replace references of function members to IC_LOCAL/IREG/FREG
+  for (rpn = cctrl->code_ctrl->ir_code->next; rpn != cctrl->code_ctrl->ir_code;
+       rpn = rpn->base.next) {
+    if (rpn->type == IC_LOCAL) {
+      if (rpn->local_mem->flags & MLF_STATIC) {
+        rpn->type = IC_STATIC;
+        rpn->integer = rpn->local_mem->static_bytes;
+      } else if (rpn->local_mem->reg != REG_NONE) {
+        i = rpn->local_mem->reg;
+        if (rpn->local_mem->member_class->raw_type == RT_F64) {
+          rpn->type = IC_FREG;
+        } else
+          rpn->type = IC_IREG;
+        rpn->integer = i;
+      } else {
+        i = rpn->local_mem->off;
+        rpn->type = IC_BASE_PTR;
+        rpn->integer = i;
+      }
+    }
+  }
+  A_FREE(mv);
 }
-static int64_t AlwaysPasses(CRPN* rpn)
-{
-	if (!IsConst(rpn))
-		return 0;
-	switch (rpn->type) {
-		break;
-	case IC_I64:
-		return !!rpn->integer;
-		break;
-	case IC_F64:
-		return !!rpn->flt;
-		break;
-	case IC_CHR:
-		return !!rpn->integer;
-		break;
-	case IC_STR:
-		return 1;
-	}
-	return 0;
+static int64_t AlwaysPasses(CRPN *rpn) {
+  if (!IsConst(rpn))
+    return 0;
+  switch (rpn->type) {
+    break;
+  case IC_I64:
+    return !!rpn->integer;
+    break;
+  case IC_F64:
+    return !!rpn->flt;
+    break;
+  case IC_CHR:
+    return !!rpn->integer;
+    break;
+  case IC_STR:
+    return 1;
+  }
+  return 0;
 }
-void OptPassRemoveUselessArith(CCmpCtrl* cctrl)
-{
-	CRPN *r, *next, *next2;
-	int64_t is_value;
-#define RPN_IS_VALUE(RPN, v)          \
-	is_value = 0;                     \
-	switch (RPN->type) {              \
-		break;                        \
-	case IC_I64:                      \
-		is_value = RPN->integer == v; \
-		break;                        \
-	case IC_F64:                      \
-		is_value = RPN->flt == v;     \
-	}
-	for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code;
-		 r = next2) {
-		next2 = r->base.next;
-		switch (r->type) {
-			break;
-		case IC_ADD:
-			next = ICArgN(r, 0);
-			RPN_IS_VALUE(next, 0);
-			if (is_value) {
-				next2 = ICArgN(r, 1);
-				ICFree(next);
-				ICFree(r);
-				continue;
-			}
-			next = ICArgN(r, 1);
-			RPN_IS_VALUE(next, 0);
-			if (is_value) {
-				next2 = ICArgN(r, 0);
-				ICFree(next);
-				ICFree(r);
-				continue;
-			}
-			break;
-		case IC_SUB:
-			next = ICArgN(r, 0);
-			RPN_IS_VALUE(next, 0);
-			if (is_value) {
-				next2 = ICArgN(r, 1);
-				ICFree(next);
-				ICFree(r);
-				continue;
-			}
-			break;
-		case IC_MUL:
-			next = ICArgN(r, 0);
-			RPN_IS_VALUE(next, 1);
-			if (is_value) {
-				next2 = ICArgN(r, 1);
-				ICFree(next);
-				ICFree(r);
-				continue;
-			}
-			next = ICArgN(r, 1);
-			RPN_IS_VALUE(next, 1);
-			if (is_value) {
-				next2 = ICArgN(r, 0);
-				ICFree(next);
-				ICFree(r);
-				continue;
-			}
-			break;
-		case IC_DIV:
-			next = ICArgN(r, 0);
-			RPN_IS_VALUE(next, 1);
-			if (is_value) {
-				next2 = ICArgN(r, 1);
-				ICFree(next);
-				ICFree(r);
-				continue;
-			}
-		}
-	}
+void OptPassRemoveUselessArith(CCmpCtrl *cctrl) {
+  CRPN *r, *next, *next2;
+  int64_t is_value;
+#define RPN_IS_VALUE(RPN, v)                                                   \
+  is_value = 0;                                                                \
+  switch (RPN->type) {                                                         \
+    break;                                                                     \
+  case IC_I64:                                                                 \
+    is_value = RPN->integer == v;                                              \
+    break;                                                                     \
+  case IC_F64:                                                                 \
+    is_value = RPN->flt == v;                                                  \
+  }
+  for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code;
+       r = next2) {
+    next2 = r->base.next;
+    switch (r->type) {
+      break;
+    case IC_ADD:
+      next = ICArgN(r, 0);
+      RPN_IS_VALUE(next, 0);
+      if (is_value) {
+        next2 = ICArgN(r, 1);
+        ICFree(next);
+        ICFree(r);
+        continue;
+      }
+      next = ICArgN(r, 1);
+      RPN_IS_VALUE(next, 0);
+      if (is_value) {
+        next2 = ICArgN(r, 0);
+        ICFree(next);
+        ICFree(r);
+        continue;
+      }
+      break;
+    case IC_SUB:
+      next = ICArgN(r, 0);
+      RPN_IS_VALUE(next, 0);
+      if (is_value) {
+        next2 = ICArgN(r, 1);
+        ICFree(next);
+        ICFree(r);
+        continue;
+      }
+      break;
+    case IC_MUL:
+      next = ICArgN(r, 0);
+      RPN_IS_VALUE(next, 1);
+      if (is_value) {
+        next2 = ICArgN(r, 1);
+        ICFree(next);
+        ICFree(r);
+        continue;
+      }
+      next = ICArgN(r, 1);
+      RPN_IS_VALUE(next, 1);
+      if (is_value) {
+        next2 = ICArgN(r, 0);
+        ICFree(next);
+        ICFree(r);
+        continue;
+      }
+      break;
+    case IC_DIV:
+      next = ICArgN(r, 0);
+      RPN_IS_VALUE(next, 1);
+      if (is_value) {
+        next2 = ICArgN(r, 1);
+        ICFree(next);
+        ICFree(r);
+        continue;
+      }
+    }
+  }
 }
-static void OptPassRemoveUselessTypecasts(CCmpCtrl* cctrl)
-{
-	CRPN *r, *next;
-	for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code;
-		 r = next) {
-		next = r->base.next;
-		if (r->type == IC_TYPECAST) {
-			if ((r->raw_type == RT_F64) == (next->raw_type == RT_F64)) {
-				next->raw_type = r->raw_type;
-				next->ic_class = r->ic_class;
-				ICFree(r);
-			}
-		}
-	}
+static void OptPassRemoveUselessTypecasts(CCmpCtrl *cctrl) {
+  CRPN *r, *next;
+  for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code;
+       r = next) {
+    next = r->base.next;
+    if (r->type == IC_TYPECAST) {
+      if ((r->raw_type == RT_F64) == (next->raw_type == RT_F64)) {
+        next->raw_type = r->raw_type;
+        next->ic_class = r->ic_class;
+        ICFree(r);
+      }
+    }
+  }
 }
-static void OptPassMergeAddressOffsets(CCmpCtrl* cctrl)
-{
-	CRPN *r, *arg, *next, *base,*off;
-	int64_t run;
-	for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code;
-		 r = next) {
-		next = r->base.next;
-		if (r->type == IC_ADD) {
-			for (run = 0; run != 2; run++) {
-				arg = ICArgN(r, run);
-				off = ICArgN(r, 1 - run);
-				if (arg->type != IC_ADDR_OF)
-					continue;
-				if (off->type != IC_I64)
-					continue;
-				base = arg->base.next;
-				switch (base->type) {
-				case IC_SHORT_ADDR:
-				case __IC_STATIC_REF:
-					base->integer += off->integer;
-					goto fin;
-				break;case IC_BASE_PTR:
-					//Stack grows down
-					#if defined (__x86_64__)
-					base->integer -= off->integer;
-					#else
-					base->integer += off->integer;
-					#endif
-fin:
-					arg->raw_type=r->raw_type;
-					ICFree(r);
-					ICFree(off);
-					next=base;
-					goto nxt;
-				}
-			}
-		}
-	nxt:;
-	}
-	//When we do "cd3.z" we have *(base_ptr+16). Turn *(base+16) into a frame ptr
-	for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code;
-		 r = next) {
-		next=r->base.next;
-		if(r->type==IC_DEREF&&next->type==IC_ADDR_OF) {
-			base=next->base.next;
-			if(base->type==IC_BASE_PTR) {
-				//Set the raw type of the IC_DEREF to the base_ptr	
-				base->raw_type=r->raw_type;
-				ICFree(r);
-				ICFree(next);
-				next=base;
-			}
-		}
-	}
+static void OptPassMergeAddressOffsets(CCmpCtrl *cctrl) {
+  CRPN *r, *arg, *next, *base, *off;
+  int64_t run;
+  for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code;
+       r = next) {
+    next = r->base.next;
+    if (r->type == IC_ADD) {
+      for (run = 0; run != 2; run++) {
+        arg = ICArgN(r, run);
+        off = ICArgN(r, 1 - run);
+        if (arg->type != IC_ADDR_OF)
+          continue;
+        if (off->type != IC_I64)
+          continue;
+        base = arg->base.next;
+        switch (base->type) {
+        case IC_SHORT_ADDR:
+        case __IC_STATIC_REF:
+          base->integer += off->integer;
+          goto fin;
+          break;
+        case IC_BASE_PTR:
+// Stack grows down
+#if defined(__x86_64__)
+          base->integer -= off->integer;
+#else
+          base->integer += off->integer;
+#endif
+        fin:
+          arg->raw_type = r->raw_type;
+          ICFree(r);
+          ICFree(off);
+          next = base;
+          goto nxt;
+        }
+      }
+    }
+  nxt:;
+  }
+  // When we do "cd3.z" we have *(base_ptr+16). Turn *(base+16) into a frame ptr
+  for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code;
+       r = next) {
+    next = r->base.next;
+    if (r->type == IC_DEREF && next->type == IC_ADDR_OF) {
+      base = next->base.next;
+      if (base->type == IC_BASE_PTR) {
+        // Set the raw type of the IC_DEREF to the base_ptr
+        base->raw_type = r->raw_type;
+        ICFree(r);
+        ICFree(next);
+        next = base;
+      }
+    }
+  }
 }
 
-char* Compile(CCmpCtrl* cctrl, int64_t* res_sz, char** dbg_info)
-{
-	CRPN* r;
-	int64_t old_flags = cctrl->flags;
-	for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code;
-		 r = r->base.next) {
-		AssignRawTypeToNode(cctrl, r);
-	}
-	OptPassFixFunArgs(cctrl);
-	OptPassExpandPtrs(cctrl);
-	OptPassConstFold(cctrl);
-	OptPassMergeCommunitives(cctrl);
-	// OptPassDeadCodeElim(cctrl);
-	OptPassRegAlloc(cctrl);
-	OptPassRemoveUselessArith(cctrl);
-	OptPassRemoveUselessTypecasts(cctrl);
-	OptPassMergeAddressOffsets(cctrl);
-	CmpCtrlCacheArgTrees(cctrl);
-	cctrl->flags = old_flags;
-	return OptPassFinal(cctrl, res_sz, dbg_info);
+char *Compile(CCmpCtrl *cctrl, int64_t *res_sz, char **dbg_info) {
+  CRPN *r;
+  int64_t old_flags = cctrl->flags;
+  for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code;
+       r = r->base.next) {
+    AssignRawTypeToNode(cctrl, r);
+  }
+  OptPassFixFunArgs(cctrl);
+  OptPassExpandPtrs(cctrl);
+  OptPassConstFold(cctrl);
+  OptPassMergeCommunitives(cctrl);
+  // OptPassDeadCodeElim(cctrl);
+  OptPassRegAlloc(cctrl);
+  OptPassRemoveUselessArith(cctrl);
+  OptPassRemoveUselessTypecasts(cctrl);
+  OptPassMergeAddressOffsets(cctrl);
+  CmpCtrlCacheArgTrees(cctrl);
+  cctrl->flags = old_flags;
+  return OptPassFinal(cctrl, res_sz, dbg_info);
 }

--- a/parser.c
+++ b/parser.c
@@ -3,3929 +3,3903 @@
 #include <assert.h>
 #include <limits.h>
 #include <stdarg.h>
-CCodeCtrl* CodeCtrlPush(CCmpCtrl* ccmp)
-{
-	CCodeCtrl* cctrl = A_MALLOC(sizeof(CCodeCtrl), ccmp->hc);
-	cctrl->hc = ccmp->hc;
-	cctrl->next = ccmp->code_ctrl;
-	cctrl->ir_code = A_MALLOC(sizeof(CRPN), cctrl->hc);
-	((CRPN*)cctrl->ir_code)->type = IC_NOP;
-	cctrl->code_misc = A_MALLOC(sizeof(CQue), cctrl->hc);
-	QueInit(cctrl->ir_code);
-	QueInit(cctrl->code_misc);
-	ccmp->code_ctrl = cctrl;
-	return cctrl;
+CCodeCtrl *CodeCtrlPush(CCmpCtrl *ccmp) {
+  CCodeCtrl *cctrl = A_MALLOC(sizeof(CCodeCtrl), ccmp->hc);
+  cctrl->hc = ccmp->hc;
+  cctrl->next = ccmp->code_ctrl;
+  cctrl->ir_code = A_MALLOC(sizeof(CRPN), cctrl->hc);
+  ((CRPN *)cctrl->ir_code)->type = IC_NOP;
+  cctrl->code_misc = A_MALLOC(sizeof(CQue), cctrl->hc);
+  QueInit(cctrl->ir_code);
+  QueInit(cctrl->code_misc);
+  ccmp->code_ctrl = cctrl;
+  return cctrl;
 }
 
-CCodeCtrl* CodeCtrlPopNoFree(CCmpCtrl* cc)
-{
-	CCodeCtrl* ctrl = cc->code_ctrl;
-	cc->code_ctrl = ctrl->next;
-	return ctrl;
+CCodeCtrl *CodeCtrlPopNoFree(CCmpCtrl *cc) {
+  CCodeCtrl *ctrl = cc->code_ctrl;
+  cc->code_ctrl = ctrl->next;
+  return ctrl;
 }
 
-void CodeCtrlAppend(CCmpCtrl* ccmp, CCodeCtrl* ct)
-{
-	CQue *head = ccmp->code_ctrl->ir_code, *next = head->next;
-	if (ct->ir_code->next != ct->ir_code->last) {
-		head->next = ct->ir_code->next;
-		next->last = ct->ir_code->last;
-		ct->ir_code->last->next = next;
-		ct->ir_code->next->last = head;
-	}
+void CodeCtrlAppend(CCmpCtrl *ccmp, CCodeCtrl *ct) {
+  CQue *head = ccmp->code_ctrl->ir_code, *next = head->next;
+  if (ct->ir_code->next != ct->ir_code->last) {
+    head->next = ct->ir_code->next;
+    next->last = ct->ir_code->last;
+    ct->ir_code->last->next = next;
+    ct->ir_code->next->last = head;
+  }
 
-	head = ccmp->code_ctrl->code_misc;
-	next = head->next;
-	if (ct->code_misc->next != ct->code_misc->last) {
-		head->next = ct->code_misc->next;
-		next->last = ct->code_misc->last;
-		ct->code_misc->last->next = next;
-		ct->code_misc->next->last = head;
-	}
-	// Transfer "ownership"  of the code-miscs and CRPN's
-	QueInit(ct->code_misc);
-	QueInit(ct->ir_code);
+  head = ccmp->code_ctrl->code_misc;
+  next = head->next;
+  if (ct->code_misc->next != ct->code_misc->last) {
+    head->next = ct->code_misc->next;
+    next->last = ct->code_misc->last;
+    ct->code_misc->last->next = next;
+    ct->code_misc->next->last = head;
+  }
+  // Transfer "ownership"  of the code-miscs and CRPN's
+  QueInit(ct->code_misc);
+  QueInit(ct->ir_code);
 }
-static void ArrayDimDel(CArrayDim* dim)
-{
-	if (dim->next)
-		ArrayDimDel(dim->next);
-	A_FREE(dim);
+static void ArrayDimDel(CArrayDim *dim) {
+  if (dim->next)
+    ArrayDimDel(dim->next);
+  A_FREE(dim);
 }
-static void HashFunDel(CHashFun* fun);
-CHashClass* PrsType(CCmpCtrl* ccmp, CHashClass* base, char** name,
-	CHashFun** fun, CArrayDim* dim);
-static void MemberLstDel(CMemberLst* lst)
-{
-	A_FREE(lst->str);
-	if (lst->next)
-		MemberLstDel(lst->next);
-	if (lst->fun_ptr)
-		HashFunDel(lst->fun_ptr);
-	// Dont free ->dim as it is not MAlloc'ed(it is a member)
-	if (lst->dim.next)
-		ArrayDimDel(lst->dim.next);
-	A_FREE(lst);
+static void HashFunDel(CHashFun *fun);
+CHashClass *PrsType(CCmpCtrl *ccmp, CHashClass *base, char **name,
+                    CHashFun **fun, CArrayDim *dim);
+static void MemberLstDel(CMemberLst *lst) {
+  A_FREE(lst->str);
+  if (lst->next)
+    MemberLstDel(lst->next);
+  if (lst->fun_ptr)
+    HashFunDel(lst->fun_ptr);
+  // Dont free ->dim as it is not MAlloc'ed(it is a member)
+  if (lst->dim.next)
+    ArrayDimDel(lst->dim.next);
+  A_FREE(lst);
 }
 
-static void HashFunDel(CHashFun* fun)
-{
-	A_FREE(fun->fun_ptr);
-	if (fun->base.members_lst)
-		MemberLstDel(fun->base.members_lst);
-	A_FREE(fun->import_name);
-	A_FREE(fun->base.base.str);
-	A_FREE(fun);
+static void HashFunDel(CHashFun *fun) {
+  A_FREE(fun->fun_ptr);
+  if (fun->base.members_lst)
+    MemberLstDel(fun->base.members_lst);
+  A_FREE(fun->import_name);
+  A_FREE(fun->base.base.str);
+  A_FREE(fun);
 }
-void CodeCtrlDel(CCodeCtrl* ctrl)
-{
-	CCodeMisc* misc;
-	for (misc = ctrl->code_misc->next; misc != ctrl->code_misc;
-		 misc = misc->base.next) {
-		switch (misc->type) {
-			break;
-		case CMT_STRING:
-			A_FREE(misc->str);
-			break;
-		case CMT_RELOC_U64:
-		case CMT_LABEL:
-			A_FREE(misc->str);
-			break;
-		case CMT_JMP_TAB:
-			A_FREE(misc->jmp_tab);
-			break;
-		case CMT_STATIC_DATA:
-			A_FREE(misc->str);
-		}
-	}
-	QueDel(ctrl->ir_code);
-	QueDel(ctrl->code_misc);
-	A_FREE(ctrl);
+void CodeCtrlDel(CCodeCtrl *ctrl) {
+  CCodeMisc *misc;
+  for (misc = ctrl->code_misc->next; misc != ctrl->code_misc;
+       misc = misc->base.next) {
+    switch (misc->type) {
+      break;
+    case CMT_STRING:
+      A_FREE(misc->str);
+      break;
+    case CMT_RELOC_U64:
+    case CMT_LABEL:
+      A_FREE(misc->str);
+      break;
+    case CMT_JMP_TAB:
+      A_FREE(misc->jmp_tab);
+      break;
+    case CMT_STATIC_DATA:
+      A_FREE(misc->str);
+    }
+  }
+  QueDel(ctrl->ir_code);
+  QueDel(ctrl->code_misc);
+  A_FREE(ctrl);
 }
 
-CCodeMisc* CodeMiscNew(CCmpCtrl* ccmp, int64_t type)
-{
-	CCodeMisc* misc = A_CALLOC(sizeof(CCodeMisc), ccmp->hc);
-	misc->type = type;
-	QueIns(misc, ccmp->code_ctrl->code_misc->last);
-	return misc;
+CCodeMisc *CodeMiscNew(CCmpCtrl *ccmp, int64_t type) {
+  CCodeMisc *misc = A_CALLOC(sizeof(CCodeMisc), ccmp->hc);
+  misc->type = type;
+  QueIns(misc, ccmp->code_ctrl->code_misc->last);
+  return misc;
 }
 
-void CodeCtrlPop(CCmpCtrl* ccmp)
-{
-	CCodeCtrl *next = ccmp->code_ctrl->next, *c = ccmp->code_ctrl;
-	CodeCtrlDel(c);
-	ccmp->code_ctrl = next;
+void CodeCtrlPop(CCmpCtrl *ccmp) {
+  CCodeCtrl *next = ccmp->code_ctrl->next, *c = ccmp->code_ctrl;
+  CodeCtrlDel(c);
+  ccmp->code_ctrl = next;
 }
 
-int64_t PrsKw(CCmpCtrl* ccmp, int64_t);
-int64_t PrsStmt(CCmpCtrl* ccmp);
-int64_t PrsIf(CCmpCtrl* ccmp); // YES
-int64_t PrsDo(CCmpCtrl* ccmp); // YES
-int64_t PrsWhile(CCmpCtrl* ccmp); // YES
-int64_t PrsFor(CCmpCtrl* ccmp); // YES
-int64_t PrsSwitch(CCmpCtrl* ccmp); // YES
-int64_t PrsScope(CCmpCtrl* ccmp);
-int64_t PrsLabel(CCmpCtrl* ccmp);
-int64_t PrsGoto(CCmpCtrl* ccmp);
-int64_t PrsReturn(CCmpCtrl* ccmp);
-int64_t ParseErr(CCmpCtrl* ctrl, char* fmt, ...);
-int64_t PrsTry(CCmpCtrl* cctrl); // YES
-int64_t PrsDecl(CCmpCtrl* ccmp, CHashClass* base, CHashClass* add_to,
-	int64_t* is_func_decl, int64_t flags, char* import_name);
-int64_t PrsSwitch(CCmpCtrl* cctrl);
-CHashClass* PrsClass(CCmpCtrl* cctrl, int64_t flags);
-CMemberLst* MemberFind(char* needle, CHashClass* cls);
-CCmpCtrl* CmpCtrlDel(CCmpCtrl* d)
-{
-	HeapCtrlDel(d->hc);
-	A_FREE(d);
+int64_t PrsKw(CCmpCtrl *ccmp, int64_t);
+int64_t PrsStmt(CCmpCtrl *ccmp);
+int64_t PrsIf(CCmpCtrl *ccmp);     // YES
+int64_t PrsDo(CCmpCtrl *ccmp);     // YES
+int64_t PrsWhile(CCmpCtrl *ccmp);  // YES
+int64_t PrsFor(CCmpCtrl *ccmp);    // YES
+int64_t PrsSwitch(CCmpCtrl *ccmp); // YES
+int64_t PrsScope(CCmpCtrl *ccmp);
+int64_t PrsLabel(CCmpCtrl *ccmp);
+int64_t PrsGoto(CCmpCtrl *ccmp);
+int64_t PrsReturn(CCmpCtrl *ccmp);
+int64_t ParseErr(CCmpCtrl *ctrl, char *fmt, ...);
+int64_t PrsTry(CCmpCtrl *cctrl); // YES
+int64_t PrsDecl(CCmpCtrl *ccmp, CHashClass *base, CHashClass *add_to,
+                int64_t *is_func_decl, int64_t flags, char *import_name);
+int64_t PrsSwitch(CCmpCtrl *cctrl);
+CHashClass *PrsClass(CCmpCtrl *cctrl, int64_t flags);
+CMemberLst *MemberFind(char *needle, CHashClass *cls);
+CCmpCtrl *CmpCtrlDel(CCmpCtrl *d) {
+  HeapCtrlDel(d->hc);
+  A_FREE(d);
 }
-CCmpCtrl* CmpCtrlNew(CLexer* lex)
-{
-	int64_t idx, idx2;
-	CHashClass* cls;
-	CCmpCtrl* ccmp = A_CALLOC(sizeof(CCmpCtrl), NULL);
-	ccmp->lex = lex;
-	ccmp->hc = HeapCtrlInit(NULL, Fs,1);
-	struct {
-		char* name;
-		int64_t rt;
-		int64_t sz;
-	} raw_types[] = {
-		{ "U0", RT_U0, 0 },
-		{ "U8i", RT_U8i, 1 },
-		{ "I8i", RT_I8i, 1 },
-		{ "U16i", RT_U16i, 2 },
-		{ "I16i", RT_I16i, 2 },
-		{ "U32i", RT_U32i, 4 },
-		{ "I32i", RT_I32i, 4 },
-		{ "U64i", RT_U64i, 8 },
-		{ "I64i", RT_I64i, 8 },
-		{ "F64", RT_F64, 8 },
-	};
-	for (idx = 0; idx != sizeof(raw_types) / sizeof(*raw_types); idx++) {
-		if (!HashFind(raw_types[idx].name, Fs->hash_table, HTT_CLASS, 1)) {
-			cls = A_CALLOC(sizeof(CHashClass) * STAR_CNT, NULL);
-			cls->base.type = HTT_CLASS;
-			cls->sz = raw_types[idx].sz;
-			for (idx2 = 0; idx2 != STAR_CNT; idx2++) {
-				cls[idx2].base.str = A_STRDUP(raw_types[idx].name, NULL);
-				if (!idx2)
-					cls[idx2].raw_type = raw_types[idx].rt,
-					cls[idx2].sz = raw_types[idx].sz;
-				else
-					cls[idx2].raw_type = RT_PTR, cls[idx2].sz = sizeof(void*);
-				cls[idx2].ptr_star_cnt = idx2;
-				cls[idx2].use_cnt++;
-			}
-			HashAdd(cls, Fs->hash_table);
-			cls = A_CALLOC(sizeof(CHashClass) * STAR_CNT, NULL);
-			cls->base.type = HTT_CLASS;
-			cls->sz = raw_types[idx].sz;
-			for (idx2 = 0; idx2 != STAR_CNT; idx2++) {
-				cls[idx2].base.str = A_STRDUP(raw_types[idx].name, NULL);
-				if (!idx2)
-					cls[idx2].raw_type = raw_types[idx].rt,
-					cls[idx2].sz = raw_types[idx].sz;
-				else
-					cls[idx2].raw_type = RT_PTR, cls[idx2].sz = sizeof(void*);
-				cls[idx2].ptr_star_cnt = idx2;
-				cls[idx2].use_cnt++;
-			}
-			HashAdd(cls, Fs->hash_table);
-		}
-	}
-	return ccmp;
+CCmpCtrl *CmpCtrlNew(CLexer *lex) {
+  int64_t idx, idx2;
+  CHashClass *cls;
+  CCmpCtrl *ccmp = A_CALLOC(sizeof(CCmpCtrl), NULL);
+  ccmp->lex = lex;
+  ccmp->hc = HeapCtrlInit(NULL, Fs, 1);
+  struct {
+    char *name;
+    int64_t rt;
+    int64_t sz;
+  } raw_types[] = {
+      {"U0", RT_U0, 0},     {"U8i", RT_U8i, 1},   {"I8i", RT_I8i, 1},
+      {"U16i", RT_U16i, 2}, {"I16i", RT_I16i, 2}, {"U32i", RT_U32i, 4},
+      {"I32i", RT_I32i, 4}, {"U64i", RT_U64i, 8}, {"I64i", RT_I64i, 8},
+      {"F64", RT_F64, 8},
+  };
+  for (idx = 0; idx != sizeof(raw_types) / sizeof(*raw_types); idx++) {
+    if (!HashFind(raw_types[idx].name, Fs->hash_table, HTT_CLASS, 1)) {
+      cls = A_CALLOC(sizeof(CHashClass) * STAR_CNT, NULL);
+      cls->base.type = HTT_CLASS;
+      cls->sz = raw_types[idx].sz;
+      for (idx2 = 0; idx2 != STAR_CNT; idx2++) {
+        cls[idx2].base.str = A_STRDUP(raw_types[idx].name, NULL);
+        if (!idx2)
+          cls[idx2].raw_type = raw_types[idx].rt,
+          cls[idx2].sz = raw_types[idx].sz;
+        else
+          cls[idx2].raw_type = RT_PTR, cls[idx2].sz = sizeof(void *);
+        cls[idx2].ptr_star_cnt = idx2;
+        cls[idx2].use_cnt++;
+      }
+      HashAdd(cls, Fs->hash_table);
+      cls = A_CALLOC(sizeof(CHashClass) * STAR_CNT, NULL);
+      cls->base.type = HTT_CLASS;
+      cls->sz = raw_types[idx].sz;
+      for (idx2 = 0; idx2 != STAR_CNT; idx2++) {
+        cls[idx2].base.str = A_STRDUP(raw_types[idx].name, NULL);
+        if (!idx2)
+          cls[idx2].raw_type = raw_types[idx].rt,
+          cls[idx2].sz = raw_types[idx].sz;
+        else
+          cls[idx2].raw_type = RT_PTR, cls[idx2].sz = sizeof(void *);
+        cls[idx2].ptr_star_cnt = idx2;
+        cls[idx2].use_cnt++;
+      }
+      HashAdd(cls, Fs->hash_table);
+    }
+  }
+  return ccmp;
 }
-CRPN* ICFwd(CRPN* rpn)
-{
-	CRPN* orig_rpn = rpn;
-	int64_t idx;
-	if(rpn->ic_fwd) return rpn->ic_fwd;
-	switch (rpn->type) {
-		break;
-	case IC_RAW_BYTES:
-	case __IC_STATICS_SIZE:
-	case __IC_SET_STATIC_DATA:
-	case __IC_STATIC_REF:
-		return rpn->base.next;
-		break;
-	case IC_SHORT_ADDR:
-	case IC_RELOC:
-		return rpn->base.next;
-		break;
-	case IC_GET_VARGS_PTR:
-	case IC_TO_F64:
-	case IC_TO_I64:
-		goto unop;
-		break;
-	case IC_GOTO_IF:
-		goto unop;
-		break;
-	case IC_STATIC:
-		return rpn->base.next;
-		break;
-	case IC_TYPECAST:
-		goto unop;
-		break;
-	case IC_COMMA:
-		goto binop;
-		break;
-	case __IC_VARGS:
-		rpn = rpn->base.next;
-		// Args
-		for (idx = 0; idx != orig_rpn->length; idx++)
-			rpn = ICFwd(rpn);
-		return rpn;
-		break;
-	case __IC_CALL:
-	case IC_CALL:
-		rpn = rpn->base.next;
-		// Args
-		for (idx = 0; idx != orig_rpn->length; idx++)
-			rpn = ICFwd(rpn);
-		// Function
-		return rpn = ICFwd(rpn);
-		break;
-	case IC_BASE_PTR:
-		return rpn->base.next;
-		break;
-	case IC_IREG:
-		return rpn->base.next;
-		break;
-	case IC_FREG:
-		return rpn->base.next;
-		break;
-	case IC_LOAD:
-		goto binop;
-		break;
-	case IC_STORE:
-		goto binop;
-		break;
-	case IC_RET:
-		return ICFwd(rpn->base.next);
-		break;
-	case IC_LABEL:
-		return rpn->base.next;
-		break;
-	case IC_GOTO:
-		return rpn->base.next;
-		break;
-	case IC_GLOBAL:
-		return rpn->base.next;
-		break;
-	case IC_LOCAL:
-		return rpn->base.next;
-		break;
-	case IC_NOP:
-		return rpn->base.next;
-		break;
-	case IC_BOUNDED_SWITCH:
-		goto swit;
-		break;
-	case IC_UNBOUNDED_SWITCH:
-	swit:
-		return ICFwd(rpn->base.next);
-		break;
-	case IC_SUB_CALL:
-		return rpn->base.next;
-		break;
-	case IC_SUB_PROLOG:
-		return rpn->base.next;
-		break;
-	case IC_SUB_RET:
-		return rpn->base.next;
-		break;
-	case IC_PAREN:
-		abort();
-		break;
-	case IC_NEG:
-	unop:
-		return ICFwd(rpn->base.next);
-		break;
-	case IC_POS:
-		goto unop;
-		break;
-	case IC_NAME:
-		return rpn->base.next;
-		break;
-	case IC_STR:
-		return rpn->base.next;
-		break;
-	case IC_CHR:
-		return rpn->base.next;
-		break;
-	case IC_POW:
-	binop:
-		return ICFwd(ICFwd(rpn->base.next));
-		break;
-	case IC_ADD:
-		goto binop;
-		break;
-	case IC_BT:
-	case IC_BTR:
-	case IC_BTS:
-	case IC_BTC:
-	case IC_LBTR:
-	case IC_LBTS:
-	case IC_LBTC:
-	case IC_EQ:
-		goto binop;
-		break;
-	case IC_SUB:
-		goto binop;
-		break;
-	case IC_DIV:
-		goto binop;
-		break;
-	case IC_MUL:
-		goto binop;
-		break;
-	case __IC_ARG:
-	case IC_DEREF:
-		goto unop;
-		break;
-	case IC_AND:
-		goto binop;
-		break;
-	case IC_ADDR_OF:
-		goto unop;
-		break;
-	case IC_XOR:
-		goto binop;
-		break;
-	case IC_MOD:
-		goto binop;
-		break;
-	case IC_OR:
-		goto binop;
-		break;
-	case IC_LT:
-		goto binop;
-		break;
-	case IC_GT:
-		goto binop;
-		break;
-	case IC_LNOT:
-		goto unop;
-		break;
-	case IC_BNOT:
-		goto unop;
-		break;
-	case IC_POST_INC:
-		goto unop;
-		break;
-	case IC_POST_DEC:
-		goto unop;
-		break;
-	case IC_PRE_INC:
-		goto unop;
-		break;
-	case IC_PRE_DEC:
-		goto unop;
-		break;
-	case IC_AND_AND:
-		goto binop;
-		break;
-	case IC_OR_OR:
-		goto binop;
-		break;
-	case IC_XOR_XOR:
-		goto binop;
-		break;
-	case IC_EQ_EQ:
-		goto binop;
-		break;
-	case IC_NE:
-		goto binop;
-		break;
-	case IC_LE:
-		goto binop;
-		break;
-	case IC_GE:
-		goto binop;
-		break;
-	case IC_LSH:
-		goto binop;
-		break;
-	case IC_RSH:
-		goto binop;
-		break;
-	case IC_ADD_EQ:
-		goto binop;
-		break;
-	case IC_SUB_EQ:
-		goto binop;
-		break;
-	case IC_MUL_EQ:
-		goto binop;
-		break;
-	case IC_DIV_EQ:
-		goto binop;
-		break;
-	case IC_LSH_EQ:
-		goto binop;
-		break;
-	case IC_RSH_EQ:
-		goto binop;
-		break;
-	case IC_AND_EQ:
-		goto binop;
-		break;
-	case IC_OR_EQ:
-		goto binop;
-		break;
-	case IC_XOR_EQ:
-		goto binop;
-		break;
-	case IC_ARROW:
-		goto unop;
-		break;
-	case IC_DOT:
-		goto unop;
-		break;
-	case IC_MOD_EQ:
-		goto binop;
-		break;
-	case IC_I64:
-		return rpn->base.next;
-		break;
-	case __IC_SET_FRAME_SIZE:
-	case IC_F64:
-		return rpn->base.next;
-		break;
-	case IC_ARRAY_ACC:
-		goto binop;
-	}
-	abort();
+CRPN *ICFwd(CRPN *rpn) {
+  CRPN *orig_rpn = rpn;
+  int64_t idx;
+  if (rpn->ic_fwd)
+    return rpn->ic_fwd;
+  switch (rpn->type) {
+    break;
+  case IC_RAW_BYTES:
+  case __IC_STATICS_SIZE:
+  case __IC_SET_STATIC_DATA:
+  case __IC_STATIC_REF:
+    return rpn->base.next;
+    break;
+  case IC_SHORT_ADDR:
+  case IC_RELOC:
+    return rpn->base.next;
+    break;
+  case IC_GET_VARGS_PTR:
+  case IC_TO_F64:
+  case IC_TO_I64:
+    goto unop;
+    break;
+  case IC_GOTO_IF:
+    goto unop;
+    break;
+  case IC_STATIC:
+    return rpn->base.next;
+    break;
+  case IC_TYPECAST:
+    goto unop;
+    break;
+  case IC_COMMA:
+    goto binop;
+    break;
+  case __IC_VARGS:
+    rpn = rpn->base.next;
+    // Args
+    for (idx = 0; idx != orig_rpn->length; idx++)
+      rpn = ICFwd(rpn);
+    return rpn;
+    break;
+  case __IC_CALL:
+  case IC_CALL:
+    rpn = rpn->base.next;
+    // Args
+    for (idx = 0; idx != orig_rpn->length; idx++)
+      rpn = ICFwd(rpn);
+    // Function
+    return rpn = ICFwd(rpn);
+    break;
+  case IC_BASE_PTR:
+    return rpn->base.next;
+    break;
+  case IC_IREG:
+    return rpn->base.next;
+    break;
+  case IC_FREG:
+    return rpn->base.next;
+    break;
+  case IC_LOAD:
+    goto binop;
+    break;
+  case IC_STORE:
+    goto binop;
+    break;
+  case IC_RET:
+    return ICFwd(rpn->base.next);
+    break;
+  case IC_LABEL:
+    return rpn->base.next;
+    break;
+  case IC_GOTO:
+    return rpn->base.next;
+    break;
+  case IC_GLOBAL:
+    return rpn->base.next;
+    break;
+  case IC_LOCAL:
+    return rpn->base.next;
+    break;
+  case IC_NOP:
+    return rpn->base.next;
+    break;
+  case IC_BOUNDED_SWITCH:
+    goto swit;
+    break;
+  case IC_UNBOUNDED_SWITCH:
+  swit:
+    return ICFwd(rpn->base.next);
+    break;
+  case IC_SUB_CALL:
+    return rpn->base.next;
+    break;
+  case IC_SUB_PROLOG:
+    return rpn->base.next;
+    break;
+  case IC_SUB_RET:
+    return rpn->base.next;
+    break;
+  case IC_PAREN:
+    abort();
+    break;
+  case IC_NEG:
+  unop:
+    return ICFwd(rpn->base.next);
+    break;
+  case IC_POS:
+    goto unop;
+    break;
+  case IC_NAME:
+    return rpn->base.next;
+    break;
+  case IC_STR:
+    return rpn->base.next;
+    break;
+  case IC_CHR:
+    return rpn->base.next;
+    break;
+  case IC_POW:
+  binop:
+    return ICFwd(ICFwd(rpn->base.next));
+    break;
+  case IC_ADD:
+    goto binop;
+    break;
+  case IC_BT:
+  case IC_BTR:
+  case IC_BTS:
+  case IC_BTC:
+  case IC_LBTR:
+  case IC_LBTS:
+  case IC_LBTC:
+  case IC_EQ:
+    goto binop;
+    break;
+  case IC_SUB:
+    goto binop;
+    break;
+  case IC_DIV:
+    goto binop;
+    break;
+  case IC_MUL:
+    goto binop;
+    break;
+  case __IC_ARG:
+  case IC_DEREF:
+    goto unop;
+    break;
+  case IC_AND:
+    goto binop;
+    break;
+  case IC_ADDR_OF:
+    goto unop;
+    break;
+  case IC_XOR:
+    goto binop;
+    break;
+  case IC_MOD:
+    goto binop;
+    break;
+  case IC_OR:
+    goto binop;
+    break;
+  case IC_LT:
+    goto binop;
+    break;
+  case IC_GT:
+    goto binop;
+    break;
+  case IC_LNOT:
+    goto unop;
+    break;
+  case IC_BNOT:
+    goto unop;
+    break;
+  case IC_POST_INC:
+    goto unop;
+    break;
+  case IC_POST_DEC:
+    goto unop;
+    break;
+  case IC_PRE_INC:
+    goto unop;
+    break;
+  case IC_PRE_DEC:
+    goto unop;
+    break;
+  case IC_AND_AND:
+    goto binop;
+    break;
+  case IC_OR_OR:
+    goto binop;
+    break;
+  case IC_XOR_XOR:
+    goto binop;
+    break;
+  case IC_EQ_EQ:
+    goto binop;
+    break;
+  case IC_NE:
+    goto binop;
+    break;
+  case IC_LE:
+    goto binop;
+    break;
+  case IC_GE:
+    goto binop;
+    break;
+  case IC_LSH:
+    goto binop;
+    break;
+  case IC_RSH:
+    goto binop;
+    break;
+  case IC_ADD_EQ:
+    goto binop;
+    break;
+  case IC_SUB_EQ:
+    goto binop;
+    break;
+  case IC_MUL_EQ:
+    goto binop;
+    break;
+  case IC_DIV_EQ:
+    goto binop;
+    break;
+  case IC_LSH_EQ:
+    goto binop;
+    break;
+  case IC_RSH_EQ:
+    goto binop;
+    break;
+  case IC_AND_EQ:
+    goto binop;
+    break;
+  case IC_OR_EQ:
+    goto binop;
+    break;
+  case IC_XOR_EQ:
+    goto binop;
+    break;
+  case IC_ARROW:
+    goto unop;
+    break;
+  case IC_DOT:
+    goto unop;
+    break;
+  case IC_MOD_EQ:
+    goto binop;
+    break;
+  case IC_I64:
+    return rpn->base.next;
+    break;
+  case __IC_SET_FRAME_SIZE:
+  case IC_F64:
+    return rpn->base.next;
+    break;
+  case IC_ARRAY_ACC:
+    goto binop;
+  }
+  abort();
 }
 
-static char* PrsString(CCmpCtrl* ccmp, int64_t* sz)
-{
-	char *ret = NULL, *tmp;
-	int64_t len = 0;
-	while (ccmp->lex->cur_tok == TK_STR) {
-		len += ccmp->lex->str_len;
-		tmp = A_MALLOC(len + 1, NULL);
-		if (ret)
-			memcpy(tmp, ret, len - ccmp->lex->str_len);
-		A_FREE(ret);
-		ret = tmp;
-		memcpy(ret + (len - ccmp->lex->str_len), ccmp->lex->string, ccmp->lex->str_len);
-		Lex(ccmp->lex);
-		ret[len] = 0;
-	}
-	if (sz)
-		*sz = len + 1;
-	return ret;
+static char *PrsString(CCmpCtrl *ccmp, int64_t *sz) {
+  char *ret = NULL, *tmp;
+  int64_t len = 0;
+  while (ccmp->lex->cur_tok == TK_STR) {
+    len += ccmp->lex->str_len;
+    tmp = A_MALLOC(len + 1, NULL);
+    if (ret)
+      memcpy(tmp, ret, len - ccmp->lex->str_len);
+    A_FREE(ret);
+    ret = tmp;
+    memcpy(ret + (len - ccmp->lex->str_len), ccmp->lex->string,
+           ccmp->lex->str_len);
+    Lex(ccmp->lex);
+    ret[len] = 0;
+  }
+  if (sz)
+    *sz = len + 1;
+  return ret;
 }
 
-CRPN* ICArgN(CRPN* rpn, int64_t n)
-{
-	if(n==0&&rpn->tree1) return  rpn->tree1;
-	if(n==1&&rpn->tree2) return  rpn->tree2;
-	rpn = rpn->base.next;
-	while (--n >= 0)
-		rpn = ICFwd(rpn);
-	return rpn;
+CRPN *ICArgN(CRPN *rpn, int64_t n) {
+  if (n == 0 && rpn->tree1)
+    return rpn->tree1;
+  if (n == 1 && rpn->tree2)
+    return rpn->tree2;
+  rpn = rpn->base.next;
+  while (--n >= 0)
+    rpn = ICFwd(rpn);
+  return rpn;
 }
-static void DumpRPNDim(CArrayDim* dim)
-{
-	if (dim->next)
-		DumpRPNDim(dim->next);
-	printf("[%ld]", dim->cnt);
+static void DumpRPNDim(CArrayDim *dim) {
+  if (dim->next)
+    DumpRPNDim(dim->next);
+  printf("[%ld]", dim->cnt);
 }
-static void DumpRPNType(CRPN* rpn)
-{
-	int64_t stars;
-	if (rpn->ic_class) {
-		stars = rpn->ic_class->ptr_star_cnt;
-		if (rpn->ic_class->raw_type != RT_FUNC)
-			printf("%s", rpn->ic_class[-stars].base.str);
-		while (--stars >= 0)
-			printf("*");
-	}
-	if (rpn->ic_dim)
-		DumpRPNDim(rpn->ic_dim);
-	switch (rpn->raw_type) {
-		break;
-	case RT_UNDEF:
-		break;
-	case RT_F64:
-		printf("(RT_F64)");
-		break;
-	case RT_FUNC:
-		printf("(RT_FUNC)");
-		break;
-	case RT_U0:
-		printf("(RT_U0)");
-		break;
-	case RT_I8i:
-		printf("(RT_I8i)");
-		break;
-	case RT_I16i:
-		printf("(RT_I16i)");
-		break;
-	case RT_I32i:
-		printf("(RT_I32i)");
-		break;
-	case RT_I64i:
-		printf("(RT_I64i)");
-		break;
-	case RT_U8i:
-		printf("(RT_U8i)");
-		break;
-	case RT_U16i:
-		printf("(RT_U16i)");
-		break;
-	case RT_U32i:
-		printf("(RT_U32i)");
-		break;
-	case RT_U64i:
-		printf("(RT_U64i)");
-		break;
-	case RT_PTR:
-		printf("(RT_PTR)");
-	}
+static void DumpRPNType(CRPN *rpn) {
+  int64_t stars;
+  if (rpn->ic_class) {
+    stars = rpn->ic_class->ptr_star_cnt;
+    if (rpn->ic_class->raw_type != RT_FUNC)
+      printf("%s", rpn->ic_class[-stars].base.str);
+    while (--stars >= 0)
+      printf("*");
+  }
+  if (rpn->ic_dim)
+    DumpRPNDim(rpn->ic_dim);
+  switch (rpn->raw_type) {
+    break;
+  case RT_UNDEF:
+    break;
+  case RT_F64:
+    printf("(RT_F64)");
+    break;
+  case RT_FUNC:
+    printf("(RT_FUNC)");
+    break;
+  case RT_U0:
+    printf("(RT_U0)");
+    break;
+  case RT_I8i:
+    printf("(RT_I8i)");
+    break;
+  case RT_I16i:
+    printf("(RT_I16i)");
+    break;
+  case RT_I32i:
+    printf("(RT_I32i)");
+    break;
+  case RT_I64i:
+    printf("(RT_I64i)");
+    break;
+  case RT_U8i:
+    printf("(RT_U8i)");
+    break;
+  case RT_U16i:
+    printf("(RT_U16i)");
+    break;
+  case RT_U32i:
+    printf("(RT_U32i)");
+    break;
+  case RT_U64i:
+    printf("(RT_U64i)");
+    break;
+  case RT_PTR:
+    printf("(RT_PTR)");
+  }
 }
 
-CRPN* ParserDumpIR(CRPN* rpn, int64_t indent)
-{
-	int64_t idx;
-	CRPN* orig_rpn = rpn;
-#define INDENT                          \
-	for (idx = 0; idx != indent; idx++) \
-		printf("  ");
-	INDENT;
-	switch (rpn->type) {
-	case IC_RAW_BYTES:
-		printf("RAW_BYTES:%ld\n", rpn->length);
-		goto ret;
-	case __IC_STATICS_SIZE:
-		printf("STATICS_SZ:%ld\n", rpn->integer);
-		goto ret;
-		break;
-	case __IC_SET_STATIC_DATA:
-		printf("SET_STATIC_DATA:%ld(%ld)\n", rpn->code_misc->integer, rpn->code_misc->str_len);
-		goto ret;
-		break;
-	case __IC_STATIC_REF:
-		printf("SET_STATIC_REF:(%ld)", rpn->integer);
-		DumpRPNType(rpn);
-		printf("\n");
-		goto ret;
-	case IC_SHORT_ADDR:
-		printf("SHORT_ADDR:%s\n", rpn->code_misc->str);
-		return ICFwd(rpn);
-	case IC_RELOC:
-		printf("RELOC:%s\n", rpn->code_misc->str);
-		return ICFwd(rpn);
-	case IC_GET_VARGS_PTR:
-		printf("GET_VARGS_PTR:\n");
-		return ParserDumpIR(rpn->base.next,indent+1);
-	case __IC_VARGS:
-		printf("VARGS:%d\n", rpn->length);
-		rpn = rpn->base.next;
-		for (idx = 0; idx != orig_rpn->length; idx++) {
-			ParserDumpIR(rpn, indent + 1);
-			rpn = ICFwd(rpn);
-		}
-		return rpn;
-	case IC_GOTO_IF:
-		printf("GOTO_IF:%p\n", rpn->code_misc);
-		goto unop;
-		break;
-	case __IC_SET_FRAME_SIZE:
-		printf("SET_FRAME_SIZE: %p\n", rpn->integer);
-		return rpn->base.next;
-		break;
-	case __IC_ARG:
-		printf("ARG %p\n", rpn->integer);
-		goto unop;
-		break;
-	case IC_STATIC:
-		printf("STATIC %p ", rpn->integer);
-		DumpRPNType(rpn);
-		printf("\n");
-		goto ret;
-	case IC_TYPECAST:
-		printf("TYPECAST");
-		DumpRPNType(rpn);
-		printf("\n");
-		ParserDumpIR(rpn->base.next, indent + 1);
-		goto ret;
-		break;
-	case IC_SUB_RET:
-		printf("IC_SUB_RET\n");
-		goto ret;
-		break;
-	case IC_SUB_PROLOG:
-		printf("IC_SUB_PROLOG\n");
-		goto ret;
-		break;
-	case IC_SUB_CALL:
-		printf("IC_SUB_CALL\n");
-		goto ret;
-		break;
-	case IC_UNBOUNDED_SWITCH:
-		printf("SWITCH[]");
-	swit:
-		ParserDumpIR(ICArgN(rpn, 0), indent + 1);
-		goto ret;
-		break;
-	case IC_TO_I64:
-		printf("TOI64");
-		goto unop;
-	case IC_TO_F64:
-		printf("TOF64");
-		goto unop;
-		break;
-	case IC_BOUNDED_SWITCH:
-		printf("SWITCH()\n");
-		goto swit;
-		break;
-	case __IC_CALL:
-	case IC_CALL:
-		rpn = rpn->base.next;
-		printf("CALL");
-		DumpRPNType(orig_rpn);
-		printf("\n");
-		for (idx = 0; idx != orig_rpn->length; idx++) {
-			ParserDumpIR(rpn, indent + 1);
-			rpn = ICFwd(rpn);
-		}
-		ParserDumpIR(rpn, indent + 1);
-		goto ret;
-		break;
-	case IC_COMMA:
-		printf(",");
-		DumpRPNType(orig_rpn);
-		goto binop;
-		break;
-	case IC_BT:
-		printf("BT");
-		goto binop;
-	case IC_BTR:
-		printf("BTR");
-		goto binop;
-	case IC_BTS:
-		printf("BTS");
-		goto binop;
-	case IC_BTC:
-		printf("BTC");
-		goto binop;
-	case IC_LBTR:
-		printf("LBTR");
-		goto binop;
-	case IC_LBTS:
-		printf("LBTS");
-		goto binop;
-	case IC_LBTC:
-		printf("LBTC");
-		goto binop;
-	case IC_BASE_PTR:
-		printf("FRAME(%ld)", rpn->integer);
-		DumpRPNType(orig_rpn);
-		printf("\n");
-		goto ret;
-		break;
-	case IC_IREG:
-		printf("IREG(%ld)", rpn->integer);
-		DumpRPNType(orig_rpn);
-		printf("\n");
-		goto ret;
-		break;
-	case IC_FREG:
-		printf("FREG(%ld)", rpn->integer);
-		DumpRPNType(orig_rpn);
-		printf("\n");
-		goto ret;
-		break;
-	case IC_LOAD:
-		printf("IC_LOAD\n");
-		goto binop;
-		break;
-	case IC_STORE:
-		printf("IC_STORE\n");
-		goto binop;
-		break;
-	case IC_RET:
-		printf("RETURN\n");
-		ParserDumpIR(rpn->base.next, indent + 1);
-		goto ret;
-		break;
-	case IC_GOTO:
-		if (rpn->code_misc)
-			printf("GOTO:%s\n", rpn->code_misc->str);
-		else
-			printf("GOTO??\n");
-		goto ret;
-		break;
-	case IC_LABEL:
-		printf("LABEL:%p\n", rpn->code_misc);
-		goto ret;
-		break;
-	case IC_GLOBAL:
-		printf("GLOBAL:%s", rpn->global_var->base.str);
-		DumpRPNType(rpn);
-		printf("\n");
-		goto ret;
-		break;
-	case IC_LOCAL:
-		printf("LOCAL:%s", rpn->local_mem->str);
-		DumpRPNType(rpn);
-		printf("\n");
-		goto ret;
-		break;
-	case IC_NOP:
-		printf("NOP\n");
-		goto ret;
-		break;
-	case IC_NAME:
-		printf("NAME:%s\n", rpn->string);
-		goto ret;
-		break;
-	case IC_POW:
-		printf("`");
-		goto binop;
-		break;
-	case IC_ADD:
-		printf("+");
-		goto binop;
-		break;
-	case IC_EQ:
-		printf("=");
-		goto binop;
-		break;
-	case IC_SUB:
-		printf("-");
-		goto binop;
-		break;
-	case IC_DIV:
-		printf("/");
-		goto binop;
-		break;
-	case IC_MUL:
-		printf("*");
-		goto binop;
-		break;
-	case IC_DEREF:
-		printf("DEREF");
-		goto unop;
-		break;
-	case IC_AND:
-		printf("&");
-		goto binop;
-		break;
-	case IC_ADDR_OF:
-		printf("ADDR_OF");
-		goto unop;
-		break;
-	case IC_XOR:
-		printf("^");
-		goto binop;
-		break;
-	case IC_MOD:
-		printf("%%");
-		goto binop;
-		break;
-	case IC_OR:
-		printf("|");
-		goto binop;
-		break;
-	case IC_LT:
-		printf("<");
-		goto binop;
-		break;
-	case IC_GT:
-		printf(">");
-		goto binop;
-		break;
-	case IC_LNOT:
-		printf("!");
-		goto unop;
-		break;
-	case IC_BNOT:
-		printf("~");
-		goto unop;
-		break;
-	case IC_POST_INC:
-		printf("x++");
-		goto unop;
-		break;
-	case IC_POST_DEC:
-		printf("x--");
-		goto unop;
-		break;
-	case IC_PRE_INC:
-		printf("++x");
-		goto unop;
-		break;
-	case IC_PRE_DEC:
-		printf("--x");
-		goto unop;
-		break;
-	case IC_AND_AND:
-		printf("&&");
-		goto binop;
-		break;
-	case IC_OR_OR:
-		printf("||");
-		goto binop;
-		break;
-	case IC_XOR_XOR:
-		printf("^^");
-		goto binop;
-		break;
-	case IC_EQ_EQ:
-		printf("==");
-		goto binop;
-		break;
-	case IC_NE:
-		printf("!=");
-		goto binop;
-		break;
-	case IC_LE:
-		printf("<=");
-		goto binop;
-		break;
-	case IC_GE:
-		printf(">=");
-		goto binop;
-		break;
-	case IC_LSH:
-		printf("<<");
-		goto binop;
-		break;
-	case IC_RSH:
-		printf(">>");
-		goto binop;
-		break;
-	case IC_ADD_EQ:
-		printf("+=");
-		goto binop;
-		break;
-	case IC_SUB_EQ:
-		printf("-=");
-		goto binop;
-		break;
-	case IC_MUL_EQ:
-		printf("*=");
-		goto binop;
-		break;
-	case IC_DIV_EQ:
-		printf("/=");
-		goto binop;
-		break;
-	case IC_LSH_EQ:
-		printf("<<=");
-		goto binop;
-		break;
-	case IC_RSH_EQ:
-		printf(">>=");
-		goto binop;
-		break;
-	case IC_AND_EQ:
-		printf("&=");
-		goto binop;
-		break;
-	case IC_OR_EQ:
-		printf("|=");
-		goto binop;
-		break;
-	case IC_XOR_EQ:
-		printf("^=");
-		goto binop;
-		break;
-	case IC_DOT:
-		printf(".%s", rpn->local_mem->str);
-	member:
-		printf(" ");
-		DumpRPNType(rpn);
-		ParserDumpIR(rpn->base.next, indent + 1);
-		goto ret;
-	case IC_ARROW:
-		printf("->%s", rpn->local_mem->str);
-		goto member;
-	case IC_MOD_EQ:
-		printf("%=");
-		goto binop;
-	case IC_I64:
-		printf("I64:%ld\n", rpn->integer);
-		goto ret;
-	case IC_STR:
-		printf("STR:%s\n", rpn->code_misc->str);
-		goto ret;
-	case IC_CHR:
-		printf("CHR:%s\n", &rpn->integer);
-		goto ret;
-	case IC_F64:
-		printf("F64:%lf\n", rpn->flt);
-		goto ret;
-	case IC_ARRAY_ACC:
-		printf("[]");
-	binop:
-		printf(" ");
-		DumpRPNType(rpn);
-		printf("\n");
-		rpn = ParserDumpIR(rpn->base.next, indent + 1);
-		rpn = ParserDumpIR(rpn, indent + 1);
-		goto ret;
-		break;
-	case IC_NEG:
-		printf("-");
-		goto unop;
-		break;
-	case IC_POS:
-		printf("+");
-	unop:
-		DumpRPNType(rpn);
-		printf("\n");
-		ParserDumpIR(rpn->base.next, indent + 1);
-		goto ret;
-	default:
-		printf("%ld\n", rpn->type);
-		abort();
-	}
-	//???
-	abort();
-	return NULL;
+CRPN *ParserDumpIR(CRPN *rpn, int64_t indent) {
+  int64_t idx;
+  CRPN *orig_rpn = rpn;
+#define INDENT                                                                 \
+  for (idx = 0; idx != indent; idx++)                                          \
+    printf("  ");
+  INDENT;
+  switch (rpn->type) {
+  case IC_RAW_BYTES:
+    printf("RAW_BYTES:%ld\n", rpn->length);
+    goto ret;
+  case __IC_STATICS_SIZE:
+    printf("STATICS_SZ:%ld\n", rpn->integer);
+    goto ret;
+    break;
+  case __IC_SET_STATIC_DATA:
+    printf("SET_STATIC_DATA:%ld(%ld)\n", rpn->code_misc->integer,
+           rpn->code_misc->str_len);
+    goto ret;
+    break;
+  case __IC_STATIC_REF:
+    printf("SET_STATIC_REF:(%ld)", rpn->integer);
+    DumpRPNType(rpn);
+    printf("\n");
+    goto ret;
+  case IC_SHORT_ADDR:
+    printf("SHORT_ADDR:%s\n", rpn->code_misc->str);
+    return ICFwd(rpn);
+  case IC_RELOC:
+    printf("RELOC:%s\n", rpn->code_misc->str);
+    return ICFwd(rpn);
+  case IC_GET_VARGS_PTR:
+    printf("GET_VARGS_PTR:\n");
+    return ParserDumpIR(rpn->base.next, indent + 1);
+  case __IC_VARGS:
+    printf("VARGS:%d\n", rpn->length);
+    rpn = rpn->base.next;
+    for (idx = 0; idx != orig_rpn->length; idx++) {
+      ParserDumpIR(rpn, indent + 1);
+      rpn = ICFwd(rpn);
+    }
+    return rpn;
+  case IC_GOTO_IF:
+    printf("GOTO_IF:%p\n", rpn->code_misc);
+    goto unop;
+    break;
+  case __IC_SET_FRAME_SIZE:
+    printf("SET_FRAME_SIZE: %p\n", rpn->integer);
+    return rpn->base.next;
+    break;
+  case __IC_ARG:
+    printf("ARG %p\n", rpn->integer);
+    goto unop;
+    break;
+  case IC_STATIC:
+    printf("STATIC %p ", rpn->integer);
+    DumpRPNType(rpn);
+    printf("\n");
+    goto ret;
+  case IC_TYPECAST:
+    printf("TYPECAST");
+    DumpRPNType(rpn);
+    printf("\n");
+    ParserDumpIR(rpn->base.next, indent + 1);
+    goto ret;
+    break;
+  case IC_SUB_RET:
+    printf("IC_SUB_RET\n");
+    goto ret;
+    break;
+  case IC_SUB_PROLOG:
+    printf("IC_SUB_PROLOG\n");
+    goto ret;
+    break;
+  case IC_SUB_CALL:
+    printf("IC_SUB_CALL\n");
+    goto ret;
+    break;
+  case IC_UNBOUNDED_SWITCH:
+    printf("SWITCH[]");
+  swit:
+    ParserDumpIR(ICArgN(rpn, 0), indent + 1);
+    goto ret;
+    break;
+  case IC_TO_I64:
+    printf("TOI64");
+    goto unop;
+  case IC_TO_F64:
+    printf("TOF64");
+    goto unop;
+    break;
+  case IC_BOUNDED_SWITCH:
+    printf("SWITCH()\n");
+    goto swit;
+    break;
+  case __IC_CALL:
+  case IC_CALL:
+    rpn = rpn->base.next;
+    printf("CALL");
+    DumpRPNType(orig_rpn);
+    printf("\n");
+    for (idx = 0; idx != orig_rpn->length; idx++) {
+      ParserDumpIR(rpn, indent + 1);
+      rpn = ICFwd(rpn);
+    }
+    ParserDumpIR(rpn, indent + 1);
+    goto ret;
+    break;
+  case IC_COMMA:
+    printf(",");
+    DumpRPNType(orig_rpn);
+    goto binop;
+    break;
+  case IC_BT:
+    printf("BT");
+    goto binop;
+  case IC_BTR:
+    printf("BTR");
+    goto binop;
+  case IC_BTS:
+    printf("BTS");
+    goto binop;
+  case IC_BTC:
+    printf("BTC");
+    goto binop;
+  case IC_LBTR:
+    printf("LBTR");
+    goto binop;
+  case IC_LBTS:
+    printf("LBTS");
+    goto binop;
+  case IC_LBTC:
+    printf("LBTC");
+    goto binop;
+  case IC_BASE_PTR:
+    printf("FRAME(%ld)", rpn->integer);
+    DumpRPNType(orig_rpn);
+    printf("\n");
+    goto ret;
+    break;
+  case IC_IREG:
+    printf("IREG(%ld)", rpn->integer);
+    DumpRPNType(orig_rpn);
+    printf("\n");
+    goto ret;
+    break;
+  case IC_FREG:
+    printf("FREG(%ld)", rpn->integer);
+    DumpRPNType(orig_rpn);
+    printf("\n");
+    goto ret;
+    break;
+  case IC_LOAD:
+    printf("IC_LOAD\n");
+    goto binop;
+    break;
+  case IC_STORE:
+    printf("IC_STORE\n");
+    goto binop;
+    break;
+  case IC_RET:
+    printf("RETURN\n");
+    ParserDumpIR(rpn->base.next, indent + 1);
+    goto ret;
+    break;
+  case IC_GOTO:
+    if (rpn->code_misc)
+      printf("GOTO:%s\n", rpn->code_misc->str);
+    else
+      printf("GOTO??\n");
+    goto ret;
+    break;
+  case IC_LABEL:
+    printf("LABEL:%p\n", rpn->code_misc);
+    goto ret;
+    break;
+  case IC_GLOBAL:
+    printf("GLOBAL:%s", rpn->global_var->base.str);
+    DumpRPNType(rpn);
+    printf("\n");
+    goto ret;
+    break;
+  case IC_LOCAL:
+    printf("LOCAL:%s", rpn->local_mem->str);
+    DumpRPNType(rpn);
+    printf("\n");
+    goto ret;
+    break;
+  case IC_NOP:
+    printf("NOP\n");
+    goto ret;
+    break;
+  case IC_NAME:
+    printf("NAME:%s\n", rpn->string);
+    goto ret;
+    break;
+  case IC_POW:
+    printf("`");
+    goto binop;
+    break;
+  case IC_ADD:
+    printf("+");
+    goto binop;
+    break;
+  case IC_EQ:
+    printf("=");
+    goto binop;
+    break;
+  case IC_SUB:
+    printf("-");
+    goto binop;
+    break;
+  case IC_DIV:
+    printf("/");
+    goto binop;
+    break;
+  case IC_MUL:
+    printf("*");
+    goto binop;
+    break;
+  case IC_DEREF:
+    printf("DEREF");
+    goto unop;
+    break;
+  case IC_AND:
+    printf("&");
+    goto binop;
+    break;
+  case IC_ADDR_OF:
+    printf("ADDR_OF");
+    goto unop;
+    break;
+  case IC_XOR:
+    printf("^");
+    goto binop;
+    break;
+  case IC_MOD:
+    printf("%%");
+    goto binop;
+    break;
+  case IC_OR:
+    printf("|");
+    goto binop;
+    break;
+  case IC_LT:
+    printf("<");
+    goto binop;
+    break;
+  case IC_GT:
+    printf(">");
+    goto binop;
+    break;
+  case IC_LNOT:
+    printf("!");
+    goto unop;
+    break;
+  case IC_BNOT:
+    printf("~");
+    goto unop;
+    break;
+  case IC_POST_INC:
+    printf("x++");
+    goto unop;
+    break;
+  case IC_POST_DEC:
+    printf("x--");
+    goto unop;
+    break;
+  case IC_PRE_INC:
+    printf("++x");
+    goto unop;
+    break;
+  case IC_PRE_DEC:
+    printf("--x");
+    goto unop;
+    break;
+  case IC_AND_AND:
+    printf("&&");
+    goto binop;
+    break;
+  case IC_OR_OR:
+    printf("||");
+    goto binop;
+    break;
+  case IC_XOR_XOR:
+    printf("^^");
+    goto binop;
+    break;
+  case IC_EQ_EQ:
+    printf("==");
+    goto binop;
+    break;
+  case IC_NE:
+    printf("!=");
+    goto binop;
+    break;
+  case IC_LE:
+    printf("<=");
+    goto binop;
+    break;
+  case IC_GE:
+    printf(">=");
+    goto binop;
+    break;
+  case IC_LSH:
+    printf("<<");
+    goto binop;
+    break;
+  case IC_RSH:
+    printf(">>");
+    goto binop;
+    break;
+  case IC_ADD_EQ:
+    printf("+=");
+    goto binop;
+    break;
+  case IC_SUB_EQ:
+    printf("-=");
+    goto binop;
+    break;
+  case IC_MUL_EQ:
+    printf("*=");
+    goto binop;
+    break;
+  case IC_DIV_EQ:
+    printf("/=");
+    goto binop;
+    break;
+  case IC_LSH_EQ:
+    printf("<<=");
+    goto binop;
+    break;
+  case IC_RSH_EQ:
+    printf(">>=");
+    goto binop;
+    break;
+  case IC_AND_EQ:
+    printf("&=");
+    goto binop;
+    break;
+  case IC_OR_EQ:
+    printf("|=");
+    goto binop;
+    break;
+  case IC_XOR_EQ:
+    printf("^=");
+    goto binop;
+    break;
+  case IC_DOT:
+    printf(".%s", rpn->local_mem->str);
+  member:
+    printf(" ");
+    DumpRPNType(rpn);
+    ParserDumpIR(rpn->base.next, indent + 1);
+    goto ret;
+  case IC_ARROW:
+    printf("->%s", rpn->local_mem->str);
+    goto member;
+  case IC_MOD_EQ:
+    printf("%=");
+    goto binop;
+  case IC_I64:
+    printf("I64:%ld\n", rpn->integer);
+    goto ret;
+  case IC_STR:
+    printf("STR:%s\n", rpn->code_misc->str);
+    goto ret;
+  case IC_CHR:
+    printf("CHR:%s\n", &rpn->integer);
+    goto ret;
+  case IC_F64:
+    printf("F64:%lf\n", rpn->flt);
+    goto ret;
+  case IC_ARRAY_ACC:
+    printf("[]");
+  binop:
+    printf(" ");
+    DumpRPNType(rpn);
+    printf("\n");
+    rpn = ParserDumpIR(rpn->base.next, indent + 1);
+    rpn = ParserDumpIR(rpn, indent + 1);
+    goto ret;
+    break;
+  case IC_NEG:
+    printf("-");
+    goto unop;
+    break;
+  case IC_POS:
+    printf("+");
+  unop:
+    DumpRPNType(rpn);
+    printf("\n");
+    ParserDumpIR(rpn->base.next, indent + 1);
+    goto ret;
+  default:
+    printf("%ld\n", rpn->type);
+    abort();
+  }
+  //???
+  abort();
+  return NULL;
 ret:
-	return ICFwd(orig_rpn);
+  return ICFwd(orig_rpn);
 }
 
-static int64_t IsRightAssoc(int64_t ic)
-{
-	switch (ic) {
-	case IC_PRE_DEC:
-	case IC_PRE_INC:
-	case IC_ADDR_OF:
-	case IC_DEREF:
-	case IC_BNOT:
-	case IC_LNOT:
-	case IC_POS:
-	case IC_NEG:
-	case IC_EQ:
-	case IC_ADD_EQ:
-	case IC_SUB_EQ:
-	case IC_MUL_EQ:
-	case IC_DIV_EQ:
-	case IC_LSH_EQ:
-	case IC_RSH_EQ:
-	case IC_AND_EQ:
-	case IC_OR_EQ:
-	case IC_XOR_EQ:
-	case IC_MOD_EQ:
-		return 1;
-	}
-	return 0;
+static int64_t IsRightAssoc(int64_t ic) {
+  switch (ic) {
+  case IC_PRE_DEC:
+  case IC_PRE_INC:
+  case IC_ADDR_OF:
+  case IC_DEREF:
+  case IC_BNOT:
+  case IC_LNOT:
+  case IC_POS:
+  case IC_NEG:
+  case IC_EQ:
+  case IC_ADD_EQ:
+  case IC_SUB_EQ:
+  case IC_MUL_EQ:
+  case IC_DIV_EQ:
+  case IC_LSH_EQ:
+  case IC_RSH_EQ:
+  case IC_AND_EQ:
+  case IC_OR_EQ:
+  case IC_XOR_EQ:
+  case IC_MOD_EQ:
+    return 1;
+  }
+  return 0;
 }
 
-CMemberLst* MemberFind(char* needle, CHashClass* cls)
-{
-	CMemberLst* lst;
-	for (lst = cls->members_lst; lst; lst = lst->next)
-		if (lst->str)
-			if (!strcmp(needle, lst->str))
-				return lst;
-	if (cls->base_class)
-		return MemberFind(needle, cls->base_class);
-	if (cls->fwd_class)
-		return MemberFind(needle, cls->fwd_class);
-	return NULL;
+CMemberLst *MemberFind(char *needle, CHashClass *cls) {
+  CMemberLst *lst;
+  for (lst = cls->members_lst; lst; lst = lst->next)
+    if (lst->str)
+      if (!strcmp(needle, lst->str))
+        return lst;
+  if (cls->base_class)
+    return MemberFind(needle, cls->base_class);
+  if (cls->fwd_class)
+    return MemberFind(needle, cls->fwd_class);
+  return NULL;
 }
 //
 // This does not mirror TempleOS's exactly,what I do
 // just fill in the ->address with the needed ptr
 //
-void SysSymImportsResolve(char* sym, int64_t flags)
-{
-	CHashImport* imp;
-	CHash* thing = HashFind(sym, Fs->hash_table, HTT_FUN | HTT_GLBL_VAR, 1);
-	void* with;
-	if (thing->type & HTT_FUN) {
-		with = ((CHashFun*)thing)->fun_ptr;
-	} else if (thing->type & HTT_GLBL_VAR) {
-		with = ((CHashGlblVar*)thing)->data_addr;
-	} else
-		throw(*(int64_t*)"Resolve");
-	if (!with)
-		return;
-	while (imp = HashSingleTableFind(sym, Fs->hash_table, HTT_IMPORT_SYS_SYM, 1)) {
-		*imp->address = with; // TODO make TempleOS like
-		imp->base.type = HTT_INVALID;
-	}
+void SysSymImportsResolve(char *sym, int64_t flags) {
+  CHashImport *imp;
+  CHash *thing = HashFind(sym, Fs->hash_table, HTT_FUN | HTT_GLBL_VAR, 1);
+  void *with;
+  if (thing->type & HTT_FUN) {
+    with = ((CHashFun *)thing)->fun_ptr;
+  } else if (thing->type & HTT_GLBL_VAR) {
+    with = ((CHashGlblVar *)thing)->data_addr;
+  } else
+    throw(*(int64_t *)"Resolve");
+  if (!with)
+    return;
+  while (imp =
+             HashSingleTableFind(sym, Fs->hash_table, HTT_IMPORT_SYS_SYM, 1)) {
+    *imp->address = with; // TODO make TempleOS like
+    imp->base.type = HTT_INVALID;
+  }
 }
-static int64_t SetIncAmt(CCmpCtrl* ccmp, CRPN* target)
-{
-	CRPN* next;
-	int64_t a = 1;
-	AssignRawTypeToNode(ccmp, next = target->base.next);
-	if (next->ic_dim || next->ic_class->ptr_star_cnt) {
-		if (next->ic_dim) {
-			a *= next->ic_dim->total_cnt;
-			a *= next->ic_class->sz;
-		} else
-			a = next->ic_class[-1].sz;
-	}
-	target->integer = a;
+static int64_t SetIncAmt(CCmpCtrl *ccmp, CRPN *target) {
+  CRPN *next;
+  int64_t a = 1;
+  AssignRawTypeToNode(ccmp, next = target->base.next);
+  if (next->ic_dim || next->ic_class->ptr_star_cnt) {
+    if (next->ic_dim) {
+      a *= next->ic_dim->total_cnt;
+      a *= next->ic_class->sz;
+    } else
+      a = next->ic_class[-1].sz;
+  }
+  target->integer = a;
 }
 // https://en.wikipedia.org/wiki/Shunting_yard_algorithm
 #define PEF_NO_COMMA 1
-int64_t ParseExpr(CCmpCtrl* ccmp, int64_t flags)
-{
-#define POST_XXX_CHECK                            \
-	{                                             \
-		CRPN* ic;                                 \
-		switch (ccmp->lex->cur_tok) {             \
-			break;                                \
-		case TK_INC_INC:                          \
-			ic = A_CALLOC(sizeof(CRPN), NULL);    \
-			ic->type = IC_POST_INC;               \
-			QueIns(ic, ccmp->code_ctrl->ir_code); \
-			AssignRawTypeToNode(ccmp, ic);        \
-			Lex(ccmp->lex);                       \
-			SetIncAmt(ccmp, ic);                  \
-			break;                                \
-		case TK_DEC_DEC:                          \
-			ic = A_CALLOC(sizeof(CRPN), NULL);    \
-			ic->type = IC_POST_DEC;               \
-			QueIns(ic, ccmp->code_ctrl->ir_code); \
-			AssignRawTypeToNode(ccmp, ic);        \
-			SetIncAmt(ccmp, ic);                  \
-			Lex(ccmp->lex);                       \
-		}                                         \
-	}
+int64_t ParseExpr(CCmpCtrl *ccmp, int64_t flags) {
+#define POST_XXX_CHECK                                                         \
+  {                                                                            \
+    CRPN *ic;                                                                  \
+    switch (ccmp->lex->cur_tok) {                                              \
+      break;                                                                   \
+    case TK_INC_INC:                                                           \
+      ic = A_CALLOC(sizeof(CRPN), NULL);                                       \
+      ic->type = IC_POST_INC;                                                  \
+      QueIns(ic, ccmp->code_ctrl->ir_code);                                    \
+      AssignRawTypeToNode(ccmp, ic);                                           \
+      Lex(ccmp->lex);                                                          \
+      SetIncAmt(ccmp, ic);                                                     \
+      break;                                                                   \
+    case TK_DEC_DEC:                                                           \
+      ic = A_CALLOC(sizeof(CRPN), NULL);                                       \
+      ic->type = IC_POST_DEC;                                                  \
+      QueIns(ic, ccmp->code_ctrl->ir_code);                                    \
+      AssignRawTypeToNode(ccmp, ic);                                           \
+      SetIncAmt(ccmp, ic);                                                     \
+      Lex(ccmp->lex);                                                          \
+    }                                                                          \
+  }
 
-	int64_t tok, prec, type, binop_before = 1, arg, str_len;
-	int64_t ic_stk[0x100];
-	int64_t prec_stk[0x100];
-	int64_t stk_ptr = 0, idx;
-	CRPN *ic, *ic2, *orig = ccmp->code_ctrl->ir_code->next;
-	char* string;
-	CMemberLst* local;
-	CHashGlblVar* global_var;
-	CCodeMisc* misc;
-	CHashClass* tc_class;
-	CHashFun* tc_fun;
-	CArrayDim dummy_dim;
+  int64_t tok, prec, type, binop_before = 1, arg, str_len;
+  int64_t ic_stk[0x100];
+  int64_t prec_stk[0x100];
+  int64_t stk_ptr = 0, idx;
+  CRPN *ic, *ic2, *orig = ccmp->code_ctrl->ir_code->next;
+  char *string;
+  CMemberLst *local;
+  CHashGlblVar *global_var;
+  CCodeMisc *misc;
+  CHashClass *tc_class;
+  CHashFun *tc_fun;
+  CArrayDim dummy_dim;
 next:
-	while (tok = ccmp->lex->cur_tok) {
-		switch (tok) {
-			break;
-		case TK_KW_OFFSET:
-		offo:
-			if (ccmp->lex->cur_tok != '(')
-				ParseErr(ccmp, "Expected a '('.");
-			Lex(ccmp->lex);
-			if (ccmp->lex->cur_tok != TK_NAME)
-				ParseErr(ccmp, "Expected a 'typename'.");
-			tc_class = HashFind(ccmp->lex->string, Fs->hash_table, HTT_CLASS, 1);
-			if (!tc_class)
-				ParseErr(ccmp, "Expected a 'typename'.");
-			Lex(ccmp->lex);
-			if (ccmp->lex->cur_tok != '.')
-				ParseErr(ccmp, "Expected a '.'.");
-			Lex(ccmp->lex);
-			if (ccmp->lex->cur_tok != TK_NAME)
-				ParseErr(ccmp, "Expected a 'member'.");
-			if (!MemberFind(ccmp->lex->string, tc_class))
-				ParseErr(ccmp, "Class '%s' is missing member '%s'.", tc_class->base.str, ccmp->lex->string);
-			Lex(ccmp->lex);
-			if (ccmp->lex->cur_tok != ')')
-				ParseErr(ccmp, "Expected a ')'.");
-			Lex(ccmp->lex);
-			ic = A_CALLOC(sizeof(CRPN), NULL);
-			ic->type = IC_I64;
-			ic->integer = MemberFind(ccmp->lex->string, tc_class)->off;
-			QueIns(ic, ccmp->code_ctrl->ir_code);
-			binop_before = 0;
-			goto next;
-			break;
-		case TK_KW_SIZEOF:
-			Lex(ccmp->lex);
-		szo:
-			if (ccmp->lex->cur_tok == '(') {
-				Lex(ccmp->lex);
-				if (ccmp->lex->cur_tok != TK_NAME)
-					ParseErr(ccmp, "Expected a typename.");
-				if (!(tc_class = HashFind(ccmp->lex->string, Fs->hash_table, HTT_CLASS, 1)))
-					ParseErr(ccmp, "Expected a typename.");
-				Lex(ccmp->lex);
-				tc_class = PrsType(ccmp, tc_class, NULL, NULL, &dummy_dim);
-				arg = tc_class->sz * dummy_dim.total_cnt;
-				if (dummy_dim.next)
-					ArrayDimDel(dummy_dim.next);
-				type = IC_I64;
-				ic = A_CALLOC(sizeof(CRPN), NULL);
-				ic->type = type;
-				QueInit(&ic->base);
-				ic->integer = arg;
-				QueIns(ic, ccmp->code_ctrl->ir_code);
-				if (ccmp->lex->cur_tok != ')')
-					ParseErr(ccmp, "Expected a ')'.");
-				Lex(ccmp->lex);
-				binop_before = 0;
-				goto next;
-			} else if (ccmp->lex->cur_tok == TK_NAME) {
-				if (!(tc_class = HashFind(ccmp->lex->string, Fs->hash_table, HTT_CLASS, 1)))
-					ParseErr(ccmp, "Expected a typename.");
-				arg = tc_class->sz;
-				Lex(ccmp->lex);
-				type = IC_I64;
-				ic = A_CALLOC(sizeof(CRPN), NULL);
-				ic->type = type;
-				QueInit(&ic->base);
-				ic->integer = arg;
-				QueIns(ic, ccmp->code_ctrl->ir_code);
-				binop_before = 0;
-				goto next;
-			} else
-				ParseErr(ccmp, "Expected a typename.");
-			break;
-		case '`':
-			prec = 1;
-			type = IC_POW;
-			binop_before = 1;
-			Lex(ccmp->lex);
-			break;
-		case '+':
-			Lex(ccmp->lex);
-			if (binop_before) {
-				// Unary
-				binop_before = 0;
-				prec = 0;
-				type = IC_POS;
-			} else {
-				prec = 6;
-				binop_before = 1;
-				type = IC_ADD;
-			}
-			break;
-		case '=':
-			Lex(ccmp->lex);
-			prec = 12;
-			binop_before = 1;
-			type = IC_EQ;
-			break;
-		case '-':
-			Lex(ccmp->lex);
-			if (binop_before) {
-				// Unary
-				binop_before = 1; // Like a binop as it consumes the right item
-				prec = 0;
-				type = IC_NEG;
-			} else {
-				prec = 6;
-				binop_before = 1;
-				type = IC_SUB;
-			}
-			break;
-		case '/':
-			Lex(ccmp->lex);
-			prec = 2;
-			type = IC_DIV;
-			binop_before = 1;
-			break;
-		case '*':
-			Lex(ccmp->lex);
-			if (binop_before) {
-				// Unary
-				binop_before = 1; // Consumes like a binop
-				prec = 0;
-				type = IC_DEREF;
-			} else {
-				prec = 2;
-				type = IC_MUL;
-				binop_before = 1;
-			}
-			break;
-		case '&':
-			Lex(ccmp->lex);
-			if (binop_before) {
-				// Unary
-				binop_before = 1; // Consumes next thing like a binop
-				prec = 0;
-				type = IC_ADDR_OF;
-			} else {
-				prec = 3;
-				type = IC_AND;
-				binop_before = 1;
-			}
-			break;
-		case '^':
-			Lex(ccmp->lex);
-			prec = 4;
-			type = IC_XOR;
-			binop_before = 1;
-			break;
-		case '%':
-			Lex(ccmp->lex);
-			prec = 2;
-			type = IC_MOD;
-			binop_before = 1;
-			break;
-		case '|':
-			Lex(ccmp->lex);
-			prec = 5;
-			type = IC_OR;
-			binop_before = 1;
-			break;
-		case '<':
-			Lex(ccmp->lex);
-			prec = 7;
-			type = IC_LT;
-			binop_before = 1;
-			break;
-		case '>':
-			Lex(ccmp->lex);
-			prec = 7;
-			type = IC_GT;
-			binop_before = 1;
-			break;
-		case '~':
-			Lex(ccmp->lex);
-			prec = 1;
-			type = IC_BNOT;
-			binop_before = 1; // Acts like a binop as it consumes the right side
-			break;
-		case '!':
-			Lex(ccmp->lex);
-			prec = 2;
-			type = IC_LNOT;
-			binop_before = 1; // Acts like a binop as it consumes the right side
-			break;
-		case '(':
-			Lex(ccmp->lex);
-			// If we are not being consumed by a binop,we are a function call
-			// or a typecast,so if we have a type,it is a typecast,else a function
-			// call
-			if (!binop_before) {
-				if (ccmp->lex->cur_tok == TK_NAME) {
-					if (tc_class = HashFind(ccmp->lex->string, Fs->hash_table, HTT_CLASS, 1)) {
-						//
-						// If our previous item is an uncalled function (we assumed we call functions when a '(' comes after),
-						// we will now call it. IT makes no  sense to typecast a function
-						//
-						// I64 Foo() {}
-						// If we have Foo(F64),treat it as Foo()(F64)
-						ic2 = ccmp->code_ctrl->ir_code->next;
-						if (ic2->type == IC_GLOBAL) {
-							if (ic2->global_var->base.type & HTT_FUN) {
-								ic = A_CALLOC(sizeof(CRPN), NULL);
-								ic->type = IC_CALL;
-								QueIns(ic, ccmp->code_ctrl->ir_code);
-								AssignRawTypeToNode(ccmp, ic);
-							}
-						}
+  while (tok = ccmp->lex->cur_tok) {
+    switch (tok) {
+      break;
+    case TK_KW_OFFSET:
+    offo:
+      if (ccmp->lex->cur_tok != '(')
+        ParseErr(ccmp, "Expected a '('.");
+      Lex(ccmp->lex);
+      if (ccmp->lex->cur_tok != TK_NAME)
+        ParseErr(ccmp, "Expected a 'typename'.");
+      tc_class = HashFind(ccmp->lex->string, Fs->hash_table, HTT_CLASS, 1);
+      if (!tc_class)
+        ParseErr(ccmp, "Expected a 'typename'.");
+      Lex(ccmp->lex);
+      if (ccmp->lex->cur_tok != '.')
+        ParseErr(ccmp, "Expected a '.'.");
+      Lex(ccmp->lex);
+      if (ccmp->lex->cur_tok != TK_NAME)
+        ParseErr(ccmp, "Expected a 'member'.");
+      if (!MemberFind(ccmp->lex->string, tc_class))
+        ParseErr(ccmp, "Class '%s' is missing member '%s'.", tc_class->base.str,
+                 ccmp->lex->string);
+      Lex(ccmp->lex);
+      if (ccmp->lex->cur_tok != ')')
+        ParseErr(ccmp, "Expected a ')'.");
+      Lex(ccmp->lex);
+      ic = A_CALLOC(sizeof(CRPN), NULL);
+      ic->type = IC_I64;
+      ic->integer = MemberFind(ccmp->lex->string, tc_class)->off;
+      QueIns(ic, ccmp->code_ctrl->ir_code);
+      binop_before = 0;
+      goto next;
+      break;
+    case TK_KW_SIZEOF:
+      Lex(ccmp->lex);
+    szo:
+      if (ccmp->lex->cur_tok == '(') {
+        Lex(ccmp->lex);
+        if (ccmp->lex->cur_tok != TK_NAME)
+          ParseErr(ccmp, "Expected a typename.");
+        if (!(tc_class =
+                  HashFind(ccmp->lex->string, Fs->hash_table, HTT_CLASS, 1)))
+          ParseErr(ccmp, "Expected a typename.");
+        Lex(ccmp->lex);
+        tc_class = PrsType(ccmp, tc_class, NULL, NULL, &dummy_dim);
+        arg = tc_class->sz * dummy_dim.total_cnt;
+        if (dummy_dim.next)
+          ArrayDimDel(dummy_dim.next);
+        type = IC_I64;
+        ic = A_CALLOC(sizeof(CRPN), NULL);
+        ic->type = type;
+        QueInit(&ic->base);
+        ic->integer = arg;
+        QueIns(ic, ccmp->code_ctrl->ir_code);
+        if (ccmp->lex->cur_tok != ')')
+          ParseErr(ccmp, "Expected a ')'.");
+        Lex(ccmp->lex);
+        binop_before = 0;
+        goto next;
+      } else if (ccmp->lex->cur_tok == TK_NAME) {
+        if (!(tc_class =
+                  HashFind(ccmp->lex->string, Fs->hash_table, HTT_CLASS, 1)))
+          ParseErr(ccmp, "Expected a typename.");
+        arg = tc_class->sz;
+        Lex(ccmp->lex);
+        type = IC_I64;
+        ic = A_CALLOC(sizeof(CRPN), NULL);
+        ic->type = type;
+        QueInit(&ic->base);
+        ic->integer = arg;
+        QueIns(ic, ccmp->code_ctrl->ir_code);
+        binop_before = 0;
+        goto next;
+      } else
+        ParseErr(ccmp, "Expected a typename.");
+      break;
+    case '`':
+      prec = 1;
+      type = IC_POW;
+      binop_before = 1;
+      Lex(ccmp->lex);
+      break;
+    case '+':
+      Lex(ccmp->lex);
+      if (binop_before) {
+        // Unary
+        binop_before = 0;
+        prec = 0;
+        type = IC_POS;
+      } else {
+        prec = 6;
+        binop_before = 1;
+        type = IC_ADD;
+      }
+      break;
+    case '=':
+      Lex(ccmp->lex);
+      prec = 12;
+      binop_before = 1;
+      type = IC_EQ;
+      break;
+    case '-':
+      Lex(ccmp->lex);
+      if (binop_before) {
+        // Unary
+        binop_before = 1; // Like a binop as it consumes the right item
+        prec = 0;
+        type = IC_NEG;
+      } else {
+        prec = 6;
+        binop_before = 1;
+        type = IC_SUB;
+      }
+      break;
+    case '/':
+      Lex(ccmp->lex);
+      prec = 2;
+      type = IC_DIV;
+      binop_before = 1;
+      break;
+    case '*':
+      Lex(ccmp->lex);
+      if (binop_before) {
+        // Unary
+        binop_before = 1; // Consumes like a binop
+        prec = 0;
+        type = IC_DEREF;
+      } else {
+        prec = 2;
+        type = IC_MUL;
+        binop_before = 1;
+      }
+      break;
+    case '&':
+      Lex(ccmp->lex);
+      if (binop_before) {
+        // Unary
+        binop_before = 1; // Consumes next thing like a binop
+        prec = 0;
+        type = IC_ADDR_OF;
+      } else {
+        prec = 3;
+        type = IC_AND;
+        binop_before = 1;
+      }
+      break;
+    case '^':
+      Lex(ccmp->lex);
+      prec = 4;
+      type = IC_XOR;
+      binop_before = 1;
+      break;
+    case '%':
+      Lex(ccmp->lex);
+      prec = 2;
+      type = IC_MOD;
+      binop_before = 1;
+      break;
+    case '|':
+      Lex(ccmp->lex);
+      prec = 5;
+      type = IC_OR;
+      binop_before = 1;
+      break;
+    case '<':
+      Lex(ccmp->lex);
+      prec = 7;
+      type = IC_LT;
+      binop_before = 1;
+      break;
+    case '>':
+      Lex(ccmp->lex);
+      prec = 7;
+      type = IC_GT;
+      binop_before = 1;
+      break;
+    case '~':
+      Lex(ccmp->lex);
+      prec = 1;
+      type = IC_BNOT;
+      binop_before = 1; // Acts like a binop as it consumes the right side
+      break;
+    case '!':
+      Lex(ccmp->lex);
+      prec = 2;
+      type = IC_LNOT;
+      binop_before = 1; // Acts like a binop as it consumes the right side
+      break;
+    case '(':
+      Lex(ccmp->lex);
+      // If we are not being consumed by a binop,we are a function call
+      // or a typecast,so if we have a type,it is a typecast,else a function
+      // call
+      if (!binop_before) {
+        if (ccmp->lex->cur_tok == TK_NAME) {
+          if (tc_class =
+                  HashFind(ccmp->lex->string, Fs->hash_table, HTT_CLASS, 1)) {
+            //
+            // If our previous item is an uncalled function (we assumed we call
+            // functions when a '(' comes after), we will now call it. IT makes
+            // no  sense to typecast a function
+            //
+            // I64 Foo() {}
+            // If we have Foo(F64),treat it as Foo()(F64)
+            ic2 = ccmp->code_ctrl->ir_code->next;
+            if (ic2->type == IC_GLOBAL) {
+              if (ic2->global_var->base.type & HTT_FUN) {
+                ic = A_CALLOC(sizeof(CRPN), NULL);
+                ic->type = IC_CALL;
+                QueIns(ic, ccmp->code_ctrl->ir_code);
+                AssignRawTypeToNode(ccmp, ic);
+              }
+            }
 
-						//
-						// See ghost ahead
-						//
-						ic2 = ccmp->code_ctrl->ir_code->next;
-						//
-						ic = A_CALLOC(sizeof(CRPN), NULL);
-						ic->type = IC_TYPECAST;
-						ic->ic_dim = A_CALLOC(sizeof(CArrayDim), NULL);
-						ic->ic_dim->total_cnt = INT_MIN; // If still negative,we didint get a dim
-						ic->ic_dim->cnt = 1;
-						Lex(ccmp->lex);
-						ic->ic_class = PrsType(ccmp, tc_class, NULL, &ic->ic_fun, ic->ic_dim);
-						if (!ic->ic_dim->next) {
-							A_FREE(ic->ic_dim);
-							ic->ic_dim = NULL;
-						}
-						binop_before = 0;
-						QueIns(ic, ccmp->code_ctrl->ir_code);
-						if (ccmp->lex->cur_tok != ')')
-							ParseErr(ccmp, "Expected a ')'.");
-						Lex(ccmp->lex);
-						POST_XXX_CHECK;
-						//  ________       ______
-						// /        \     | READ \
+            //
+            // See ghost ahead
+            //
+            ic2 = ccmp->code_ctrl->ir_code->next;
+            //
+            ic = A_CALLOC(sizeof(CRPN), NULL);
+            ic->type = IC_TYPECAST;
+            ic->ic_dim = A_CALLOC(sizeof(CArrayDim), NULL);
+            ic->ic_dim->total_cnt =
+                INT_MIN; // If still negative,we didint get a dim
+            ic->ic_dim->cnt = 1;
+            Lex(ccmp->lex);
+            ic->ic_class =
+                PrsType(ccmp, tc_class, NULL, &ic->ic_fun, ic->ic_dim);
+            if (!ic->ic_dim->next) {
+              A_FREE(ic->ic_dim);
+              ic->ic_dim = NULL;
+            }
+            binop_before = 0;
+            QueIns(ic, ccmp->code_ctrl->ir_code);
+            if (ccmp->lex->cur_tok != ')')
+              ParseErr(ccmp, "Expected a ')'.");
+            Lex(ccmp->lex);
+            POST_XXX_CHECK;
+            //  ________       ______
+            // /        \     | READ \
             // | (*)_(*)|     |  ME  |
-						// |  \___/ | <===_______/
-						// |        |
-						// \/\/\/\/\/
-						// if we have function,make an implicit function call and typecast
-						// the result
-						if (ic2->type == IC_GLOBAL) {
-							// If IC_ADDR_OF comes before,dont do an implicit call
-							if (ic_stk[stk_ptr - 1] == IC_ADDR_OF) {
-								// Do nothing
-								if (ic2->global_var->base.type & HTF_EXTERN)
-									ParseErr(ccmp, "Can't address of extern symbol");
-							} else if (ic2->global_var->base.type & HTT_FUN) {
-								ic = A_CALLOC(sizeof(CRPN), NULL);
-								ic->type = IC_CALL;
-								QueIns(ic, ic2->base.last);
-							}
-						}
-						goto next;
-					} else
-						goto is_func_call;
-				} else {
-					// Is func
-				is_func_call:
-					ic = A_CALLOC(sizeof(CRPN), NULL);
-					ic->type = IC_CALL;
-					for (arg = 0;;) {
-						ic2 = ccmp->code_ctrl->ir_code->next;
-						ParseExpr(ccmp, PEF_NO_COMMA);
-						if (ic2 != ccmp->code_ctrl->ir_code->next)
-							arg++;
-						if (ccmp->lex->cur_tok == ')') {
-							Lex(ccmp->lex);
-							break;
-						}
-						if (ic2 == ccmp->code_ctrl->ir_code->next) {
-							// Found no argument so make a IC_NOP
-							ic2 = A_CALLOC(sizeof(CRPN), NULL);
-							ic2->type = IC_NOP;
-							QueIns(ic2, ccmp->code_ctrl->ir_code);
-							arg++;
-						}
-						if (ccmp->lex->cur_tok == ',') {
-							Lex(ccmp->lex);
-						} else
-							ParseErr(ccmp, "Expected a ')'.");
-					}
-					ic->length = arg;
-					QueIns(ic, ccmp->code_ctrl->ir_code);
-					AssignRawTypeToNode(ccmp, ic);
-					goto next;
-				}
-			}
-			prec = -1;
-			type = IC_PAREN;
-			binop_before = 1; // We consume the next thing like a binop
-			break;
-		case ')':
-			binop_before = 0;
-			for (idx = 0; idx != stk_ptr; idx++) {
-				if (ic_stk[idx] == IC_PAREN) {
-					Lex(ccmp->lex);
-					while (ic_stk[--stk_ptr] != IC_PAREN) {
-						ic = A_CALLOC(sizeof(CRPN), NULL);
-						ic->type = ic_stk[stk_ptr];
-						QueIns(ic, ccmp->code_ctrl->ir_code);
-						AssignRawTypeToNode(ccmp, ic);
-						if (ic->type == IC_PRE_DEC || ic->type == IC_PRE_INC)
-							SetIncAmt(ccmp, ic);
-					}
-					POST_XXX_CHECK;
-					goto next;
-				}
-			}
-			goto fin;
-			break;
-		case '[':
-			prec = -1;
-			type = IC_ARRAY_ACC;
-			Lex(ccmp->lex);
-			binop_before = 1; // Acts like a binop as it consumes the right side
-			break;
-		case ']':
-			binop_before = 0;
-			for (idx = 0; idx != stk_ptr; idx++) {
-				if (ic_stk[idx] == IC_ARRAY_ACC) {
-					Lex(ccmp->lex);
-					while (ic_stk[--stk_ptr] != IC_ARRAY_ACC) {
-						ic = A_CALLOC(sizeof(CRPN), NULL);
-						ic->type = ic_stk[stk_ptr];
-						QueIns(ic, ccmp->code_ctrl->ir_code);
-						AssignRawTypeToNode(ccmp, ic);
-						if (ic->type == IC_PRE_DEC || ic->type == IC_PRE_INC)
-							SetIncAmt(ccmp, ic);
-					}
-					ic = A_CALLOC(sizeof(CRPN), NULL);
-					ic->type = IC_ARRAY_ACC;
-					QueIns(ic, ccmp->code_ctrl->ir_code);
-					AssignRawTypeToNode(ccmp, ic);
-					POST_XXX_CHECK;
-					goto next;
-				}
-			}
-			goto fin;
-			break;
-		case TK_I64:
-			binop_before = 0;
-			prec = -2;
-			type = IC_I64;
-			ic = A_CALLOC(sizeof(CRPN), NULL);
-			ic->type = type;
-			QueInit(&ic->base);
-			ic->integer = ccmp->lex->integer;
-			QueIns(ic, ccmp->code_ctrl->ir_code);
-			Lex(ccmp->lex);
-			goto next;
-			break;
-		case TK_F64:
-			binop_before = 0;
-			prec = -2;
-			type = IC_F64;
-			ic = A_CALLOC(sizeof(CRPN), NULL);
-			ic->type = type;
-			QueInit(&ic->base);
-			ic->flt = ccmp->lex->flt;
-			QueIns(ic, ccmp->code_ctrl->ir_code);
-			Lex(ccmp->lex);
-			goto next;
-			break;
-		case TK_NAME:
-			if (PrsKw(ccmp, TK_KW_SIZEOF))
-				goto szo;
-			if (PrsKw(ccmp, TK_KW_OFFSET))
-				goto offo;
-			binop_before = 0;
-			ic = A_CALLOC(sizeof(CRPN), NULL);
-			QueInit(&ic->base);
-			if (ccmp->cur_fun) {
-				if (local = MemberFind(ccmp->lex->string, ccmp->cur_fun)) {
-					ic->type = IC_LOCAL;
-					ic->local_mem = local;
-					goto name_pass;
-				}
-			}
-			if (global_var = HashFind(ccmp->lex->string, Fs->hash_table, HTT_GLBL_VAR, 1)) {
-				ic->type = IC_GLOBAL;
-				ic->global_var = global_var;
-				goto name_pass;
-			} else if (global_var = HashFind(ccmp->lex->string, Fs->hash_table, HTT_FUN, 1)) {
-				if (((CRPN*)ccmp->code_ctrl->ir_code->next)->type == IC_ADDR_OF) {
-					ic->type = IC_GLOBAL;
-					ic->global_var = global_var;
-					goto name_pass;
-				} else {
-					Lex(ccmp->lex);
-					ic->type = IC_GLOBAL;
-					ic->global_var = global_var;
-					if (ccmp->lex->cur_tok != '(') {
-						// If IC_ADDR_OF comes before,dont do an implicit call
-						if (stk_ptr && ic_stk[stk_ptr - 1] == IC_ADDR_OF) {
-							// Do nothing
-							if (ic->global_var->base.type & HTF_EXTERN)
-								ParseWarn(ccmp, "Can't address of extern symbol");
-						} else if (ic->global_var->base.type & HTT_FUN) {
-							QueIns(ic, ccmp->code_ctrl->ir_code);
-							ic2 = ic;
-							ic = A_CALLOC(sizeof(CRPN), NULL);
-							ic->type = IC_CALL;
-							QueIns(ic, ic2->base.last);
-							goto next;
-						}
-					}
-					QueIns(ic, ccmp->code_ctrl->ir_code);
-					goto next;
-				}
-			} else {
-				A_FREE(ic);
-				ParseErr(ccmp, "Unknown symbol '%s'.", ccmp->lex->string);
-				return 0;
-			}
-		name_pass:
-			Lex(ccmp->lex);
-			QueIns(ic, ccmp->code_ctrl->ir_code);
-			POST_XXX_CHECK;
-			goto next;
-			break;
-		case TK_STR:
-			binop_before = 0;
-			string = PrsString(ccmp, &str_len);
-			ic = A_CALLOC(sizeof(CRPN), NULL);
-			QueInit(&ic->base);
-			ic->type = IC_STR;
-			for (misc = ccmp->code_ctrl->code_misc->next;
-				 ccmp->code_ctrl->code_misc != misc; misc = misc->base.next) {
-				if (misc->type == CMT_STRING)
-					if (misc->str_len == ccmp->lex->str_len)
-						if (0 == memcmp(misc->str, string, str_len)) {
-							ic->code_misc = misc;
-							goto found_str;
-						}
-			}
-			misc = CodeMiscNew(ccmp, CMT_STRING);
-			misc->str_len = str_len;
-			misc->str = string;
-			ic->code_misc = misc;
-		found_str:
-			QueIns(ic, ccmp->code_ctrl->ir_code);
-			goto next;
-			break;
-		case TK_CHR:
-			binop_before = 0;
-			ic = A_CALLOC(sizeof(CRPN), NULL);
-			QueInit(&ic->base);
-			ic->type = IC_CHR;
-			ic->integer = ccmp->lex->integer;
-			QueIns(ic, ccmp->code_ctrl->ir_code);
-			Lex(ccmp->lex);
-			goto next;
-			break;
-		case TK_ERR: // TODO
-			return 0;
-			break;
-		case TK_INC_INC:
-			Lex(ccmp->lex);
-			binop_before = 1; // Consumes next arg like a binop
-			type = IC_PRE_INC;
-			prec = 0;
-			break;
-		case TK_DEC_DEC:
-			Lex(ccmp->lex);
-			binop_before = 1; // Consumes next arg like a binop
-			type = IC_PRE_DEC;
-			prec = 0;
-			break;
-		case TK_AND_AND:
-			Lex(ccmp->lex);
-			prec = 9;
-			binop_before = 1;
-			type = IC_AND_AND;
-			break;
-		case TK_XOR_XOR:
-			Lex(ccmp->lex);
-			prec = 10;
-			binop_before = 1;
-			type = IC_XOR_XOR;
-			break;
-		case TK_OR_OR:
-			Lex(ccmp->lex);
-			prec = 11;
-			binop_before = 1;
-			type = IC_OR_OR;
-			break;
-		case TK_EQ_EQ:
-			Lex(ccmp->lex);
-			prec = 8;
-			binop_before = 1;
-			type = IC_EQ_EQ;
-			break;
-		case TK_NE:
-			Lex(ccmp->lex);
-			prec = 8;
-			binop_before = 1;
-			type = IC_NE;
-			break;
-		case TK_LE:
-			Lex(ccmp->lex);
-			prec = 7;
-			binop_before = 1;
-			type = IC_LE;
-			break;
-		case TK_GE:
-			Lex(ccmp->lex);
-			prec = 7;
-			binop_before = 1;
-			type = IC_GE;
-			break;
-		case TK_LSH:
-			Lex(ccmp->lex);
-			prec = 1;
-			binop_before = 1;
-			type = IC_LSH;
-			break;
-		case TK_RSH:
-			Lex(ccmp->lex);
-			prec = 1;
-			binop_before = 1;
-			type = IC_RSH;
-			break;
-		case TK_ADD_EQ:
-			Lex(ccmp->lex);
-			prec = 12;
-			binop_before = 1;
-			type = IC_ADD_EQ;
-			break;
-		case TK_SUB_EQ:
-			Lex(ccmp->lex);
-			prec = 12;
-			binop_before = 1;
-			type = IC_SUB_EQ;
-			break;
-		case TK_MUL_EQ:
-			Lex(ccmp->lex);
-			prec = 12;
-			binop_before = 1;
-			type = IC_MUL_EQ;
-			break;
-		case TK_DIV_EQ:
-			Lex(ccmp->lex);
-			prec = 12;
-			binop_before = 1;
-			type = IC_DIV_EQ;
-			break;
-		case TK_LSH_EQ:
-			Lex(ccmp->lex);
-			prec = 12;
-			binop_before = 1;
-			type = IC_LSH_EQ;
-			break;
-		case TK_RSH_EQ:
-			Lex(ccmp->lex);
-			prec = 12;
-			binop_before = 1;
-			type = IC_RSH_EQ;
-			break;
-		case TK_AND_EQ:
-			Lex(ccmp->lex);
-			prec = 12;
-			binop_before = 1;
-			type = IC_AND_EQ;
-			break;
-		case TK_OR_EQ:
-			Lex(ccmp->lex);
-			prec = 12;
-			binop_before = 1;
-			type = IC_OR_EQ;
-			break;
-		case TK_XOR_EQ:
-			Lex(ccmp->lex);
-			prec = 12;
-			binop_before = 1;
-			type = IC_XOR_EQ;
-			break;
-		case ',':
-			if (flags & PEF_NO_COMMA)
-				goto fin;
-			Lex(ccmp->lex);
-			prec = 13;
-			binop_before = 1;
-			type = IC_COMMA;
-			break;
-		case TK_ARROW:
-			Lex(ccmp->lex);
-			AssignRawTypeToNode(ccmp, ic2 = ccmp->code_ctrl->ir_code->next);
-			if (ccmp->lex->cur_tok != TK_NAME)
-				ParseErr(ccmp, "Expected a name.");
-			if (!ic2->ic_class->ptr_star_cnt)
-				ParseErr(ccmp, "Can't get member of non-pointer/array.");
-			if (!MemberFind(ccmp->lex->string, ic2->ic_class - 1))
-				ParseErr(ccmp, "Class '%s' is missing member '%s'\n",
-					ic2->ic_class[-1].base.str, ccmp->lex->string);
-			ic = A_CALLOC(sizeof(CRPN), NULL);
-			ic->type = IC_ARROW;
-			ic->local_mem = MemberFind(ccmp->lex->string, ic2->ic_class - 1);
-			QueIns(ic, ccmp->code_ctrl->ir_code);
-			ic->ic_fun = ic->local_mem->fun_ptr;
-			Lex(ccmp->lex);
-			binop_before = 0;
-			POST_XXX_CHECK;
-			goto next;
-			break;
-		case '.':
-			Lex(ccmp->lex);
-			AssignRawTypeToNode(ccmp, ic2 = ccmp->code_ctrl->ir_code->next);
-			if (ccmp->lex->cur_tok != TK_NAME)
-				ParseErr(ccmp, "Expected a name.");
-			if (!MemberFind(ccmp->lex->string, ic2->ic_class))
-				ParseErr(ccmp, "Class '%s' is missing member '%s'\n",
-					ic2->ic_class->base.str, ccmp->lex->string);
-			ic = A_CALLOC(sizeof(CRPN), NULL);
-			ic->type = IC_DOT;
-			ic->local_mem = MemberFind(ccmp->lex->string, ic2->ic_class);
-			QueIns(ic, ccmp->code_ctrl->ir_code);
-			Lex(ccmp->lex);
-			binop_before = 0;
-			POST_XXX_CHECK;
-			goto next;
-			break;
-		case TK_MOD_EQ:
-			Lex(ccmp->lex);
-			prec = 12;
-			binop_before = 1;
-			type = IC_MOD_EQ;
-			break;
-		default:
-			goto fin;
-		}
-		if (type == IC_PAREN || type == IC_ARRAY_ACC) {
-			prec_stk[stk_ptr] = prec;
-			ic_stk[stk_ptr++] = type;
-		} else {
-			for (; stk_ptr;) {
-				if (ic_stk[stk_ptr - 1] == IC_PAREN || ic_stk[stk_ptr - 1] == IC_ARRAY_ACC)
-					goto fail;
-				if (prec_stk[stk_ptr - 1] < prec)
-					goto pass;
-				if (prec_stk[stk_ptr - 1] <= prec && !IsRightAssoc(ic_stk[stk_ptr - 1]))
-					goto pass;
-				goto fail;
-			pass:
-				ic = A_CALLOC(sizeof(CRPN), NULL);
-				ic->type = ic_stk[stk_ptr - 1];
-				QueIns(ic, ccmp->code_ctrl->ir_code);
-				AssignRawTypeToNode(ccmp, ic);
-				if (ic->type == IC_PRE_DEC || ic->type == IC_PRE_INC)
-					SetIncAmt(ccmp, ic);
-				stk_ptr--;
-			}
-		fail:
-			prec_stk[stk_ptr] = prec;
-			ic_stk[stk_ptr++] = type;
-		}
-	}
+            // |  \___/ | <===_______/
+            // |        |
+            // \/\/\/\/\/
+            // if we have function,make an implicit function call and typecast
+            // the result
+            if (ic2->type == IC_GLOBAL) {
+              // If IC_ADDR_OF comes before,dont do an implicit call
+              if (ic_stk[stk_ptr - 1] == IC_ADDR_OF) {
+                // Do nothing
+                if (ic2->global_var->base.type & HTF_EXTERN)
+                  ParseErr(ccmp, "Can't address of extern symbol");
+              } else if (ic2->global_var->base.type & HTT_FUN) {
+                ic = A_CALLOC(sizeof(CRPN), NULL);
+                ic->type = IC_CALL;
+                QueIns(ic, ic2->base.last);
+              }
+            }
+            goto next;
+          } else
+            goto is_func_call;
+        } else {
+          // Is func
+        is_func_call:
+          ic = A_CALLOC(sizeof(CRPN), NULL);
+          ic->type = IC_CALL;
+          for (arg = 0;;) {
+            ic2 = ccmp->code_ctrl->ir_code->next;
+            ParseExpr(ccmp, PEF_NO_COMMA);
+            if (ic2 != ccmp->code_ctrl->ir_code->next)
+              arg++;
+            if (ccmp->lex->cur_tok == ')') {
+              Lex(ccmp->lex);
+              break;
+            }
+            if (ic2 == ccmp->code_ctrl->ir_code->next) {
+              // Found no argument so make a IC_NOP
+              ic2 = A_CALLOC(sizeof(CRPN), NULL);
+              ic2->type = IC_NOP;
+              QueIns(ic2, ccmp->code_ctrl->ir_code);
+              arg++;
+            }
+            if (ccmp->lex->cur_tok == ',') {
+              Lex(ccmp->lex);
+            } else
+              ParseErr(ccmp, "Expected a ')'.");
+          }
+          ic->length = arg;
+          QueIns(ic, ccmp->code_ctrl->ir_code);
+          AssignRawTypeToNode(ccmp, ic);
+          goto next;
+        }
+      }
+      prec = -1;
+      type = IC_PAREN;
+      binop_before = 1; // We consume the next thing like a binop
+      break;
+    case ')':
+      binop_before = 0;
+      for (idx = 0; idx != stk_ptr; idx++) {
+        if (ic_stk[idx] == IC_PAREN) {
+          Lex(ccmp->lex);
+          while (ic_stk[--stk_ptr] != IC_PAREN) {
+            ic = A_CALLOC(sizeof(CRPN), NULL);
+            ic->type = ic_stk[stk_ptr];
+            QueIns(ic, ccmp->code_ctrl->ir_code);
+            AssignRawTypeToNode(ccmp, ic);
+            if (ic->type == IC_PRE_DEC || ic->type == IC_PRE_INC)
+              SetIncAmt(ccmp, ic);
+          }
+          POST_XXX_CHECK;
+          goto next;
+        }
+      }
+      goto fin;
+      break;
+    case '[':
+      prec = -1;
+      type = IC_ARRAY_ACC;
+      Lex(ccmp->lex);
+      binop_before = 1; // Acts like a binop as it consumes the right side
+      break;
+    case ']':
+      binop_before = 0;
+      for (idx = 0; idx != stk_ptr; idx++) {
+        if (ic_stk[idx] == IC_ARRAY_ACC) {
+          Lex(ccmp->lex);
+          while (ic_stk[--stk_ptr] != IC_ARRAY_ACC) {
+            ic = A_CALLOC(sizeof(CRPN), NULL);
+            ic->type = ic_stk[stk_ptr];
+            QueIns(ic, ccmp->code_ctrl->ir_code);
+            AssignRawTypeToNode(ccmp, ic);
+            if (ic->type == IC_PRE_DEC || ic->type == IC_PRE_INC)
+              SetIncAmt(ccmp, ic);
+          }
+          ic = A_CALLOC(sizeof(CRPN), NULL);
+          ic->type = IC_ARRAY_ACC;
+          QueIns(ic, ccmp->code_ctrl->ir_code);
+          AssignRawTypeToNode(ccmp, ic);
+          POST_XXX_CHECK;
+          goto next;
+        }
+      }
+      goto fin;
+      break;
+    case TK_I64:
+      binop_before = 0;
+      prec = -2;
+      type = IC_I64;
+      ic = A_CALLOC(sizeof(CRPN), NULL);
+      ic->type = type;
+      QueInit(&ic->base);
+      ic->integer = ccmp->lex->integer;
+      QueIns(ic, ccmp->code_ctrl->ir_code);
+      Lex(ccmp->lex);
+      goto next;
+      break;
+    case TK_F64:
+      binop_before = 0;
+      prec = -2;
+      type = IC_F64;
+      ic = A_CALLOC(sizeof(CRPN), NULL);
+      ic->type = type;
+      QueInit(&ic->base);
+      ic->flt = ccmp->lex->flt;
+      QueIns(ic, ccmp->code_ctrl->ir_code);
+      Lex(ccmp->lex);
+      goto next;
+      break;
+    case TK_NAME:
+      if (PrsKw(ccmp, TK_KW_SIZEOF))
+        goto szo;
+      if (PrsKw(ccmp, TK_KW_OFFSET))
+        goto offo;
+      binop_before = 0;
+      ic = A_CALLOC(sizeof(CRPN), NULL);
+      QueInit(&ic->base);
+      if (ccmp->cur_fun) {
+        if (local = MemberFind(ccmp->lex->string, ccmp->cur_fun)) {
+          ic->type = IC_LOCAL;
+          ic->local_mem = local;
+          goto name_pass;
+        }
+      }
+      if (global_var =
+              HashFind(ccmp->lex->string, Fs->hash_table, HTT_GLBL_VAR, 1)) {
+        ic->type = IC_GLOBAL;
+        ic->global_var = global_var;
+        goto name_pass;
+      } else if (global_var =
+                     HashFind(ccmp->lex->string, Fs->hash_table, HTT_FUN, 1)) {
+        if (((CRPN *)ccmp->code_ctrl->ir_code->next)->type == IC_ADDR_OF) {
+          ic->type = IC_GLOBAL;
+          ic->global_var = global_var;
+          goto name_pass;
+        } else {
+          Lex(ccmp->lex);
+          ic->type = IC_GLOBAL;
+          ic->global_var = global_var;
+          if (ccmp->lex->cur_tok != '(') {
+            // If IC_ADDR_OF comes before,dont do an implicit call
+            if (stk_ptr && ic_stk[stk_ptr - 1] == IC_ADDR_OF) {
+              // Do nothing
+              if (ic->global_var->base.type & HTF_EXTERN)
+                ParseWarn(ccmp, "Can't address of extern symbol");
+            } else if (ic->global_var->base.type & HTT_FUN) {
+              QueIns(ic, ccmp->code_ctrl->ir_code);
+              ic2 = ic;
+              ic = A_CALLOC(sizeof(CRPN), NULL);
+              ic->type = IC_CALL;
+              QueIns(ic, ic2->base.last);
+              goto next;
+            }
+          }
+          QueIns(ic, ccmp->code_ctrl->ir_code);
+          goto next;
+        }
+      } else {
+        A_FREE(ic);
+        ParseErr(ccmp, "Unknown symbol '%s'.", ccmp->lex->string);
+        return 0;
+      }
+    name_pass:
+      Lex(ccmp->lex);
+      QueIns(ic, ccmp->code_ctrl->ir_code);
+      POST_XXX_CHECK;
+      goto next;
+      break;
+    case TK_STR:
+      binop_before = 0;
+      string = PrsString(ccmp, &str_len);
+      ic = A_CALLOC(sizeof(CRPN), NULL);
+      QueInit(&ic->base);
+      ic->type = IC_STR;
+      for (misc = ccmp->code_ctrl->code_misc->next;
+           ccmp->code_ctrl->code_misc != misc; misc = misc->base.next) {
+        if (misc->type == CMT_STRING)
+          if (misc->str_len == ccmp->lex->str_len)
+            if (0 == memcmp(misc->str, string, str_len)) {
+              ic->code_misc = misc;
+              goto found_str;
+            }
+      }
+      misc = CodeMiscNew(ccmp, CMT_STRING);
+      misc->str_len = str_len;
+      misc->str = string;
+      ic->code_misc = misc;
+    found_str:
+      QueIns(ic, ccmp->code_ctrl->ir_code);
+      goto next;
+      break;
+    case TK_CHR:
+      binop_before = 0;
+      ic = A_CALLOC(sizeof(CRPN), NULL);
+      QueInit(&ic->base);
+      ic->type = IC_CHR;
+      ic->integer = ccmp->lex->integer;
+      QueIns(ic, ccmp->code_ctrl->ir_code);
+      Lex(ccmp->lex);
+      goto next;
+      break;
+    case TK_ERR: // TODO
+      return 0;
+      break;
+    case TK_INC_INC:
+      Lex(ccmp->lex);
+      binop_before = 1; // Consumes next arg like a binop
+      type = IC_PRE_INC;
+      prec = 0;
+      break;
+    case TK_DEC_DEC:
+      Lex(ccmp->lex);
+      binop_before = 1; // Consumes next arg like a binop
+      type = IC_PRE_DEC;
+      prec = 0;
+      break;
+    case TK_AND_AND:
+      Lex(ccmp->lex);
+      prec = 9;
+      binop_before = 1;
+      type = IC_AND_AND;
+      break;
+    case TK_XOR_XOR:
+      Lex(ccmp->lex);
+      prec = 10;
+      binop_before = 1;
+      type = IC_XOR_XOR;
+      break;
+    case TK_OR_OR:
+      Lex(ccmp->lex);
+      prec = 11;
+      binop_before = 1;
+      type = IC_OR_OR;
+      break;
+    case TK_EQ_EQ:
+      Lex(ccmp->lex);
+      prec = 8;
+      binop_before = 1;
+      type = IC_EQ_EQ;
+      break;
+    case TK_NE:
+      Lex(ccmp->lex);
+      prec = 8;
+      binop_before = 1;
+      type = IC_NE;
+      break;
+    case TK_LE:
+      Lex(ccmp->lex);
+      prec = 7;
+      binop_before = 1;
+      type = IC_LE;
+      break;
+    case TK_GE:
+      Lex(ccmp->lex);
+      prec = 7;
+      binop_before = 1;
+      type = IC_GE;
+      break;
+    case TK_LSH:
+      Lex(ccmp->lex);
+      prec = 1;
+      binop_before = 1;
+      type = IC_LSH;
+      break;
+    case TK_RSH:
+      Lex(ccmp->lex);
+      prec = 1;
+      binop_before = 1;
+      type = IC_RSH;
+      break;
+    case TK_ADD_EQ:
+      Lex(ccmp->lex);
+      prec = 12;
+      binop_before = 1;
+      type = IC_ADD_EQ;
+      break;
+    case TK_SUB_EQ:
+      Lex(ccmp->lex);
+      prec = 12;
+      binop_before = 1;
+      type = IC_SUB_EQ;
+      break;
+    case TK_MUL_EQ:
+      Lex(ccmp->lex);
+      prec = 12;
+      binop_before = 1;
+      type = IC_MUL_EQ;
+      break;
+    case TK_DIV_EQ:
+      Lex(ccmp->lex);
+      prec = 12;
+      binop_before = 1;
+      type = IC_DIV_EQ;
+      break;
+    case TK_LSH_EQ:
+      Lex(ccmp->lex);
+      prec = 12;
+      binop_before = 1;
+      type = IC_LSH_EQ;
+      break;
+    case TK_RSH_EQ:
+      Lex(ccmp->lex);
+      prec = 12;
+      binop_before = 1;
+      type = IC_RSH_EQ;
+      break;
+    case TK_AND_EQ:
+      Lex(ccmp->lex);
+      prec = 12;
+      binop_before = 1;
+      type = IC_AND_EQ;
+      break;
+    case TK_OR_EQ:
+      Lex(ccmp->lex);
+      prec = 12;
+      binop_before = 1;
+      type = IC_OR_EQ;
+      break;
+    case TK_XOR_EQ:
+      Lex(ccmp->lex);
+      prec = 12;
+      binop_before = 1;
+      type = IC_XOR_EQ;
+      break;
+    case ',':
+      if (flags & PEF_NO_COMMA)
+        goto fin;
+      Lex(ccmp->lex);
+      prec = 13;
+      binop_before = 1;
+      type = IC_COMMA;
+      break;
+    case TK_ARROW:
+      Lex(ccmp->lex);
+      AssignRawTypeToNode(ccmp, ic2 = ccmp->code_ctrl->ir_code->next);
+      if (ccmp->lex->cur_tok != TK_NAME)
+        ParseErr(ccmp, "Expected a name.");
+      if (!ic2->ic_class->ptr_star_cnt)
+        ParseErr(ccmp, "Can't get member of non-pointer/array.");
+      if (!MemberFind(ccmp->lex->string, ic2->ic_class - 1))
+        ParseErr(ccmp, "Class '%s' is missing member '%s'\n",
+                 ic2->ic_class[-1].base.str, ccmp->lex->string);
+      ic = A_CALLOC(sizeof(CRPN), NULL);
+      ic->type = IC_ARROW;
+      ic->local_mem = MemberFind(ccmp->lex->string, ic2->ic_class - 1);
+      QueIns(ic, ccmp->code_ctrl->ir_code);
+      ic->ic_fun = ic->local_mem->fun_ptr;
+      Lex(ccmp->lex);
+      binop_before = 0;
+      POST_XXX_CHECK;
+      goto next;
+      break;
+    case '.':
+      Lex(ccmp->lex);
+      AssignRawTypeToNode(ccmp, ic2 = ccmp->code_ctrl->ir_code->next);
+      if (ccmp->lex->cur_tok != TK_NAME)
+        ParseErr(ccmp, "Expected a name.");
+      if (!MemberFind(ccmp->lex->string, ic2->ic_class))
+        ParseErr(ccmp, "Class '%s' is missing member '%s'\n",
+                 ic2->ic_class->base.str, ccmp->lex->string);
+      ic = A_CALLOC(sizeof(CRPN), NULL);
+      ic->type = IC_DOT;
+      ic->local_mem = MemberFind(ccmp->lex->string, ic2->ic_class);
+      QueIns(ic, ccmp->code_ctrl->ir_code);
+      Lex(ccmp->lex);
+      binop_before = 0;
+      POST_XXX_CHECK;
+      goto next;
+      break;
+    case TK_MOD_EQ:
+      Lex(ccmp->lex);
+      prec = 12;
+      binop_before = 1;
+      type = IC_MOD_EQ;
+      break;
+    default:
+      goto fin;
+    }
+    if (type == IC_PAREN || type == IC_ARRAY_ACC) {
+      prec_stk[stk_ptr] = prec;
+      ic_stk[stk_ptr++] = type;
+    } else {
+      for (; stk_ptr;) {
+        if (ic_stk[stk_ptr - 1] == IC_PAREN ||
+            ic_stk[stk_ptr - 1] == IC_ARRAY_ACC)
+          goto fail;
+        if (prec_stk[stk_ptr - 1] < prec)
+          goto pass;
+        if (prec_stk[stk_ptr - 1] <= prec && !IsRightAssoc(ic_stk[stk_ptr - 1]))
+          goto pass;
+        goto fail;
+      pass:
+        ic = A_CALLOC(sizeof(CRPN), NULL);
+        ic->type = ic_stk[stk_ptr - 1];
+        QueIns(ic, ccmp->code_ctrl->ir_code);
+        AssignRawTypeToNode(ccmp, ic);
+        if (ic->type == IC_PRE_DEC || ic->type == IC_PRE_INC)
+          SetIncAmt(ccmp, ic);
+        stk_ptr--;
+      }
+    fail:
+      prec_stk[stk_ptr] = prec;
+      ic_stk[stk_ptr++] = type;
+    }
+  }
 fin:
-	while (stk_ptr) {
-		ic = A_CALLOC(sizeof(CRPN), NULL);
-		ic->type = ic_stk[stk_ptr - 1];
-		QueIns(ic, ccmp->code_ctrl->ir_code);
-		AssignRawTypeToNode(ccmp, ic);
-		if (ic->type == IC_PRE_DEC || ic->type == IC_PRE_INC)
-			SetIncAmt(ccmp, ic);
-		stk_ptr--;
-	}
-	return orig != ccmp->code_ctrl->ir_code->next;
+  while (stk_ptr) {
+    ic = A_CALLOC(sizeof(CRPN), NULL);
+    ic->type = ic_stk[stk_ptr - 1];
+    QueIns(ic, ccmp->code_ctrl->ir_code);
+    AssignRawTypeToNode(ccmp, ic);
+    if (ic->type == IC_PRE_DEC || ic->type == IC_PRE_INC)
+      SetIncAmt(ccmp, ic);
+    stk_ptr--;
+  }
+  return orig != ccmp->code_ctrl->ir_code->next;
 }
 
-int64_t ParseWarn(CCmpCtrl* ctrl, char* fmt, ...)
-{
-	va_list lst;
-	va_start(lst, fmt);
-	char buf[STR_LEN];
-	vsprintf(buf, fmt, lst);
-	va_end(lst);
-	fprintf(AIWNIOS_OSTREAM, "WARN:%s:%d:%d %s\n", ctrl->lex->file->filename,
-		ctrl->lex->file->ln + 1, ctrl->lex->file->col + 1, buf);
+int64_t ParseWarn(CCmpCtrl *ctrl, char *fmt, ...) {
+  va_list lst;
+  va_start(lst, fmt);
+  char buf[STR_LEN];
+  vsprintf(buf, fmt, lst);
+  va_end(lst);
+  fprintf(AIWNIOS_OSTREAM, "WARN:%s:%d:%d %s\n", ctrl->lex->file->filename,
+          ctrl->lex->file->ln + 1, ctrl->lex->file->col + 1, buf);
 }
 
-int64_t ParseErr(CCmpCtrl* ctrl, char* fmt, ...)
-{
-	va_list lst;
-	va_start(lst, fmt);
-	char buf[STR_LEN];
-	vsprintf(buf, fmt, lst);
-	va_end(lst);
-	fprintf(AIWNIOS_OSTREAM, "ERR:%s:%d:%d %s\n", ctrl->lex->file->filename,
-		ctrl->lex->file->ln + 1, ctrl->lex->file->col + 1, buf);
-	throw(*(int64_t*)"Prs\0\0\0\0\0");
+int64_t ParseErr(CCmpCtrl *ctrl, char *fmt, ...) {
+  va_list lst;
+  va_start(lst, fmt);
+  char buf[STR_LEN];
+  vsprintf(buf, fmt, lst);
+  va_end(lst);
+  fprintf(AIWNIOS_OSTREAM, "ERR:%s:%d:%d %s\n", ctrl->lex->file->filename,
+          ctrl->lex->file->ln + 1, ctrl->lex->file->col + 1, buf);
+  throw(*(int64_t *)"Prs\0\0\0\0\0");
 }
 
-int64_t PrsKw(CCmpCtrl* ccmp, int64_t kwt)
-{
-	CHashKeyword* kw;
-	if (ccmp->lex->cur_tok == TK_NAME)
-		if (kw = HashFind(ccmp->lex->string, Fs->hash_table, HTT_KEYWORD, 1))
-			if (kw->tk == kwt) {
-				Lex(ccmp->lex);
-				return 1;
-			}
-	return 0;
+int64_t PrsKw(CCmpCtrl *ccmp, int64_t kwt) {
+  CHashKeyword *kw;
+  if (ccmp->lex->cur_tok == TK_NAME)
+    if (kw = HashFind(ccmp->lex->string, Fs->hash_table, HTT_KEYWORD, 1))
+      if (kw->tk == kwt) {
+        Lex(ccmp->lex);
+        return 1;
+      }
+  return 0;
 }
-static int64_t PeekKw(CCmpCtrl* ccmp, int64_t kwt)
-{
-	CHashKeyword* kw;
-	if (ccmp->lex->cur_tok == TK_NAME)
-		if (kw = HashFind(ccmp->lex->string, Fs->hash_table, HTT_KEYWORD, 1))
-			if (kw->tk == kwt) {
-				return 1;
-			}
-	return 0;
+static int64_t PeekKw(CCmpCtrl *ccmp, int64_t kwt) {
+  CHashKeyword *kw;
+  if (ccmp->lex->cur_tok == TK_NAME)
+    if (kw = HashFind(ccmp->lex->string, Fs->hash_table, HTT_KEYWORD, 1))
+      if (kw->tk == kwt) {
+        return 1;
+      }
+  return 0;
 }
 
-int64_t PrsGoto(CCmpCtrl* ccmp)
-{
-	CRPN* rpn;
-	CCodeMisc* misc;
-	if (PrsKw(ccmp, TK_KW_GOTO)) {
-		if (ccmp->lex->cur_tok != TK_NAME) {
-			ParseErr(ccmp, "Expected a name.");
-			return 0;
-		}
-		rpn = A_CALLOC(sizeof(CRPN), NULL);
-		rpn->type = IC_GOTO;
-		for (misc = ccmp->code_ctrl->code_misc->next;
-			 misc != ccmp->code_ctrl->code_misc; misc = misc->base.next) {
-			if (misc->type == CMT_LABEL)
-				if (misc->str)
-					if (!strcmp(misc->str, ccmp->lex->string)) {
-						rpn->code_misc = misc;
-						goto found;
-					}
-		}
-		rpn->code_misc = CodeMiscNew(ccmp, CMT_LABEL);
-		rpn->code_misc->str = A_CALLOC(ccmp->lex->str_len + 1, NULL);
-		memcpy(rpn->code_misc->str, ccmp->lex->string, ccmp->lex->str_len + 1);
-	found:
-		QueIns(rpn, ccmp->code_ctrl->ir_code);
-		Lex(ccmp->lex);
-		if (ccmp->lex->cur_tok != ';') {
-			ParseErr(ccmp, "Expected a ';'.");
-			return 0;
-		}
-		Lex(ccmp->lex);
-		return 1;
-	}
-	return 0;
+int64_t PrsGoto(CCmpCtrl *ccmp) {
+  CRPN *rpn;
+  CCodeMisc *misc;
+  if (PrsKw(ccmp, TK_KW_GOTO)) {
+    if (ccmp->lex->cur_tok != TK_NAME) {
+      ParseErr(ccmp, "Expected a name.");
+      return 0;
+    }
+    rpn = A_CALLOC(sizeof(CRPN), NULL);
+    rpn->type = IC_GOTO;
+    for (misc = ccmp->code_ctrl->code_misc->next;
+         misc != ccmp->code_ctrl->code_misc; misc = misc->base.next) {
+      if (misc->type == CMT_LABEL)
+        if (misc->str)
+          if (!strcmp(misc->str, ccmp->lex->string)) {
+            rpn->code_misc = misc;
+            goto found;
+          }
+    }
+    rpn->code_misc = CodeMiscNew(ccmp, CMT_LABEL);
+    rpn->code_misc->str = A_CALLOC(ccmp->lex->str_len + 1, NULL);
+    memcpy(rpn->code_misc->str, ccmp->lex->string, ccmp->lex->str_len + 1);
+  found:
+    QueIns(rpn, ccmp->code_ctrl->ir_code);
+    Lex(ccmp->lex);
+    if (ccmp->lex->cur_tok != ';') {
+      ParseErr(ccmp, "Expected a ';'.");
+      return 0;
+    }
+    Lex(ccmp->lex);
+    return 1;
+  }
+  return 0;
 }
-int64_t _PrsStmt(CCmpCtrl* ccmp)
-{
-	CHashClass *cls, *cls2;
-	CRPN* rpn;
-	CCodeMisc* misc;
-	int64_t is_func = 0, flags = 0;
-	int64_t found_label = 0, assign_cnt = 0;
-	char *import_name = NULL, *string;
-	int64_t str_len, argc;
+int64_t _PrsStmt(CCmpCtrl *ccmp) {
+  CHashClass *cls, *cls2;
+  CRPN *rpn;
+  CCodeMisc *misc;
+  int64_t is_func = 0, flags = 0;
+  int64_t found_label = 0, assign_cnt = 0;
+  char *import_name = NULL, *string;
+  int64_t str_len, argc;
 label_loop:
-	// Check for label if not a function,global or local
-	if (ccmp->lex->cur_tok == TK_NAME) {
-		if (ccmp->cur_fun)
-			if (MemberFind(ccmp->lex->string, ccmp->cur_fun))
-				goto not_label;
-		if (HashFind(
-				ccmp->lex->string, Fs->hash_table,
-				HTT_GLBL_VAR | HTT_GLBL_VAR | HTT_CLASS | HTT_KEYWORD | HTT_FUN, 1))
-			goto not_label;
-		rpn = A_CALLOC(sizeof(CRPN), NULL);
-		rpn->type = IC_LABEL;
-		found_label = 1;
-		for (misc = ccmp->code_ctrl->code_misc->next;
-			 misc != ccmp->code_ctrl->code_misc; misc = misc->base.next) {
-			if (misc->type == CMT_LABEL && misc->str)
-				if (!strcmp(misc->str, ccmp->lex->string)) {
-					rpn->code_misc = misc;
-					goto label_fin;
-				}
-		}
-		rpn->code_misc = CodeMiscNew(ccmp, CMT_LABEL);
-		rpn->code_misc->str = A_STRDUP(ccmp->lex->string, NULL);
-	label_fin:
-		if (rpn->code_misc->flags & CMF_DEFINED)
-			ParseErr(ccmp, "Redefinition of label '%s'.", rpn->code_misc->str);
-		rpn->code_misc->flags |= CMF_DEFINED;
-		Lex(ccmp->lex);
-		if (ccmp->lex->cur_tok != ':') {
-			ParseErr(ccmp, "Expected a ':'.");
-			return 0;
-		}
-		Lex(ccmp->lex);
-	}
+  // Check for label if not a function,global or local
+  if (ccmp->lex->cur_tok == TK_NAME) {
+    if (ccmp->cur_fun)
+      if (MemberFind(ccmp->lex->string, ccmp->cur_fun))
+        goto not_label;
+    if (HashFind(
+            ccmp->lex->string, Fs->hash_table,
+            HTT_GLBL_VAR | HTT_GLBL_VAR | HTT_CLASS | HTT_KEYWORD | HTT_FUN, 1))
+      goto not_label;
+    rpn = A_CALLOC(sizeof(CRPN), NULL);
+    rpn->type = IC_LABEL;
+    found_label = 1;
+    for (misc = ccmp->code_ctrl->code_misc->next;
+         misc != ccmp->code_ctrl->code_misc; misc = misc->base.next) {
+      if (misc->type == CMT_LABEL && misc->str)
+        if (!strcmp(misc->str, ccmp->lex->string)) {
+          rpn->code_misc = misc;
+          goto label_fin;
+        }
+    }
+    rpn->code_misc = CodeMiscNew(ccmp, CMT_LABEL);
+    rpn->code_misc->str = A_STRDUP(ccmp->lex->string, NULL);
+  label_fin:
+    if (rpn->code_misc->flags & CMF_DEFINED)
+      ParseErr(ccmp, "Redefinition of label '%s'.", rpn->code_misc->str);
+    rpn->code_misc->flags |= CMF_DEFINED;
+    Lex(ccmp->lex);
+    if (ccmp->lex->cur_tok != ':') {
+      ParseErr(ccmp, "Expected a ':'.");
+      return 0;
+    }
+    Lex(ccmp->lex);
+  }
 not_label:
-	if (found_label) {
-		QueIns(rpn, ccmp->code_ctrl->ir_code);
-		if (!PrsStmt(ccmp)) {
-			ParseErr(ccmp, "Expected a statement for a label.");
-		}
-		return 1;
-	}
-	if (PrsKw(ccmp, TK_KW_BREAK)) {
-		if (!ccmp->code_ctrl->break_to) {
-			ParseErr(ccmp, "Unexpected break.");
-			return 0;
-		}
-		if (ccmp->lex->cur_tok != ';') {
-			ParseErr(ccmp, "Expected a ';'.");
-			return 0;
-		}
-		Lex(ccmp->lex);
-		if (ccmp->flags & CCF_IN_SUBSWITCH_START_BLOCK) {
-			rpn = A_CALLOC(sizeof(CRPN), NULL);
-			rpn->type = IC_SUB_RET;
-			QueIns(rpn, ccmp->code_ctrl->ir_code);
-		} else {
-			rpn = A_CALLOC(sizeof(CRPN), NULL);
-			rpn->type = IC_GOTO;
-			rpn->code_misc = ccmp->code_ctrl->break_to;
-			QueIns(rpn, ccmp->code_ctrl->ir_code);
-		}
-		return 1;
-	}
-	if (PrsTry(ccmp))
-		return 1;
-	if (PrsGoto(ccmp))
-		return 1;
-	if (PrsReturn(ccmp))
-		return 1;
-	if (PrsScope(ccmp))
-		return 1;
-	if (PrsIf(ccmp))
-		return 1;
-	if (PrsFor(ccmp))
-		return 1;
-	if (PrsSwitch(ccmp))
-		return 1;
-	if (PrsWhile(ccmp))
-		return 1;
-	if (PrsDo(ccmp))
-		return 1;
-	if (PrsKw(ccmp, TK_KW_EXTERN)) {
-		flags = PRSF_EXTERN;
-	prs_global:
-		if (ccmp->lex->cur_tok != TK_NAME)
-			ParseErr(ccmp, "Expected a type name.");
-		if (cls = HashFind(ccmp->lex->string, Fs->hash_table, HTT_CLASS, 1)) {
-			Lex(ccmp->lex);
-		} else if (!(cls = PrsClass(ccmp, flags)))
-			ParseErr(ccmp, "Expected a type name.");
-		else { // cls was declared if we reach here
-			// Don't whine about class declaration without variable declared also
-			if (ccmp->lex->cur_tok == ';') {
-				Lex(ccmp->lex);
-				return 1;
-			}
-		}
-	prs_global_loop:
-		PrsDecl(ccmp, cls, NULL, &is_func, flags, import_name);
-		if (is_func) {
-			return 1;
-		} else if (ccmp->lex->cur_tok == ',') {
-			Lex(ccmp->lex);
-			goto prs_global_loop;
-		}
-		if (ccmp->lex->cur_tok != ';' && !is_func) {
-			ParseErr(ccmp, "Expected ';'");
-			return 0;
-		}
-		if (import_name)
-			A_FREE(import_name);
-	} else if (PrsKw(ccmp, TK_KW__EXTERN)) {
-		flags = PRSF__EXTERN;
-		if (ccmp->lex->cur_tok != TK_NAME)
-			ParseErr(ccmp, "Expected a extern name.");
-		import_name = A_STRDUP(ccmp->lex->string, NULL);
-		goto prs_global;
-	} else if (PrsKw(ccmp, TK_KW_IMPORT)) {
-		flags = PRSF_IMPORT;
-		goto prs_global;
-	} else if (PrsKw(ccmp, TK_KW__IMPORT)) {
-		flags = PRSF__IMPORT;
-		if (ccmp->lex->cur_tok != TK_NAME)
-			ParseErr(ccmp, "Expected a import name.");
-		import_name = A_STRDUP(ccmp->lex->string, NULL);
-		goto prs_global;
-	}
-	if (PrsKw(ccmp, TK_KW_STATIC)) {
-		flags |= PRSF_STATIC;
-	}
-	if (ccmp->lex->cur_tok == TK_NAME) {
-		if (cls = PrsClass(ccmp, flags))
-			goto mloop;
-		if (cls = HashFind(ccmp->lex->string, Fs->hash_table, HTT_CLASS, 1)) {
-			Lex(ccmp->lex);
-			// Here's the deal,TempleOS lets you put a fallback type a class/union
-			// Time to rock like kanYe West
-			if (PeekKw(ccmp, TK_KW_CLASS)) {
-			ye:
-				cls2 = PrsClass(ccmp, 0);
-				if (!cls2)
-					ParseErr(ccmp, "Expected a class.");
-				cls2->fwd_class = cls;
-				cls2->raw_type = cls->raw_type;
-				cls = cls2;
-			} else if (PeekKw(ccmp, TK_KW_UNION)) {
-				goto ye;
-			}
-		mloop:
-			if (ccmp->cur_fun) {
-				// IF we added a RPN,we assigned(?)
-				rpn = ccmp->code_ctrl->ir_code->next;
-				PrsDecl(ccmp, cls, ccmp->cur_fun, NULL, flags, NULL);
-				if (ccmp->code_ctrl->ir_code->next != rpn)
-					assign_cnt++;
-			} else
-				goto prs_global_loop;
-			if (is_func)
-				return 1;
-			if (ccmp->lex->cur_tok == ',') {
-				Lex(ccmp->lex);
-				goto mloop;
-			}
-			if (ccmp->lex->cur_tok != ';' && !is_func) {
-				ParseErr(ccmp, "Expected ';'");
-				return 0;
-			}
-			Lex(ccmp->lex);
-			return 1;
-		}
-	}
-	if (ccmp->lex->cur_tok == TK_STR) {
-		string = PrsString(ccmp, &str_len);
-		rpn = A_CALLOC(sizeof(CRPN), NULL);
-		rpn->type = IC_GLOBAL;
-		rpn->global_var = HashFind("Print", Fs->hash_table, HTT_FUN, 1);
-		if (!rpn->global_var)
-			ParseErr(ccmp, "'Print' function doesnt exist yet.");
-		QueIns(rpn, ccmp->code_ctrl->ir_code);
-		rpn = A_CALLOC(sizeof(CRPN), NULL);
-		rpn->type = IC_STR;
-		for (misc = ccmp->code_ctrl->code_misc->next;
-			 ccmp->code_ctrl->code_misc != misc; misc = misc->base.next) {
-			if (misc->type == CMT_STRING)
-				if (misc->str_len == ccmp->lex->str_len)
-					if (0 == memcmp(misc->str, string, str_len)) {
-						goto found_str;
-					}
-		}
-		misc = CodeMiscNew(ccmp, CMT_STRING);
-		misc->str_len = str_len;
-		misc->str = string;
-	found_str:
-		rpn->code_misc = misc;
-		argc = 1;
-		QueIns(rpn, ccmp->code_ctrl->ir_code);
-		for (;;) {
-			switch (ccmp->lex->cur_tok) {
-				break;
-			case ',':
-				Lex(ccmp->lex);
-				if (!ParseExpr(ccmp, PEF_NO_COMMA)) {
-					ParseErr(ccmp, "Expected an expression,");
-				}
-				argc++;
-				break;
-			case ';':
-				Lex(ccmp->lex);
-				goto fin_str;
-				break;
-			default:
-				ParseErr(ccmp, "Expected an argument.");
-			}
-		}
-	fin_str:
-		rpn = A_CALLOC(sizeof(CRPN), NULL);
-		rpn->type = IC_CALL;
-		rpn->length = argc;
-		QueIns(rpn, ccmp->code_ctrl->ir_code);
-		return 1;
-	}
-	if (ccmp->lex->cur_tok == ';') {
-		Lex(ccmp->lex);
-		rpn = A_CALLOC(sizeof(CRPN), NULL);
-		rpn->type = IC_NOP;
-		QueIns(rpn, ccmp->code_ctrl->ir_code);
-		return 1;
-	}
-	if (ParseExpr(ccmp, 0)) {
-		if (ccmp->lex->cur_tok != ';')
-			ParseErr(ccmp, "Expected a ';'.");
-		Lex(ccmp->lex);
-		return 1;
-	}
-	return 0;
+  if (found_label) {
+    QueIns(rpn, ccmp->code_ctrl->ir_code);
+    if (!PrsStmt(ccmp)) {
+      ParseErr(ccmp, "Expected a statement for a label.");
+    }
+    return 1;
+  }
+  if (PrsKw(ccmp, TK_KW_BREAK)) {
+    if (!ccmp->code_ctrl->break_to) {
+      ParseErr(ccmp, "Unexpected break.");
+      return 0;
+    }
+    if (ccmp->lex->cur_tok != ';') {
+      ParseErr(ccmp, "Expected a ';'.");
+      return 0;
+    }
+    Lex(ccmp->lex);
+    if (ccmp->flags & CCF_IN_SUBSWITCH_START_BLOCK) {
+      rpn = A_CALLOC(sizeof(CRPN), NULL);
+      rpn->type = IC_SUB_RET;
+      QueIns(rpn, ccmp->code_ctrl->ir_code);
+    } else {
+      rpn = A_CALLOC(sizeof(CRPN), NULL);
+      rpn->type = IC_GOTO;
+      rpn->code_misc = ccmp->code_ctrl->break_to;
+      QueIns(rpn, ccmp->code_ctrl->ir_code);
+    }
+    return 1;
+  }
+  if (PrsTry(ccmp))
+    return 1;
+  if (PrsGoto(ccmp))
+    return 1;
+  if (PrsReturn(ccmp))
+    return 1;
+  if (PrsScope(ccmp))
+    return 1;
+  if (PrsIf(ccmp))
+    return 1;
+  if (PrsFor(ccmp))
+    return 1;
+  if (PrsSwitch(ccmp))
+    return 1;
+  if (PrsWhile(ccmp))
+    return 1;
+  if (PrsDo(ccmp))
+    return 1;
+  if (PrsKw(ccmp, TK_KW_EXTERN)) {
+    flags = PRSF_EXTERN;
+  prs_global:
+    if (ccmp->lex->cur_tok != TK_NAME)
+      ParseErr(ccmp, "Expected a type name.");
+    if (cls = HashFind(ccmp->lex->string, Fs->hash_table, HTT_CLASS, 1)) {
+      Lex(ccmp->lex);
+    } else if (!(cls = PrsClass(ccmp, flags)))
+      ParseErr(ccmp, "Expected a type name.");
+    else { // cls was declared if we reach here
+      // Don't whine about class declaration without variable declared also
+      if (ccmp->lex->cur_tok == ';') {
+        Lex(ccmp->lex);
+        return 1;
+      }
+    }
+  prs_global_loop:
+    PrsDecl(ccmp, cls, NULL, &is_func, flags, import_name);
+    if (is_func) {
+      return 1;
+    } else if (ccmp->lex->cur_tok == ',') {
+      Lex(ccmp->lex);
+      goto prs_global_loop;
+    }
+    if (ccmp->lex->cur_tok != ';' && !is_func) {
+      ParseErr(ccmp, "Expected ';'");
+      return 0;
+    }
+    if (import_name)
+      A_FREE(import_name);
+  } else if (PrsKw(ccmp, TK_KW__EXTERN)) {
+    flags = PRSF__EXTERN;
+    if (ccmp->lex->cur_tok != TK_NAME)
+      ParseErr(ccmp, "Expected a extern name.");
+    import_name = A_STRDUP(ccmp->lex->string, NULL);
+    goto prs_global;
+  } else if (PrsKw(ccmp, TK_KW_IMPORT)) {
+    flags = PRSF_IMPORT;
+    goto prs_global;
+  } else if (PrsKw(ccmp, TK_KW__IMPORT)) {
+    flags = PRSF__IMPORT;
+    if (ccmp->lex->cur_tok != TK_NAME)
+      ParseErr(ccmp, "Expected a import name.");
+    import_name = A_STRDUP(ccmp->lex->string, NULL);
+    goto prs_global;
+  }
+  if (PrsKw(ccmp, TK_KW_STATIC)) {
+    flags |= PRSF_STATIC;
+  }
+  if (ccmp->lex->cur_tok == TK_NAME) {
+    if (cls = PrsClass(ccmp, flags))
+      goto mloop;
+    if (cls = HashFind(ccmp->lex->string, Fs->hash_table, HTT_CLASS, 1)) {
+      Lex(ccmp->lex);
+      // Here's the deal,TempleOS lets you put a fallback type a class/union
+      // Time to rock like kanYe West
+      if (PeekKw(ccmp, TK_KW_CLASS)) {
+      ye:
+        cls2 = PrsClass(ccmp, 0);
+        if (!cls2)
+          ParseErr(ccmp, "Expected a class.");
+        cls2->fwd_class = cls;
+        cls2->raw_type = cls->raw_type;
+        cls = cls2;
+      } else if (PeekKw(ccmp, TK_KW_UNION)) {
+        goto ye;
+      }
+    mloop:
+      if (ccmp->cur_fun) {
+        // IF we added a RPN,we assigned(?)
+        rpn = ccmp->code_ctrl->ir_code->next;
+        PrsDecl(ccmp, cls, ccmp->cur_fun, NULL, flags, NULL);
+        if (ccmp->code_ctrl->ir_code->next != rpn)
+          assign_cnt++;
+      } else
+        goto prs_global_loop;
+      if (is_func)
+        return 1;
+      if (ccmp->lex->cur_tok == ',') {
+        Lex(ccmp->lex);
+        goto mloop;
+      }
+      if (ccmp->lex->cur_tok != ';' && !is_func) {
+        ParseErr(ccmp, "Expected ';'");
+        return 0;
+      }
+      Lex(ccmp->lex);
+      return 1;
+    }
+  }
+  if (ccmp->lex->cur_tok == TK_STR) {
+    string = PrsString(ccmp, &str_len);
+    rpn = A_CALLOC(sizeof(CRPN), NULL);
+    rpn->type = IC_GLOBAL;
+    rpn->global_var = HashFind("Print", Fs->hash_table, HTT_FUN, 1);
+    if (!rpn->global_var)
+      ParseErr(ccmp, "'Print' function doesnt exist yet.");
+    QueIns(rpn, ccmp->code_ctrl->ir_code);
+    rpn = A_CALLOC(sizeof(CRPN), NULL);
+    rpn->type = IC_STR;
+    for (misc = ccmp->code_ctrl->code_misc->next;
+         ccmp->code_ctrl->code_misc != misc; misc = misc->base.next) {
+      if (misc->type == CMT_STRING)
+        if (misc->str_len == ccmp->lex->str_len)
+          if (0 == memcmp(misc->str, string, str_len)) {
+            goto found_str;
+          }
+    }
+    misc = CodeMiscNew(ccmp, CMT_STRING);
+    misc->str_len = str_len;
+    misc->str = string;
+  found_str:
+    rpn->code_misc = misc;
+    argc = 1;
+    QueIns(rpn, ccmp->code_ctrl->ir_code);
+    for (;;) {
+      switch (ccmp->lex->cur_tok) {
+        break;
+      case ',':
+        Lex(ccmp->lex);
+        if (!ParseExpr(ccmp, PEF_NO_COMMA)) {
+          ParseErr(ccmp, "Expected an expression,");
+        }
+        argc++;
+        break;
+      case ';':
+        Lex(ccmp->lex);
+        goto fin_str;
+        break;
+      default:
+        ParseErr(ccmp, "Expected an argument.");
+      }
+    }
+  fin_str:
+    rpn = A_CALLOC(sizeof(CRPN), NULL);
+    rpn->type = IC_CALL;
+    rpn->length = argc;
+    QueIns(rpn, ccmp->code_ctrl->ir_code);
+    return 1;
+  }
+  if (ccmp->lex->cur_tok == ';') {
+    Lex(ccmp->lex);
+    rpn = A_CALLOC(sizeof(CRPN), NULL);
+    rpn->type = IC_NOP;
+    QueIns(rpn, ccmp->code_ctrl->ir_code);
+    return 1;
+  }
+  if (ParseExpr(ccmp, 0)) {
+    if (ccmp->lex->cur_tok != ';')
+      ParseErr(ccmp, "Expected a ';'.");
+    Lex(ccmp->lex);
+    return 1;
+  }
+  return 0;
 }
 
-int64_t PrsStmt(CCmpCtrl* ccmp)
-{
-	CRPN *old = ccmp->code_ctrl->ir_code->next, *cur, *new;
-	char ret = _PrsStmt(ccmp);
-	if (old == ccmp->code_ctrl->ir_code->next) {
-		old = A_CALLOC(sizeof(CRPN), 0);
-		old->type = IC_NOP;
-		QueIns(old, ccmp->code_ctrl->ir_code);
-	} else if (ICFwd(cur = ccmp->code_ctrl->ir_code->next) != old) {
-	}
-	return ret;
+int64_t PrsStmt(CCmpCtrl *ccmp) {
+  CRPN *old = ccmp->code_ctrl->ir_code->next, *cur, *new;
+  char ret = _PrsStmt(ccmp);
+  if (old == ccmp->code_ctrl->ir_code->next) {
+    old = A_CALLOC(sizeof(CRPN), 0);
+    old->type = IC_NOP;
+    QueIns(old, ccmp->code_ctrl->ir_code);
+  } else if (ICFwd(cur = ccmp->code_ctrl->ir_code->next) != old) {
+  }
+  return ret;
 }
-int64_t PrsScope(CCmpCtrl* ccmp)
-{ // YES
-	CRPN *ic, *old, *cur;
-	int64_t old_cnt;
-	if (ccmp->lex->cur_tok == '{') {
-		old = ccmp->code_ctrl->ir_code->next;
-		Lex(ccmp->lex);
-		while (ccmp->lex->cur_tok != '}') {
-			if (!PrsStmt(ccmp)) {
-				ParseErr(ccmp, "Expected an expression.");
-				return 0;
-			}
-		}
-		Lex(ccmp->lex);
-		return 1;
-	}
-	return 0;
+int64_t PrsScope(CCmpCtrl *ccmp) { // YES
+  CRPN *ic, *old, *cur;
+  int64_t old_cnt;
+  if (ccmp->lex->cur_tok == '{') {
+    old = ccmp->code_ctrl->ir_code->next;
+    Lex(ccmp->lex);
+    while (ccmp->lex->cur_tok != '}') {
+      if (!PrsStmt(ccmp)) {
+        ParseErr(ccmp, "Expected an expression.");
+        return 0;
+      }
+    }
+    Lex(ccmp->lex);
+    return 1;
+  }
+  return 0;
 }
 
-int64_t PrsI64(CCmpCtrl* ccmp)
-{
-	int64_t res;
-	int64_t (*bin)();
-	double (*binf)();
-	CRPN* ir_code;
-	CHashFun* fun = ccmp->cur_fun;
-	ccmp->cur_fun = NULL;
-	CodeCtrlPush(ccmp);
-	ParseExpr(ccmp, PEF_NO_COMMA);
-	ir_code = A_CALLOC(sizeof(CRPN), NULL);
-	ir_code->type = IC_RET;
-	QueIns(ir_code, ccmp->code_ctrl->ir_code);
-	binf = bin = Compile(ccmp, NULL, NULL);
-	if (AssignRawTypeToNode(ccmp, ir_code->base.next) != RT_F64)
-		res = (*bin)();
-	else
-		res = (*binf)();
-	CodeCtrlPop(ccmp);
-	ccmp->cur_fun = fun; // Restore
-	return res;
+int64_t PrsI64(CCmpCtrl *ccmp) {
+  int64_t res;
+  int64_t (*bin)();
+  double (*binf)();
+  CRPN *ir_code;
+  CHashFun *fun = ccmp->cur_fun;
+  ccmp->cur_fun = NULL;
+  CodeCtrlPush(ccmp);
+  ParseExpr(ccmp, PEF_NO_COMMA);
+  ir_code = A_CALLOC(sizeof(CRPN), NULL);
+  ir_code->type = IC_RET;
+  QueIns(ir_code, ccmp->code_ctrl->ir_code);
+  binf = bin = Compile(ccmp, NULL, NULL);
+  if (AssignRawTypeToNode(ccmp, ir_code->base.next) != RT_F64)
+    res = (*bin)();
+  else
+    res = (*binf)();
+  CodeCtrlPop(ccmp);
+  ccmp->cur_fun = fun; // Restore
+  return res;
 }
 
-double PrsF64(CCmpCtrl* ccmp)
-{
-	double res;
-	int64_t (*bin)();
-	double (*binf)();
-	CRPN* ir_code;
-	CHashFun* fun = ccmp->cur_fun;
-	ccmp->cur_fun = NULL;
-	CodeCtrlPush(ccmp);
-	ParseExpr(ccmp, PEF_NO_COMMA);
-	ir_code = A_CALLOC(sizeof(CRPN), NULL);
-	ir_code->type = IC_RET;
-	QueIns(ir_code, ccmp->code_ctrl->ir_code);
-	binf = bin = Compile(ccmp, NULL, NULL);
-	if (AssignRawTypeToNode(ccmp, ir_code->base.next) != RT_F64)
-		res = (*bin)();
-	else
-		res = (*binf)();
-	CodeCtrlPop(ccmp);
-	ccmp->cur_fun = fun;
-	return res;
+double PrsF64(CCmpCtrl *ccmp) {
+  double res;
+  int64_t (*bin)();
+  double (*binf)();
+  CRPN *ir_code;
+  CHashFun *fun = ccmp->cur_fun;
+  ccmp->cur_fun = NULL;
+  CodeCtrlPush(ccmp);
+  ParseExpr(ccmp, PEF_NO_COMMA);
+  ir_code = A_CALLOC(sizeof(CRPN), NULL);
+  ir_code->type = IC_RET;
+  QueIns(ir_code, ccmp->code_ctrl->ir_code);
+  binf = bin = Compile(ccmp, NULL, NULL);
+  if (AssignRawTypeToNode(ccmp, ir_code->base.next) != RT_F64)
+    res = (*bin)();
+  else
+    res = (*binf)();
+  CodeCtrlPop(ccmp);
+  ccmp->cur_fun = fun;
+  return res;
 }
 
-int64_t PrsArrayDim(CCmpCtrl* ccmp, CArrayDim* to)
-{
-	int64_t dim;
-	// CDimArray.next!=NULL if array
-	to->total_cnt = 1;
-	to->next = NULL;
-	if (ccmp->lex->cur_tok == '[') {
-		Lex(ccmp->lex);
-		dim = PrsI64(ccmp);
-		if (ccmp->lex->cur_tok != ']') {
-			ParseErr(ccmp, "Expected a ']'.");
-			return 0;
-		} else
-			Lex(ccmp->lex);
-		to->next = A_MALLOC(sizeof(CArrayDim), NULL);
-		to->next->total_cnt = 1;
-		to->next->cnt = dim;
-		to->total_cnt *= dim;
-		if (PrsArrayDim(ccmp, to->next))
-			to->total_cnt *= to->next->total_cnt;
-		return 1;
-	}
-	return 0;
+int64_t PrsArrayDim(CCmpCtrl *ccmp, CArrayDim *to) {
+  int64_t dim;
+  // CDimArray.next!=NULL if array
+  to->total_cnt = 1;
+  to->next = NULL;
+  if (ccmp->lex->cur_tok == '[') {
+    Lex(ccmp->lex);
+    dim = PrsI64(ccmp);
+    if (ccmp->lex->cur_tok != ']') {
+      ParseErr(ccmp, "Expected a ']'.");
+      return 0;
+    } else
+      Lex(ccmp->lex);
+    to->next = A_MALLOC(sizeof(CArrayDim), NULL);
+    to->next->total_cnt = 1;
+    to->next->cnt = dim;
+    to->total_cnt *= dim;
+    if (PrsArrayDim(ccmp, to->next))
+      to->total_cnt *= to->next->total_cnt;
+    return 1;
+  }
+  return 0;
 }
 
 // Be sure to assign members
-static void MemberAdd(CCmpCtrl* ccmp, CMemberLst* lst, CHashClass* cls)
-{
-	CMemberLst** ptr = &cls->members_lst;
-	CMemberLst* last = cls->members_lst;
-	while (*ptr) {
-		last = *ptr;
-		ptr = &ptr[0]->next;
-	}
-	*ptr = lst;
-	lst->last = last;
-	cls->member_cnt++;
+static void MemberAdd(CCmpCtrl *ccmp, CMemberLst *lst, CHashClass *cls) {
+  CMemberLst **ptr = &cls->members_lst;
+  CMemberLst *last = cls->members_lst;
+  while (*ptr) {
+    last = *ptr;
+    ptr = &ptr[0]->next;
+  }
+  *ptr = lst;
+  lst->last = last;
+  cls->member_cnt++;
 }
-int64_t PrsFunArgs(CCmpCtrl* ccmp, CHashFun* fun)
-{
-	CMemberLst* bungis;
-	CHashClass* cls;
-	int64_t idx = 0;
-	if (ccmp->lex->cur_tok != '(') {
-		ParseErr(ccmp, "Expected a '('.");
-		return 0;
-	} else
-		Lex(ccmp->lex);
-	idx = 0;
-	while (ccmp->lex->cur_tok != ')') {
-		if (ccmp->lex->cur_tok == TK_NAME) {
-			if (!(cls = HashFind(ccmp->lex->string, Fs->hash_table, HTT_CLASS, 1))) {
-				ParseErr(ccmp, "Expected a type name.");
-				return 0;
-			}
-			Lex(ccmp->lex);
-			PrsDecl(ccmp, cls, fun, NULL, PRSF_FUN_ARGS, NULL);
-			fun->argc++;
-			if (ccmp->lex->cur_tok == ',') {
-				Lex(ccmp->lex);
-				continue;
-			} else if (ccmp->lex->cur_tok == ')') {
-				break;
-			} else
-				goto func_err;
-		} else if (ccmp->lex->cur_tok == TK_DOT_DOT_DOT) {
-			fun->base.flags |= CLSF_VARGS;
-			bungis = A_CALLOC(sizeof(CMemberLst), NULL);
-			bungis->dim.total_cnt = 1; // MUST HAVE A DIM OF 1 TO NOT BE ZERO(Nroot was here)
-			bungis->reg = REG_MAYBE;
-			bungis->member_class = HashFind("I64i", Fs->hash_table, HTT_CLASS, 1);
-			assert(bungis->member_class);
-			bungis->str = A_STRDUP("argc", NULL);
-			MemberAdd(ccmp, bungis, fun);
-			bungis = A_CALLOC(sizeof(CMemberLst), NULL);
-			bungis->reg = REG_MAYBE;
-			bungis->member_class = HashFind("I64i", Fs->hash_table, HTT_CLASS, 1);
-			assert(bungis->member_class);
-			bungis->member_class++;
-			bungis->str = A_STRDUP("argv", NULL);
-			MemberAdd(ccmp, bungis, fun);
-			bungis->dim.total_cnt = 1; // MUST HAVE A DIM OF 1 TO NOT BE ZERO(Nroot was here)
-			Lex(ccmp->lex);
-			fun->argc += 2;
-			if (ccmp->lex->cur_tok == ')') {
-				break;
-			}
-			goto func_err;
-		} else {
-		func_err:
-			ParseErr(ccmp, "Expected ')'.");
-			return 0;
-		}
-	}
-	Lex(ccmp->lex);
-	return 1;
+int64_t PrsFunArgs(CCmpCtrl *ccmp, CHashFun *fun) {
+  CMemberLst *bungis;
+  CHashClass *cls;
+  int64_t idx = 0;
+  if (ccmp->lex->cur_tok != '(') {
+    ParseErr(ccmp, "Expected a '('.");
+    return 0;
+  } else
+    Lex(ccmp->lex);
+  idx = 0;
+  while (ccmp->lex->cur_tok != ')') {
+    if (ccmp->lex->cur_tok == TK_NAME) {
+      if (!(cls = HashFind(ccmp->lex->string, Fs->hash_table, HTT_CLASS, 1))) {
+        ParseErr(ccmp, "Expected a type name.");
+        return 0;
+      }
+      Lex(ccmp->lex);
+      PrsDecl(ccmp, cls, fun, NULL, PRSF_FUN_ARGS, NULL);
+      fun->argc++;
+      if (ccmp->lex->cur_tok == ',') {
+        Lex(ccmp->lex);
+        continue;
+      } else if (ccmp->lex->cur_tok == ')') {
+        break;
+      } else
+        goto func_err;
+    } else if (ccmp->lex->cur_tok == TK_DOT_DOT_DOT) {
+      fun->base.flags |= CLSF_VARGS;
+      bungis = A_CALLOC(sizeof(CMemberLst), NULL);
+      bungis->dim.total_cnt =
+          1; // MUST HAVE A DIM OF 1 TO NOT BE ZERO(Nroot was here)
+      bungis->reg = REG_MAYBE;
+      bungis->member_class = HashFind("I64i", Fs->hash_table, HTT_CLASS, 1);
+      assert(bungis->member_class);
+      bungis->str = A_STRDUP("argc", NULL);
+      MemberAdd(ccmp, bungis, fun);
+      bungis = A_CALLOC(sizeof(CMemberLst), NULL);
+      bungis->reg = REG_MAYBE;
+      bungis->member_class = HashFind("I64i", Fs->hash_table, HTT_CLASS, 1);
+      assert(bungis->member_class);
+      bungis->member_class++;
+      bungis->str = A_STRDUP("argv", NULL);
+      MemberAdd(ccmp, bungis, fun);
+      bungis->dim.total_cnt =
+          1; // MUST HAVE A DIM OF 1 TO NOT BE ZERO(Nroot was here)
+      Lex(ccmp->lex);
+      fun->argc += 2;
+      if (ccmp->lex->cur_tok == ')') {
+        break;
+      }
+      goto func_err;
+    } else {
+    func_err:
+      ParseErr(ccmp, "Expected ')'.");
+      return 0;
+    }
+  }
+  Lex(ccmp->lex);
+  return 1;
 }
-CHashClass* PrsType(CCmpCtrl* ccmp, CHashClass* base, char** name,
-	CHashFun** fun, CArrayDim* dim)
-{
-	int64_t star_cnt = 0, star_cnt2 = 0;
-	int64_t is_func_ptr = 0;
-	if (name)
-		*name = NULL;
-	if (fun)
-		*fun = NULL;
-	if (dim) {
-		memset(dim, 0, sizeof(CArrayDim));
-		dim->total_cnt = 1;
-	}
-	while (ccmp->lex->cur_tok == '*')
-		Lex(ccmp->lex), star_cnt++;
-	if (star_cnt >= STAR_CNT)
-		ParseErr(ccmp, "Too many pointer stars!");
-	is_func_ptr = ccmp->lex->cur_tok == '(';
-	if (is_func_ptr) {
-		Lex(ccmp->lex);
-		star_cnt2 = 0;
-		while (ccmp->lex->cur_tok == '*')
-			Lex(ccmp->lex), star_cnt2++;
-		if (star_cnt >= STAR_CNT)
-			ParseErr(ccmp, "Too many pointer stars!");
-	}
-	if (ccmp->lex->cur_tok == TK_NAME) {
-		if (name)
-			*name = A_STRDUP(ccmp->lex->string, NULL);
-		Lex(ccmp->lex);
-	}
-	PrsArrayDim(ccmp, dim);
-	if (is_func_ptr) {
-		if (ccmp->lex->cur_tok != ')') {
-			ParseErr(ccmp, "Expected a ')'!");
-		} else
-			Lex(ccmp->lex);
-		assert(fun);
-		*fun = A_CALLOC(sizeof(CHashFun), NULL);
-		fun[0]->base.flags |= CLSF_FUNPTR;
-		fun[0]->return_class = base + star_cnt;
-		fun[0]->base.raw_type = RT_FUNC;
-		fun[0]->base.sz = sizeof(void*);
-		fun[0]->base.ptr_star_cnt = star_cnt2;
-		PrsFunArgs(ccmp, *fun);
-		return *fun;
-	}
-	return base + star_cnt;
+CHashClass *PrsType(CCmpCtrl *ccmp, CHashClass *base, char **name,
+                    CHashFun **fun, CArrayDim *dim) {
+  int64_t star_cnt = 0, star_cnt2 = 0;
+  int64_t is_func_ptr = 0;
+  if (name)
+    *name = NULL;
+  if (fun)
+    *fun = NULL;
+  if (dim) {
+    memset(dim, 0, sizeof(CArrayDim));
+    dim->total_cnt = 1;
+  }
+  while (ccmp->lex->cur_tok == '*')
+    Lex(ccmp->lex), star_cnt++;
+  if (star_cnt >= STAR_CNT)
+    ParseErr(ccmp, "Too many pointer stars!");
+  is_func_ptr = ccmp->lex->cur_tok == '(';
+  if (is_func_ptr) {
+    Lex(ccmp->lex);
+    star_cnt2 = 0;
+    while (ccmp->lex->cur_tok == '*')
+      Lex(ccmp->lex), star_cnt2++;
+    if (star_cnt >= STAR_CNT)
+      ParseErr(ccmp, "Too many pointer stars!");
+  }
+  if (ccmp->lex->cur_tok == TK_NAME) {
+    if (name)
+      *name = A_STRDUP(ccmp->lex->string, NULL);
+    Lex(ccmp->lex);
+  }
+  PrsArrayDim(ccmp, dim);
+  if (is_func_ptr) {
+    if (ccmp->lex->cur_tok != ')') {
+      ParseErr(ccmp, "Expected a ')'!");
+    } else
+      Lex(ccmp->lex);
+    assert(fun);
+    *fun = A_CALLOC(sizeof(CHashFun), NULL);
+    fun[0]->base.flags |= CLSF_FUNPTR;
+    fun[0]->return_class = base + star_cnt;
+    fun[0]->base.raw_type = RT_FUNC;
+    fun[0]->base.sz = sizeof(void *);
+    fun[0]->base.ptr_star_cnt = star_cnt2;
+    PrsFunArgs(ccmp, *fun);
+    return *fun;
+  }
+  return base + star_cnt;
 }
 //
-// Array declarations within functions are not permited in TempleOS,so we just write into the
+// Array declarations within functions are not permited in TempleOS,so we just
+// write into the
 //  array's data directy
 //
-char* PrsArray(CCmpCtrl* ccmp, CHashClass* base, CArrayDim* dim, char* write_to)
-{
-	CMemberLst* cur_mem;
-	int64_t i, cap, ptr_width = base->sz;
-	char* string;
-	if (dim)
-		if (dim->next)
-			ptr_width *= dim->next->total_cnt;
-	if (ccmp->lex->cur_tok != '{') {
-		if (dim) {
-			if (base->raw_type == RT_U8i && ccmp->lex->cur_tok == TK_STR) {
-				cap = dim->cnt;
-				string = PrsString(ccmp, &i);
-				if (i + 1 > cap) {
-					ParseWarn(ccmp, "String excedes array dim.");
-					memcpy(write_to, string, cap);
-				} else {
-					memcpy(write_to, string, i + 1);
-				}
-				i = cap;
-				A_FREE(string);
-				return write_to + i;
-			}
-			ParseErr(ccmp, "Expected a value for array.");
-		}
-		if (base->raw_type == RT_F64)
-			*(double*)write_to = PrsF64(ccmp);
-		else {
-			i = PrsI64(ccmp);
-			switch (ptr_width) {
-				break;
-			case 1:
-				*(int8_t*)write_to = i;
-				break;
-			case 2:
-				*(int16_t*)write_to = i;
-				break;
-			case 4:
-				*(int32_t*)write_to = i;
-				break;
-			case 8:
-				*(int64_t*)write_to = i;
-			}
-		}
-		return write_to + ptr_width;
-	} else
-		Lex(ccmp->lex);
-	if (dim) {
-		cap = dim->cnt;
-		for (i = 0; i != cap; i++) {
-			write_to = PrsArray(ccmp, base, dim->next, write_to);
-			if (ccmp->lex->cur_tok != ',') {
-				if (i + 1 == cap) {
-					// I64 arr[3]={1,2,3,};
-					// All is good,not expecting other item
-				} else
-					ParseErr(ccmp, "Expected another array element.");
-			} else
-				Lex(ccmp->lex);
-		}
-	} else {
-		for (cur_mem = base->members_lst; cur_mem; cur_mem = cur_mem->next) {
-			PrsArray(ccmp, cur_mem->member_class, cur_mem->dim.next, write_to + cur_mem->off);
-			if (ccmp->lex->cur_tok != ',') {
-				if (!cur_mem->next) {
-					// class {I64 a,b,c;}={1,2,3,};
-					// All is good,not expecting other item
-				} else
-					ParseErr(ccmp, "Expected another member element.");
-			} else
-				Lex(ccmp->lex);
-		}
-		write_to += base->sz;
-	}
-	if (ccmp->lex->cur_tok != '}')
-		ParseErr(ccmp, "Expected a '}'.");
-	Lex(ccmp->lex);
-	return write_to;
+char *PrsArray(CCmpCtrl *ccmp, CHashClass *base, CArrayDim *dim,
+               char *write_to) {
+  CMemberLst *cur_mem;
+  int64_t i, cap, ptr_width = base->sz;
+  char *string;
+  if (dim)
+    if (dim->next)
+      ptr_width *= dim->next->total_cnt;
+  if (ccmp->lex->cur_tok != '{') {
+    if (dim) {
+      if (base->raw_type == RT_U8i && ccmp->lex->cur_tok == TK_STR) {
+        cap = dim->cnt;
+        string = PrsString(ccmp, &i);
+        if (i + 1 > cap) {
+          ParseWarn(ccmp, "String excedes array dim.");
+          memcpy(write_to, string, cap);
+        } else {
+          memcpy(write_to, string, i + 1);
+        }
+        i = cap;
+        A_FREE(string);
+        return write_to + i;
+      }
+      ParseErr(ccmp, "Expected a value for array.");
+    }
+    if (base->raw_type == RT_F64)
+      *(double *)write_to = PrsF64(ccmp);
+    else {
+      i = PrsI64(ccmp);
+      switch (ptr_width) {
+        break;
+      case 1:
+        *(int8_t *)write_to = i;
+        break;
+      case 2:
+        *(int16_t *)write_to = i;
+        break;
+      case 4:
+        *(int32_t *)write_to = i;
+        break;
+      case 8:
+        *(int64_t *)write_to = i;
+      }
+    }
+    return write_to + ptr_width;
+  } else
+    Lex(ccmp->lex);
+  if (dim) {
+    cap = dim->cnt;
+    for (i = 0; i != cap; i++) {
+      write_to = PrsArray(ccmp, base, dim->next, write_to);
+      if (ccmp->lex->cur_tok != ',') {
+        if (i + 1 == cap) {
+          // I64 arr[3]={1,2,3,};
+          // All is good,not expecting other item
+        } else
+          ParseErr(ccmp, "Expected another array element.");
+      } else
+        Lex(ccmp->lex);
+    }
+  } else {
+    for (cur_mem = base->members_lst; cur_mem; cur_mem = cur_mem->next) {
+      PrsArray(ccmp, cur_mem->member_class, cur_mem->dim.next,
+               write_to + cur_mem->off);
+      if (ccmp->lex->cur_tok != ',') {
+        if (!cur_mem->next) {
+          // class {I64 a,b,c;}={1,2,3,};
+          // All is good,not expecting other item
+        } else
+          ParseErr(ccmp, "Expected another member element.");
+      } else
+        Lex(ccmp->lex);
+    }
+    write_to += base->sz;
+  }
+  if (ccmp->lex->cur_tok != '}')
+    ParseErr(ccmp, "Expected a '}'.");
+  Lex(ccmp->lex);
+  return write_to;
 }
-int64_t PrsDecl(CCmpCtrl* ccmp, CHashClass* base, CHashClass* add_to,
-	int64_t* is_func_decl, int64_t flags, char* import_name)
-{
-	if (is_func_decl)
-		*is_func_decl = 0;
-	int64_t reg = REG_MAYBE, is_fun = 0, used = 0, tmpi;
-	CArrayDim dim;
-	CHashClass* cls;
-	CMemberLst *lst, *bungis;
-	CHashFun* fun;
-	CHashGlblVar *glbl_var, *import_var;
-	CRPN* rpn;
-	char* name;
-	double tmpf;
-	if (!(flags & PRSF_CLASS)) {
-		if (PrsKw(ccmp, TK_KW_NOREG))
-			reg = REG_NONE;
-		else if (PrsKw(ccmp, TK_KW_REG)) {
-			reg = REG_ALLOC;
-			if (ccmp->lex->cur_tok == TK_I64) {
-				reg = ccmp->lex->integer;
-				Lex(ccmp->lex);
-			}
-		}
-	}
-	cls = PrsType(ccmp, base, &name, &fun, &dim);
-	lst = A_CALLOC(sizeof(CMemberLst), NULL);
-	lst->reg = reg;
-	if (name)
-		lst->str = name;
-	lst->member_class = cls;
-	lst->dim = dim;
-	lst->member_class->use_cnt++;
-	lst->fun_ptr = fun;
-	if (ccmp->lex->cur_tok == '(') {
-		if (ccmp->cur_fun) {
-			ParseErr(ccmp, "No nested functions!!!");
-			return 0;
-		}
-		fun = ccmp->cur_fun = A_CALLOC(sizeof(CHashFun), NULL);
-		fun->base.base.str = A_STRDUP(name, NULL);
-		fun->base.raw_type = RT_FUNC;
-		fun->base.base.type = HTT_FUN;
-		fun->return_class = cls;
-		if (flags & (PRSF_EXTERN | PRSF__EXTERN)) {
-			fun->base.base.type |= HTF_EXTERN;
-		} else if (flags & (PRSF_IMPORT | PRSF__IMPORT)) {
-			fun->base.base.type |= HTF_IMPORT;
-		}
-		if (flags & (PRSF__EXTERN | PRSF__IMPORT)) {
-			fun->import_name = A_STRDUP(import_name, NULL);
-		}
-		HashAdd(fun, Fs->hash_table); // TODO acount for extern
-		is_fun = 1;
-		PrsFunArgs(ccmp, fun);
-	}
-	if (is_fun) {
-		if (fun->base.base.type & (HTF_EXTERN | HTF_IMPORT)) {
-			if (ccmp->lex->cur_tok == '{') {
-				ParseErr(ccmp, "Function body on a extern/import.");
-				return 0;
-			}
-			if (is_func_decl)
-				*is_func_decl = 1;
-			ccmp->cur_fun = NULL;
-			goto ret;
-		} else {
-			// TempleOS doesn't allow C style forward declarations and will fill a
-			// function Will an "empty" body,AIWN will force function bodies during
-			// the Bootstraping phase
-			if (ccmp->lex->cur_tok != '{') {
-				ParseErr(ccmp, "Expected a function body.");
-				return 0;
-			}
-		}
-		CodeCtrlPush(ccmp);
-		PrsScope(ccmp);
-		//
-		// Here's the deal. The function will stay "extern" so if it call's
-		// itself a CMT_RELOC_U64 will be made and the function address will be
-		// filled in later
-		//
-		ccmp->cur_fun->base.base.type |= HTF_EXTERN;
-		ccmp->cur_fun->fun_ptr = Compile(ccmp, NULL, NULL);
-		ccmp->cur_fun->base.base.type &= ~HTF_EXTERN;
-		if (ccmp->cur_fun->base.base.str)
-			SysSymImportsResolve(ccmp->cur_fun->base.base.str, 0);
-		CodeCtrlPop(ccmp);
-		ccmp->cur_fun = NULL;
-		if (is_func_decl)
-			*is_func_decl = 1;
-		goto ret;
-	}
-	if (add_to) {
-		if (flags & PRSF_STATIC)
-			lst->flags |= MLF_STATIC;
-		MemberAdd(ccmp, lst, add_to);
-		used = 1;
-	}
-	if (ccmp->lex->cur_tok == '=') {
-		//
-		// Here's the Donald Trump deal. I will handle global assigns later
-		//
-		if ((flags & PRSF_FUN_ARGS) || (flags & PRSF_STATIC)) {
-			Lex(ccmp->lex);
-			lst->flags |= MLF_DFT_AVAILABLE;
-			if (!lst->dim.next) {
-				switch (lst->member_class->raw_type) {
-					break;
-				case RT_U8i:
-				case RT_I8i:
-				case RT_U16i:
-				case RT_I16i:
-				case RT_U32i:
-				case RT_I32i:
-				case RT_U64i:
-				case RT_I64i:
-				case RT_PTR:
-				case RT_FUNC: // func ptr
-					tmpi = lst->dft_val = PrsI64(ccmp);
-					if (flags & PRSF_STATIC) {
-						lst->static_bytes = A_MALLOC(8, NULL);
-						*(int64_t*)lst->static_bytes = tmpi;
-					}
-					break;
-				case RT_F64:
-					tmpf = lst->dft_val_flt = PrsF64(ccmp);
-					if (flags & PRSF_STATIC) {
-						lst->static_bytes = A_MALLOC(lst->member_class->sz, NULL);
-						*(double*)lst->static_bytes = tmpf;
-					}
-					break;
-				default:
-					if (flags & PRSF_STATIC)
-						goto static_array;
-				}
-			} else {
-			static_array: // Also applies to classes
-				lst->static_bytes = A_CALLOC(lst->dim.total_cnt * lst->member_class->sz, NULL);
-				PrsArray(ccmp, lst->member_class, lst->dim.next, lst->static_bytes);
-			}
-		} else if (add_to) { // TODO is a local???
-			Lex(ccmp->lex);
-			rpn = A_CALLOC(sizeof(CRPN), NULL);
-			rpn->type = IC_LOCAL;
-			rpn->local_mem = lst;
-			QueIns(rpn, ccmp->code_ctrl->ir_code);
-			ParseExpr(ccmp, PEF_NO_COMMA);
-			rpn = A_CALLOC(sizeof(CRPN), NULL);
-			rpn->type = IC_EQ;
-			QueIns(rpn, ccmp->code_ctrl->ir_code);
-		}
-	}
-	if (!add_to && lst->str) {
-		// Is a global?
-		glbl_var = A_CALLOC(sizeof(CHashGlblVar), NULL);
-		glbl_var->base.str = lst->str; // we "steal" this from lst;
-		lst->str = NULL;
-		glbl_var->base.type = HTT_GLBL_VAR;
-		glbl_var->var_class = lst->member_class;
-		glbl_var->dim = lst->dim;
-		lst->dim.next = NULL; // We steal this
-		glbl_var->fun_ptr = lst->fun_ptr;
-		lst->fun_ptr = NULL; // We steal this
-		// lst will be Free'd at ret
-		glbl_var->data_addr = A_MALLOC(glbl_var->var_class->sz * glbl_var->dim.total_cnt, NULL);
-		if (flags & PRSF_IMPORT) {
-			glbl_var->base.type |= HTF_IMPORT;
-			goto set_import_name;
-		} else if (flags & PRSF__IMPORT) {
-			glbl_var->base.type |= HTF_IMPORT;
-		set_import_name:
-			// Ensure the import exists
-			if (import_var = HashFind(import_name, Fs->hash_table,
-					HTT_FUN | HTT_GLBL_VAR, 1)) {
-			} else {
-				ParseErr(ccmp, "Can't import;missing symbol '%s'.", import_name);
-				return 0;
-			}
-			//
-			if (glbl_var->base.type & HTT_GLBL_VAR) {
-				glbl_var->import_name = A_STRDUP(import_name, NULL);
-			} else if (glbl_var->base.type & HTT_FUN) {
-				((CHashFun*)glbl_var)->import_name = A_STRDUP(import_name, NULL);
-			}
-		} else if (flags & PRSF_EXTERN) {
-			glbl_var->base.type |= HTF_EXTERN;
-		} else if (flags & PRSF__EXTERN) {
-			glbl_var->base.type |= HTF_EXTERN;
-			if (glbl_var->base.type & HTT_GLBL_VAR) {
-				glbl_var->import_name = A_STRDUP(import_name, NULL);
-			} else if (glbl_var->base.type & HTT_FUN) {
-				((CHashFun*)glbl_var)->import_name = A_STRDUP(import_name, NULL);
-			}
-		}
-		HashAdd(glbl_var, Fs->hash_table);
-		SysSymImportsResolve(glbl_var->base.str, 0);
-		if (ccmp->lex->cur_tok == '=') {
-			Lex(ccmp->lex);
-			if (ccmp->lex->cur_tok == '{') {
-				PrsArray(ccmp, glbl_var->var_class, glbl_var->dim.next, glbl_var->data_addr);
-			} else {
-				rpn = A_CALLOC(sizeof(CRPN), NULL);
-				rpn->type = IC_GLOBAL;
-				rpn->global_var = glbl_var;
-				QueIns(rpn, ccmp->code_ctrl->ir_code);
-				ParseExpr(ccmp, PEF_NO_COMMA);
-				rpn = A_CALLOC(sizeof(CRPN), NULL);
-				rpn->type = IC_EQ;
-				QueIns(rpn, ccmp->code_ctrl->ir_code);
-			}
-		}
-		goto ret;
-	}
+int64_t PrsDecl(CCmpCtrl *ccmp, CHashClass *base, CHashClass *add_to,
+                int64_t *is_func_decl, int64_t flags, char *import_name) {
+  if (is_func_decl)
+    *is_func_decl = 0;
+  int64_t reg = REG_MAYBE, is_fun = 0, used = 0, tmpi;
+  CArrayDim dim;
+  CHashClass *cls;
+  CMemberLst *lst, *bungis;
+  CHashFun *fun;
+  CHashGlblVar *glbl_var, *import_var;
+  CRPN *rpn;
+  char *name;
+  double tmpf;
+  if (!(flags & PRSF_CLASS)) {
+    if (PrsKw(ccmp, TK_KW_NOREG))
+      reg = REG_NONE;
+    else if (PrsKw(ccmp, TK_KW_REG)) {
+      reg = REG_ALLOC;
+      if (ccmp->lex->cur_tok == TK_I64) {
+        reg = ccmp->lex->integer;
+        Lex(ccmp->lex);
+      }
+    }
+  }
+  cls = PrsType(ccmp, base, &name, &fun, &dim);
+  lst = A_CALLOC(sizeof(CMemberLst), NULL);
+  lst->reg = reg;
+  if (name)
+    lst->str = name;
+  lst->member_class = cls;
+  lst->dim = dim;
+  lst->member_class->use_cnt++;
+  lst->fun_ptr = fun;
+  if (ccmp->lex->cur_tok == '(') {
+    if (ccmp->cur_fun) {
+      ParseErr(ccmp, "No nested functions!!!");
+      return 0;
+    }
+    fun = ccmp->cur_fun = A_CALLOC(sizeof(CHashFun), NULL);
+    fun->base.base.str = A_STRDUP(name, NULL);
+    fun->base.raw_type = RT_FUNC;
+    fun->base.base.type = HTT_FUN;
+    fun->return_class = cls;
+    if (flags & (PRSF_EXTERN | PRSF__EXTERN)) {
+      fun->base.base.type |= HTF_EXTERN;
+    } else if (flags & (PRSF_IMPORT | PRSF__IMPORT)) {
+      fun->base.base.type |= HTF_IMPORT;
+    }
+    if (flags & (PRSF__EXTERN | PRSF__IMPORT)) {
+      fun->import_name = A_STRDUP(import_name, NULL);
+    }
+    HashAdd(fun, Fs->hash_table); // TODO acount for extern
+    is_fun = 1;
+    PrsFunArgs(ccmp, fun);
+  }
+  if (is_fun) {
+    if (fun->base.base.type & (HTF_EXTERN | HTF_IMPORT)) {
+      if (ccmp->lex->cur_tok == '{') {
+        ParseErr(ccmp, "Function body on a extern/import.");
+        return 0;
+      }
+      if (is_func_decl)
+        *is_func_decl = 1;
+      ccmp->cur_fun = NULL;
+      goto ret;
+    } else {
+      // TempleOS doesn't allow C style forward declarations and will fill a
+      // function Will an "empty" body,AIWN will force function bodies during
+      // the Bootstraping phase
+      if (ccmp->lex->cur_tok != '{') {
+        ParseErr(ccmp, "Expected a function body.");
+        return 0;
+      }
+    }
+    CodeCtrlPush(ccmp);
+    PrsScope(ccmp);
+    //
+    // Here's the deal. The function will stay "extern" so if it call's
+    // itself a CMT_RELOC_U64 will be made and the function address will be
+    // filled in later
+    //
+    ccmp->cur_fun->base.base.type |= HTF_EXTERN;
+    ccmp->cur_fun->fun_ptr = Compile(ccmp, NULL, NULL);
+    ccmp->cur_fun->base.base.type &= ~HTF_EXTERN;
+    if (ccmp->cur_fun->base.base.str)
+      SysSymImportsResolve(ccmp->cur_fun->base.base.str, 0);
+    CodeCtrlPop(ccmp);
+    ccmp->cur_fun = NULL;
+    if (is_func_decl)
+      *is_func_decl = 1;
+    goto ret;
+  }
+  if (add_to) {
+    if (flags & PRSF_STATIC)
+      lst->flags |= MLF_STATIC;
+    MemberAdd(ccmp, lst, add_to);
+    used = 1;
+  }
+  if (ccmp->lex->cur_tok == '=') {
+    //
+    // Here's the Donald Trump deal. I will handle global assigns later
+    //
+    if ((flags & PRSF_FUN_ARGS) || (flags & PRSF_STATIC)) {
+      Lex(ccmp->lex);
+      lst->flags |= MLF_DFT_AVAILABLE;
+      if (!lst->dim.next) {
+        switch (lst->member_class->raw_type) {
+          break;
+        case RT_U8i:
+        case RT_I8i:
+        case RT_U16i:
+        case RT_I16i:
+        case RT_U32i:
+        case RT_I32i:
+        case RT_U64i:
+        case RT_I64i:
+        case RT_PTR:
+        case RT_FUNC: // func ptr
+          tmpi = lst->dft_val = PrsI64(ccmp);
+          if (flags & PRSF_STATIC) {
+            lst->static_bytes = A_MALLOC(8, NULL);
+            *(int64_t *)lst->static_bytes = tmpi;
+          }
+          break;
+        case RT_F64:
+          tmpf = lst->dft_val_flt = PrsF64(ccmp);
+          if (flags & PRSF_STATIC) {
+            lst->static_bytes = A_MALLOC(lst->member_class->sz, NULL);
+            *(double *)lst->static_bytes = tmpf;
+          }
+          break;
+        default:
+          if (flags & PRSF_STATIC)
+            goto static_array;
+        }
+      } else {
+      static_array: // Also applies to classes
+        lst->static_bytes =
+            A_CALLOC(lst->dim.total_cnt * lst->member_class->sz, NULL);
+        PrsArray(ccmp, lst->member_class, lst->dim.next, lst->static_bytes);
+      }
+    } else if (add_to) { // TODO is a local???
+      Lex(ccmp->lex);
+      rpn = A_CALLOC(sizeof(CRPN), NULL);
+      rpn->type = IC_LOCAL;
+      rpn->local_mem = lst;
+      QueIns(rpn, ccmp->code_ctrl->ir_code);
+      ParseExpr(ccmp, PEF_NO_COMMA);
+      rpn = A_CALLOC(sizeof(CRPN), NULL);
+      rpn->type = IC_EQ;
+      QueIns(rpn, ccmp->code_ctrl->ir_code);
+    }
+  }
+  if (!add_to && lst->str) {
+    // Is a global?
+    glbl_var = A_CALLOC(sizeof(CHashGlblVar), NULL);
+    glbl_var->base.str = lst->str; // we "steal" this from lst;
+    lst->str = NULL;
+    glbl_var->base.type = HTT_GLBL_VAR;
+    glbl_var->var_class = lst->member_class;
+    glbl_var->dim = lst->dim;
+    lst->dim.next = NULL; // We steal this
+    glbl_var->fun_ptr = lst->fun_ptr;
+    lst->fun_ptr = NULL; // We steal this
+    // lst will be Free'd at ret
+    glbl_var->data_addr =
+        A_MALLOC(glbl_var->var_class->sz * glbl_var->dim.total_cnt, NULL);
+    if (flags & PRSF_IMPORT) {
+      glbl_var->base.type |= HTF_IMPORT;
+      goto set_import_name;
+    } else if (flags & PRSF__IMPORT) {
+      glbl_var->base.type |= HTF_IMPORT;
+    set_import_name:
+      // Ensure the import exists
+      if (import_var = HashFind(import_name, Fs->hash_table,
+                                HTT_FUN | HTT_GLBL_VAR, 1)) {
+      } else {
+        ParseErr(ccmp, "Can't import;missing symbol '%s'.", import_name);
+        return 0;
+      }
+      //
+      if (glbl_var->base.type & HTT_GLBL_VAR) {
+        glbl_var->import_name = A_STRDUP(import_name, NULL);
+      } else if (glbl_var->base.type & HTT_FUN) {
+        ((CHashFun *)glbl_var)->import_name = A_STRDUP(import_name, NULL);
+      }
+    } else if (flags & PRSF_EXTERN) {
+      glbl_var->base.type |= HTF_EXTERN;
+    } else if (flags & PRSF__EXTERN) {
+      glbl_var->base.type |= HTF_EXTERN;
+      if (glbl_var->base.type & HTT_GLBL_VAR) {
+        glbl_var->import_name = A_STRDUP(import_name, NULL);
+      } else if (glbl_var->base.type & HTT_FUN) {
+        ((CHashFun *)glbl_var)->import_name = A_STRDUP(import_name, NULL);
+      }
+    }
+    HashAdd(glbl_var, Fs->hash_table);
+    SysSymImportsResolve(glbl_var->base.str, 0);
+    if (ccmp->lex->cur_tok == '=') {
+      Lex(ccmp->lex);
+      if (ccmp->lex->cur_tok == '{') {
+        PrsArray(ccmp, glbl_var->var_class, glbl_var->dim.next,
+                 glbl_var->data_addr);
+      } else {
+        rpn = A_CALLOC(sizeof(CRPN), NULL);
+        rpn->type = IC_GLOBAL;
+        rpn->global_var = glbl_var;
+        QueIns(rpn, ccmp->code_ctrl->ir_code);
+        ParseExpr(ccmp, PEF_NO_COMMA);
+        rpn = A_CALLOC(sizeof(CRPN), NULL);
+        rpn->type = IC_EQ;
+        QueIns(rpn, ccmp->code_ctrl->ir_code);
+      }
+    }
+    goto ret;
+  }
 ret:
-	if (!used)
-		MemberLstDel(lst);
-	return 1;
+  if (!used)
+    MemberLstDel(lst);
+  return 1;
 }
 
-int64_t PrsWhile(CCmpCtrl* ccmp)
-{ // YES
-	CRPN* ic;
-	CCodeMisc *old_break_to, *break_to, *enter_label;
-	if (PrsKw(ccmp, TK_KW_WHILE)) {
-		old_break_to = ccmp->code_ctrl->break_to; // Restored
-		break_to = ccmp->code_ctrl->break_to = CodeMiscNew(ccmp, CMT_LABEL);
-		enter_label = CodeMiscNew(ccmp, CMT_LABEL);
-		ic = A_CALLOC(sizeof(CRPN), NULL);
-		ic->type = IC_LABEL;
-		ic->code_misc = enter_label;
-		QueIns(ic, ccmp->code_ctrl->ir_code);
-		if (ccmp->lex->cur_tok != '(')
-			ParseErr(ccmp, "Expected a '('.");
-		Lex(ccmp->lex);
-		if (!ParseExpr(ccmp, 0))
-			ParseErr(ccmp, "Expected expression.");
-		ic = A_CALLOC(sizeof(CRPN), NULL);
-		ic->type = IC_LNOT;
-		QueIns(ic, ccmp->code_ctrl->ir_code);
-		ic = A_CALLOC(sizeof(CRPN), NULL);
-		ic->type = IC_GOTO_IF;
-		ic->code_misc = break_to;
-		QueIns(ic, ccmp->code_ctrl->ir_code);
-		if (ccmp->lex->cur_tok != ')')
-			ParseErr(ccmp, "Expected a ')'.");
-		Lex(ccmp->lex);
-		if (!PrsStmt(ccmp)) {
-			ParseErr(ccmp, "Expected expression.");
-		}
-		ic = A_CALLOC(sizeof(CRPN), NULL);
-		ic->type = IC_GOTO;
-		ic->code_misc = enter_label;
-		QueIns(ic, ccmp->code_ctrl->ir_code);
-		ic = A_CALLOC(sizeof(CRPN), NULL);
-		ic->type = IC_LABEL;
-		ic->code_misc = break_to;
-		QueIns(ic, ccmp->code_ctrl->ir_code);
-		ccmp->code_ctrl->break_to = old_break_to;
-		return 1;
-	}
-	return 0;
+int64_t PrsWhile(CCmpCtrl *ccmp) { // YES
+  CRPN *ic;
+  CCodeMisc *old_break_to, *break_to, *enter_label;
+  if (PrsKw(ccmp, TK_KW_WHILE)) {
+    old_break_to = ccmp->code_ctrl->break_to; // Restored
+    break_to = ccmp->code_ctrl->break_to = CodeMiscNew(ccmp, CMT_LABEL);
+    enter_label = CodeMiscNew(ccmp, CMT_LABEL);
+    ic = A_CALLOC(sizeof(CRPN), NULL);
+    ic->type = IC_LABEL;
+    ic->code_misc = enter_label;
+    QueIns(ic, ccmp->code_ctrl->ir_code);
+    if (ccmp->lex->cur_tok != '(')
+      ParseErr(ccmp, "Expected a '('.");
+    Lex(ccmp->lex);
+    if (!ParseExpr(ccmp, 0))
+      ParseErr(ccmp, "Expected expression.");
+    ic = A_CALLOC(sizeof(CRPN), NULL);
+    ic->type = IC_LNOT;
+    QueIns(ic, ccmp->code_ctrl->ir_code);
+    ic = A_CALLOC(sizeof(CRPN), NULL);
+    ic->type = IC_GOTO_IF;
+    ic->code_misc = break_to;
+    QueIns(ic, ccmp->code_ctrl->ir_code);
+    if (ccmp->lex->cur_tok != ')')
+      ParseErr(ccmp, "Expected a ')'.");
+    Lex(ccmp->lex);
+    if (!PrsStmt(ccmp)) {
+      ParseErr(ccmp, "Expected expression.");
+    }
+    ic = A_CALLOC(sizeof(CRPN), NULL);
+    ic->type = IC_GOTO;
+    ic->code_misc = enter_label;
+    QueIns(ic, ccmp->code_ctrl->ir_code);
+    ic = A_CALLOC(sizeof(CRPN), NULL);
+    ic->type = IC_LABEL;
+    ic->code_misc = break_to;
+    QueIns(ic, ccmp->code_ctrl->ir_code);
+    ccmp->code_ctrl->break_to = old_break_to;
+    return 1;
+  }
+  return 0;
 }
 
-int64_t PrsDo(CCmpCtrl* ccmp)
-{
-	CRPN* ic;
-	CCodeMisc *old_break_to, *enter_label;
-	if (PrsKw(ccmp, TK_KW_DO)) {
-		enter_label = CodeMiscNew(ccmp, CMT_LABEL);
-		old_break_to = ccmp->code_ctrl->break_to; // Restored
-		ic = A_CALLOC(sizeof(CRPN), NULL);
-		ic->type = IC_LABEL;
-		ic->code_misc = enter_label;
-		QueIns(ic, ccmp->code_ctrl->ir_code);
-		ccmp->code_ctrl->break_to = CodeMiscNew(ccmp, CMT_LABEL);
-		PrsStmt(ccmp);
-		if (!PrsKw(ccmp, TK_KW_WHILE))
-			ParseErr(ccmp, "Expected a 'while'.");
-		if (ccmp->lex->cur_tok != '(')
-			ParseErr(ccmp, "Expected a '('.");
-		Lex(ccmp->lex);
-		if (!ParseExpr(ccmp, 0))
-			ParseErr(ccmp, "Expected expression.");
-		if (ccmp->lex->cur_tok != ')')
-			ParseErr(ccmp, "Expected a ')'.");
-		Lex(ccmp->lex);
-		if (ccmp->lex->cur_tok != ';')
-			ParseErr(ccmp, "Expected a ';'.");
-		Lex(ccmp->lex);
+int64_t PrsDo(CCmpCtrl *ccmp) {
+  CRPN *ic;
+  CCodeMisc *old_break_to, *enter_label;
+  if (PrsKw(ccmp, TK_KW_DO)) {
+    enter_label = CodeMiscNew(ccmp, CMT_LABEL);
+    old_break_to = ccmp->code_ctrl->break_to; // Restored
+    ic = A_CALLOC(sizeof(CRPN), NULL);
+    ic->type = IC_LABEL;
+    ic->code_misc = enter_label;
+    QueIns(ic, ccmp->code_ctrl->ir_code);
+    ccmp->code_ctrl->break_to = CodeMiscNew(ccmp, CMT_LABEL);
+    PrsStmt(ccmp);
+    if (!PrsKw(ccmp, TK_KW_WHILE))
+      ParseErr(ccmp, "Expected a 'while'.");
+    if (ccmp->lex->cur_tok != '(')
+      ParseErr(ccmp, "Expected a '('.");
+    Lex(ccmp->lex);
+    if (!ParseExpr(ccmp, 0))
+      ParseErr(ccmp, "Expected expression.");
+    if (ccmp->lex->cur_tok != ')')
+      ParseErr(ccmp, "Expected a ')'.");
+    Lex(ccmp->lex);
+    if (ccmp->lex->cur_tok != ';')
+      ParseErr(ccmp, "Expected a ';'.");
+    Lex(ccmp->lex);
 
-		ic = A_CALLOC(sizeof(CRPN), NULL);
-		ic->type = IC_GOTO_IF;
-		ic->code_misc = enter_label;
-		QueIns(ic, ccmp->code_ctrl->ir_code);
-		ic = A_CALLOC(sizeof(CRPN), NULL);
-		ic->type = IC_LABEL;
-		ic->code_misc = ccmp->code_ctrl->break_to;
-		QueIns(ic, ccmp->code_ctrl->ir_code);
-		ccmp->code_ctrl->break_to = old_break_to;
-		return 1;
-	}
-	return 0;
+    ic = A_CALLOC(sizeof(CRPN), NULL);
+    ic->type = IC_GOTO_IF;
+    ic->code_misc = enter_label;
+    QueIns(ic, ccmp->code_ctrl->ir_code);
+    ic = A_CALLOC(sizeof(CRPN), NULL);
+    ic->type = IC_LABEL;
+    ic->code_misc = ccmp->code_ctrl->break_to;
+    QueIns(ic, ccmp->code_ctrl->ir_code);
+    ccmp->code_ctrl->break_to = old_break_to;
+    return 1;
+  }
+  return 0;
 }
 
-int64_t PrsFor(CCmpCtrl* ccmp)
-{ // YES
-	CRPN *ic, *nop;
-	CCodeMisc *break_to, *old_break_to, *enter_label, *exit_label;
-	CCodeCtrl* cctrl = NULL;
-	int64_t idx;
-	if (PrsKw(ccmp, TK_KW_FOR)) {
-		old_break_to = ccmp->code_ctrl->break_to; //.Restored
-		break_to = CodeMiscNew(ccmp, CMT_LABEL);
-		ccmp->code_ctrl->break_to = break_to;
-		if (ccmp->lex->cur_tok != '(')
-			ParseErr(ccmp, "Expected a '('.");
-		Lex(ccmp->lex);
-		if (!ParseExpr(ccmp, 0)) {
-			// Do nothing
-		}
-		if (ccmp->lex->cur_tok != ';')
-			ParseErr(ccmp, "Expected a ';'.");
-		Lex(ccmp->lex);
-		enter_label = CodeMiscNew(ccmp, CMT_LABEL);
-		ic = A_CALLOC(sizeof(CRPN), NULL);
-		ic->type = IC_LABEL;
-		ic->code_misc = enter_label;
-		QueIns(ic, ccmp->code_ctrl->ir_code);
-		if (!ParseExpr(ccmp, 0)) {
-			ParseErr(ccmp, "Expected a condition.");
-		}
-		ic = A_CALLOC(sizeof(CRPN), NULL);
-		ic->type = IC_LNOT;
-		QueIns(ic, ccmp->code_ctrl->ir_code);
-		ic = A_CALLOC(sizeof(CRPN), NULL);
-		ic->type = IC_GOTO_IF;
-		ic->code_misc = break_to;
-		QueIns(ic, ccmp->code_ctrl->ir_code);
-		if (ccmp->lex->cur_tok != ';')
-			ParseErr(ccmp, "Expected a ';'.");
-		Lex(ccmp->lex);
-		if (ccmp->lex->cur_tok != ')') {
-			CodeCtrlPush(ccmp);
-			ParseExpr(ccmp, 0);
-			cctrl = CodeCtrlPopNoFree(ccmp);
-		}
-		if (ccmp->lex->cur_tok != ')')
-			ParseErr(ccmp, "Expected a ')'.");
-		Lex(ccmp->lex);
-		PrsStmt(ccmp);
-		if (cctrl) {
-			CodeCtrlAppend(ccmp, cctrl);
-			CodeCtrlDel(cctrl);
-		}
-		ic = A_CALLOC(sizeof(CRPN), NULL);
-		ic->type = IC_GOTO;
-		ic->code_misc = enter_label;
-		QueIns(ic, ccmp->code_ctrl->ir_code);
-		ic = A_CALLOC(sizeof(CRPN), NULL);
-		ic->type = IC_LABEL;
-		ic->code_misc = break_to;
-		QueIns(ic, ccmp->code_ctrl->ir_code);
-		ccmp->code_ctrl->break_to = old_break_to;
-		return 1;
-	}
-	return 0;
+int64_t PrsFor(CCmpCtrl *ccmp) { // YES
+  CRPN *ic, *nop;
+  CCodeMisc *break_to, *old_break_to, *enter_label, *exit_label;
+  CCodeCtrl *cctrl = NULL;
+  int64_t idx;
+  if (PrsKw(ccmp, TK_KW_FOR)) {
+    old_break_to = ccmp->code_ctrl->break_to; //.Restored
+    break_to = CodeMiscNew(ccmp, CMT_LABEL);
+    ccmp->code_ctrl->break_to = break_to;
+    if (ccmp->lex->cur_tok != '(')
+      ParseErr(ccmp, "Expected a '('.");
+    Lex(ccmp->lex);
+    if (!ParseExpr(ccmp, 0)) {
+      // Do nothing
+    }
+    if (ccmp->lex->cur_tok != ';')
+      ParseErr(ccmp, "Expected a ';'.");
+    Lex(ccmp->lex);
+    enter_label = CodeMiscNew(ccmp, CMT_LABEL);
+    ic = A_CALLOC(sizeof(CRPN), NULL);
+    ic->type = IC_LABEL;
+    ic->code_misc = enter_label;
+    QueIns(ic, ccmp->code_ctrl->ir_code);
+    if (!ParseExpr(ccmp, 0)) {
+      ParseErr(ccmp, "Expected a condition.");
+    }
+    ic = A_CALLOC(sizeof(CRPN), NULL);
+    ic->type = IC_LNOT;
+    QueIns(ic, ccmp->code_ctrl->ir_code);
+    ic = A_CALLOC(sizeof(CRPN), NULL);
+    ic->type = IC_GOTO_IF;
+    ic->code_misc = break_to;
+    QueIns(ic, ccmp->code_ctrl->ir_code);
+    if (ccmp->lex->cur_tok != ';')
+      ParseErr(ccmp, "Expected a ';'.");
+    Lex(ccmp->lex);
+    if (ccmp->lex->cur_tok != ')') {
+      CodeCtrlPush(ccmp);
+      ParseExpr(ccmp, 0);
+      cctrl = CodeCtrlPopNoFree(ccmp);
+    }
+    if (ccmp->lex->cur_tok != ')')
+      ParseErr(ccmp, "Expected a ')'.");
+    Lex(ccmp->lex);
+    PrsStmt(ccmp);
+    if (cctrl) {
+      CodeCtrlAppend(ccmp, cctrl);
+      CodeCtrlDel(cctrl);
+    }
+    ic = A_CALLOC(sizeof(CRPN), NULL);
+    ic->type = IC_GOTO;
+    ic->code_misc = enter_label;
+    QueIns(ic, ccmp->code_ctrl->ir_code);
+    ic = A_CALLOC(sizeof(CRPN), NULL);
+    ic->type = IC_LABEL;
+    ic->code_misc = break_to;
+    QueIns(ic, ccmp->code_ctrl->ir_code);
+    ccmp->code_ctrl->break_to = old_break_to;
+    return 1;
+  }
+  return 0;
 }
 
-int64_t PrsIf(CCmpCtrl* ccmp)
-{
-	CRPN* ic;
-	CCodeMisc *misc, *misc2;
-	if (PrsKw(ccmp, TK_KW_IF)) {
-		if (ccmp->lex->cur_tok != '(')
-			ParseErr(ccmp, "Expected a '('.");
-		Lex(ccmp->lex);
-		ParseExpr(ccmp, 0);
-		ic = A_CALLOC(sizeof(CRPN), NULL);
-		ic->type = IC_LNOT;
-		QueIns(ic, ccmp->code_ctrl->ir_code);
-		ic = A_CALLOC(sizeof(CRPN), NULL);
-		ic->type = IC_GOTO_IF;
-		QueIns(ic, ccmp->code_ctrl->ir_code);
-		misc = CodeMiscNew(ccmp, CMT_LABEL);
-		ic->code_misc = misc;
-		if (ccmp->lex->cur_tok != ')')
-			ParseErr(ccmp, "Expected a ')'.");
-		Lex(ccmp->lex);
-		PrsStmt(ccmp);
-		if (PrsKw(ccmp, TK_KW_ELSE)) {
-			misc2 = CodeMiscNew(ccmp, CMT_LABEL);
-			ic = A_CALLOC(sizeof(CRPN), NULL);
-			ic->type = IC_GOTO;
-			ic->code_misc = misc2;
-			QueIns(ic, ccmp->code_ctrl->ir_code);
-			ic = A_CALLOC(sizeof(CRPN), NULL);
-			ic->type = IC_LABEL;
-			ic->code_misc = misc;
-			QueIns(ic, ccmp->code_ctrl->ir_code);
-			PrsStmt(ccmp);
-			ic = A_CALLOC(sizeof(CRPN), NULL);
-			ic->type = IC_LABEL;
-			ic->code_misc = misc2;
-			QueIns(ic, ccmp->code_ctrl->ir_code);
-		} else {
-			ic = A_CALLOC(sizeof(CRPN), NULL);
-			ic->type = IC_LABEL;
-			ic->code_misc = misc;
-			QueIns(ic, ccmp->code_ctrl->ir_code);
-		}
-		return 1;
-	}
-	return 0;
+int64_t PrsIf(CCmpCtrl *ccmp) {
+  CRPN *ic;
+  CCodeMisc *misc, *misc2;
+  if (PrsKw(ccmp, TK_KW_IF)) {
+    if (ccmp->lex->cur_tok != '(')
+      ParseErr(ccmp, "Expected a '('.");
+    Lex(ccmp->lex);
+    ParseExpr(ccmp, 0);
+    ic = A_CALLOC(sizeof(CRPN), NULL);
+    ic->type = IC_LNOT;
+    QueIns(ic, ccmp->code_ctrl->ir_code);
+    ic = A_CALLOC(sizeof(CRPN), NULL);
+    ic->type = IC_GOTO_IF;
+    QueIns(ic, ccmp->code_ctrl->ir_code);
+    misc = CodeMiscNew(ccmp, CMT_LABEL);
+    ic->code_misc = misc;
+    if (ccmp->lex->cur_tok != ')')
+      ParseErr(ccmp, "Expected a ')'.");
+    Lex(ccmp->lex);
+    PrsStmt(ccmp);
+    if (PrsKw(ccmp, TK_KW_ELSE)) {
+      misc2 = CodeMiscNew(ccmp, CMT_LABEL);
+      ic = A_CALLOC(sizeof(CRPN), NULL);
+      ic->type = IC_GOTO;
+      ic->code_misc = misc2;
+      QueIns(ic, ccmp->code_ctrl->ir_code);
+      ic = A_CALLOC(sizeof(CRPN), NULL);
+      ic->type = IC_LABEL;
+      ic->code_misc = misc;
+      QueIns(ic, ccmp->code_ctrl->ir_code);
+      PrsStmt(ccmp);
+      ic = A_CALLOC(sizeof(CRPN), NULL);
+      ic->type = IC_LABEL;
+      ic->code_misc = misc2;
+      QueIns(ic, ccmp->code_ctrl->ir_code);
+    } else {
+      ic = A_CALLOC(sizeof(CRPN), NULL);
+      ic->type = IC_LABEL;
+      ic->code_misc = misc;
+      QueIns(ic, ccmp->code_ctrl->ir_code);
+    }
+    return 1;
+  }
+  return 0;
 }
 
 #define BETWEEN(a, min, max) ((a) >= min) && ((a) <= max)
-int64_t AssignRawTypeToNode(CCmpCtrl* ccmp, CRPN* rpn)
-{
-	int64_t a, b, arg;
-	CMemberLst* mlst;
-	CHashFun* fun;
-	char* name;
-	CRPN* orig_rpn = rpn;
-	if (rpn->raw_type)
-		return rpn->raw_type;
-	switch (rpn->type) {
-		break;
-	case IC_BT:
-	case IC_BTR:
-	case IC_BTS:
-	case IC_BTC:
-	case IC_LBTR:
-	case IC_LBTS:
-	case IC_LBTC:
-		AssignRawTypeToNode(ccmp, ICArgN(rpn, 1));
-		AssignRawTypeToNode(ccmp, ICArgN(rpn, 0));
-		rpn->ic_class = HashFind("I64i", Fs->hash_table, HTT_CLASS, 1);
-		return rpn->raw_type = RT_I64i;
-		break;
-	case IC_SHORT_ADDR:
-	case IC_RELOC:
-		rpn->ic_class = HashFind("U8i", Fs->hash_table, HTT_CLASS, 1);
-		rpn->ic_class++;
-		return rpn->raw_type = RT_PTR;
-		break;
-	case __IC_VARGS:
-		rpn->ic_class = HashFind("I64i", Fs->hash_table, HTT_CLASS, 1);
-		return rpn->raw_type = RT_I64i;
-		break;
-	case IC_TO_I64:
-		rpn->ic_class = HashFind("I64i", Fs->hash_table, HTT_CLASS, 1);
-		return rpn->raw_type = RT_I64i;
-		break;
-	case IC_TO_F64:
-		rpn->ic_class = HashFind("F64", Fs->hash_table, HTT_CLASS, 1);
-		return rpn->raw_type = RT_F64;
-		break;
-	case IC_TYPECAST:
-		return rpn->raw_type = rpn->ic_class->raw_type;
-		break;
-	case __IC_CALL:
-		rpn = orig_rpn->base.next;
-		for (arg = 0; arg != orig_rpn->length + 1; arg++) {
-			if (rpn->type != IC_NOP)
-				AssignRawTypeToNode(ccmp, rpn);
-			rpn = ICFwd(rpn);
-		}
-		return rpn->raw_type = rpn->ic_class;
-	case IC_CALL:
-		rpn = orig_rpn->base.next;
-		for (arg = 0; arg != orig_rpn->length; arg++) {
-			if (rpn->type != IC_NOP)
-				AssignRawTypeToNode(ccmp, rpn);
-			rpn = ICFwd(rpn);
-		}
-		if (RT_PTR == AssignRawTypeToNode(ccmp, rpn)) {
-			if (rpn->ic_class->ptr_star_cnt > 1)
-				ParseErr(ccmp, "Can't call this pointer."); // TODO add type name
-		}
-		fun = rpn->ic_fun;
-	got_fun:
-		if (!fun)
-			ParseErr(ccmp, "Invalid type to call."); // TODO add type name
-		if (arg > fun->argc && !(fun->base.flags & CLSF_VARGS)) {
-			ParseErr(ccmp, "Excess arguments for function");
-		}
-		mlst = fun->base.members_lst;
-		rpn = orig_rpn->base.next;
-		for (arg = 0; arg != orig_rpn->length; arg++) {
-			if (arg >= fun->argc)
-				break;
-			rpn = ICArgN(orig_rpn, orig_rpn->length - arg - 1);
-			if (rpn->type == IC_NOP)
-				if (!(mlst->flags & MLF_DFT_AVAILABLE)) {
-					ParseErr(ccmp, "No default value for argument %d.", arg);
-				}
-			mlst = mlst->next;
-		}
-		for (; arg < fun->argc; arg++) {
-			if (fun->base.flags & CLSF_VARGS && arg >= fun->argc - 2)
-				break;
-			if (!(mlst->flags & MLF_DFT_AVAILABLE)) {
-				ParseErr(ccmp, "No default value for argument %d.", arg);
-			}
-			mlst = mlst->next;
-		}
-		orig_rpn->ic_class = fun->return_class;
-		orig_rpn->ic_dim = NULL;
-		orig_rpn->raw_type = orig_rpn->ic_class->raw_type;
-		break;
-	case IC_COMMA:
-		AssignRawTypeToNode(ccmp, rpn->base.next);
-		AssignRawTypeToNode(ccmp, ICFwd(rpn->base.next));
-		rpn->ic_class = ((CRPN*)rpn->base.next)->ic_class;
-		rpn->ic_dim = ((CRPN*)rpn->base.next)->ic_dim;
-		rpn->ic_fun = ((CRPN*)rpn->base.next)->ic_fun;
-		return rpn->raw_type = ((CRPN*)rpn->base.next)->raw_type;
-		break;
-	case IC_GLOBAL:
-		if (rpn->global_var->base.type & HTT_GLBL_VAR) {
-			rpn->ic_class = rpn->global_var->var_class;
-			rpn->ic_dim = rpn->global_var->dim.next;
-			rpn->ic_fun = rpn->global_var->fun_ptr;
-			return rpn->raw_type = rpn->ic_class->raw_type;
-		} else if (rpn->global_var->base.type & HTT_FUN) {
-			fun = rpn->global_var;
-			rpn->ic_class = &fun->base;
-			rpn->ic_dim = NULL;
-			rpn->ic_fun = fun;
-			return RT_FUNC;
-		}
-		abort();
-		break;
-	case IC_LOCAL:
-		rpn->ic_class = rpn->local_mem->member_class;
-		rpn->ic_dim = rpn->local_mem->dim.next;
-		rpn->ic_fun = rpn->local_mem->fun_ptr;
-		return rpn->raw_type = rpn->ic_class->raw_type;
-		break;
-	case IC_NEG:
-	unop:
-		AssignRawTypeToNode(ccmp, rpn->base.next);
-		if (BETWEEN(((CRPN*)rpn->base.next)->raw_type, RT_I8i, RT_U32i)) {
-			// Promote to 64bit
-			rpn->raw_type = RT_I64i;
-		} else {
-			rpn->raw_type = ((CRPN*)rpn->base.next)->raw_type;
-			rpn->ic_class = ((CRPN*)rpn->base.next)->ic_class;
-			rpn->ic_fun = ((CRPN*)rpn->base.next)->ic_fun;
-			rpn->ic_dim = NULL;
-		}
-		goto ret;
-		break;
-	case IC_POS:
-		goto unop;
-		break;
-	case IC_NAME:
-		abort();
-		break;
-	case IC_STR:
-		rpn->raw_type = RT_PTR;
-		goto ret;
-		break;
-	case IC_CHR:
-		rpn->raw_type = RT_U64i;
-		goto ret;
-		break;
-	case IC_POW:
-		rpn->raw_type = RT_F64;
-		goto ret;
-		break;
-	case IC_ADD:
-		a = AssignRawTypeToNode(ccmp, ICFwd(rpn->base.next));
-		b = AssignRawTypeToNode(ccmp, rpn->base.next);
-		if (a == RT_PTR || b == RT_PTR) {
-			if (a == RT_PTR) {
-				rpn->raw_type = RT_PTR;
-				rpn->ic_class = ICFwd(rpn->base.next)->ic_class;
-				rpn->ic_dim = ICFwd(rpn->base.next)->ic_dim;
-				rpn->ic_fun = ICFwd(rpn->base.next)->ic_fun;
-			} else {
-				rpn->raw_type = RT_PTR;
-				rpn->ic_class = ((CRPN*)rpn->base.next)->ic_class;
-				rpn->ic_fun = ((CRPN*)rpn->base.next)->ic_fun;
-				rpn->ic_dim = ((CRPN*)rpn->base.next)->ic_dim;
-			}
-			return rpn->raw_type;
-		} else if (BETWEEN(a, RT_I8i, RT_U32i) && BETWEEN(a, RT_I8i, RT_U32i)) {
-			// Promote to I64i
-			a = RT_I64i;
-		}
-		rpn->raw_type = (a > b) ? a : b;
-		goto ret;
-		break;
-	case IC_EQ:
-		goto abinop;
-		break;
-	case IC_SUB:
-		a = AssignRawTypeToNode(ccmp, ICFwd(rpn->base.next));
-		b = AssignRawTypeToNode(ccmp, rpn->base.next);
-		// PTR-idx
-		if (a == RT_PTR) {
-			rpn->raw_type = RT_PTR;
-			rpn->ic_class = ICFwd(rpn->base.next)->ic_class;
-			rpn->ic_dim = ICFwd(rpn->base.next)->ic_dim;
-			rpn->ic_fun = ICFwd(rpn->base.next)->ic_fun;
-			return rpn->raw_type;
-		} else if (BETWEEN(a, RT_I8i, RT_U32i) && BETWEEN(a, RT_I8i, RT_U32i)) {
-			// Promote to I64i
-			a = RT_I64i;
-		}
-		rpn->raw_type = (a > b) ? a : b;
-		goto ret;
-		break;
-	case IC_DIV:
-	binop:
-		a = AssignRawTypeToNode(ccmp, ICFwd(rpn->base.next));
-		b = AssignRawTypeToNode(ccmp, rpn->base.next);
-		if (BETWEEN(a, RT_I8i, RT_U32i) && BETWEEN(b, RT_I8i, RT_U32i)) {
-			// Promote to I64i
-			a = RT_I64i;
-		}
-		rpn->raw_type = (a > b) ? a : b;
-		goto ret;
-		break;
-	case IC_MUL:
-		goto binop;
-		break;
-	case IC_DEREF:
-		AssignRawTypeToNode(ccmp, rpn->base.next);
-		if (!((CRPN*)rpn->base.next)->ic_class->ptr_star_cnt) {
-			ParseErr(ccmp, "Can't derefernce a non-pointer/array.");
-			return 0;
-		}
-		rpn->ic_dim = ((CRPN*)rpn->base.next)->ic_dim;
-		rpn->ic_fun = ((CRPN*)rpn->base.next)->ic_fun;
-		if (!rpn->ic_dim)
-			goto no_dim;
-		if (!rpn->ic_dim->next) {
-		no_dim:
-			rpn->ic_class = ((CRPN*)rpn->base.next)->ic_class - 1;
-		} else {
-			rpn->ic_dim = rpn->ic_dim->next;
-		}
-		rpn->raw_type = rpn->ic_class->raw_type;
-		return rpn->raw_type;
-		break;
-	case IC_AND:
-		goto binop;
-		break;
-	case IC_DOT:
-		AssignRawTypeToNode(ccmp, rpn->base.next);
-		if (((CRPN*)rpn->base.next)->ic_class->ptr_star_cnt || ((CRPN*)rpn->base.next)->ic_dim) {
-			ParseErr(ccmp, "Must not be a pointer to use a '.' operator.");
-			return 0;
-		}
-		rpn->ic_class = rpn->local_mem->member_class;
-		rpn->ic_dim = rpn->local_mem->dim.next;
-		rpn->ic_fun = rpn->local_mem->fun_ptr;
-		return rpn->raw_type = rpn->ic_class->raw_type;
-		break;
-	case IC_ADDR_OF:
-		AssignRawTypeToNode(ccmp, rpn->base.next);
-		if (((CRPN*)rpn->base.next)->ic_class->ptr_star_cnt >= STAR_CNT) {
-			ParseErr(ccmp, "Too many pointer stars.");
-			return 0;
-		}
-		if (((CRPN*)rpn->base.next)->ic_dim) {
-			rpn->ic_class = ((CRPN*)rpn->base.next)->ic_class;
-			rpn->ic_dim = ((CRPN*)rpn->base.next)->ic_dim;
-		} else {
-			rpn->ic_class = ((CRPN*)rpn->base.next)->ic_class;
-			if (rpn->ic_class->raw_type == RT_FUNC)
-				rpn->ic_class = HashFind("U8i", Fs->hash_table, HTT_CLASS, 1);
-			rpn->ic_class++;
-		}
-		rpn->ic_fun = ((CRPN*)rpn->base.next)->ic_fun;
-		return rpn->raw_type = RT_PTR;
-		break;
-	case IC_XOR:
-		goto binop;
-		break;
-	case IC_MOD:
-		goto binop;
-		break;
-	case IC_OR:
-		goto binop;
-		break;
-	case IC_LT:
-		rpn->raw_type = RT_I64i;
-		goto ret;
-		break;
-	case IC_GT:
-		rpn->raw_type = RT_I64i;
-		goto ret;
-		break;
-	case IC_LNOT:
-		rpn->raw_type = RT_I64i;
-		goto ret;
-		break;
-	case IC_BNOT:
-		goto unop;
-		break;
-	case IC_POST_INC:
-		goto unop;
-		break;
-	case IC_POST_DEC:
-		goto unop;
-		break;
-	case IC_PRE_INC:
-		goto unop;
-		break;
-	case IC_PRE_DEC:
-		goto unop;
-		break;
-	case IC_AND_AND:
-	cmp:
-		rpn->raw_type = RT_I64i;
-		goto ret;
-		break;
-	case IC_OR_OR:
-		goto cmp;
-		break;
-	case IC_XOR_XOR:
-		goto cmp;
-		break;
-	case IC_EQ_EQ:
-		goto cmp;
-		break;
-	case IC_NE:
-		goto cmp;
-		break;
-	case IC_LE:
-		goto cmp;
-		break;
-	case IC_GE:
-		goto cmp;
-		break;
-	case IC_LSH:
-		goto binop;
-		break;
-	case IC_RSH:
-		goto binop;
-		break;
-	case IC_ADD_EQ:
-	abinop:
-		AssignRawTypeToNode(ccmp, rpn->base.next);
-		AssignRawTypeToNode(ccmp, ICFwd(rpn->base.next));
-		rpn->ic_class = ICFwd(rpn->base.next)->ic_class;
-		rpn->ic_fun = ICFwd(rpn->base.next)->ic_fun;
-		rpn->ic_dim = ICFwd(rpn->base.next)->ic_dim;
-		rpn->raw_type = rpn->ic_class->raw_type;
-		return rpn->raw_type;
-		break;
-	case IC_SUB_EQ:
-		goto abinop;
-		break;
-	case IC_MUL_EQ:
-		goto abinop;
-		break;
-	case IC_DIV_EQ:
-		goto abinop;
-		break;
-	case IC_LSH_EQ:
-		goto abinop;
-		break;
-	case IC_RSH_EQ:
-		goto abinop;
-		break;
-	case IC_AND_EQ:
-		goto abinop;
-		break;
-	case IC_OR_EQ:
-		goto abinop;
-		break;
-	case IC_XOR_EQ:
-		goto abinop;
-		break;
-	case IC_ARROW:
-		AssignRawTypeToNode(ccmp, rpn->base.next);
-		rpn->ic_class = rpn->local_mem->member_class;
-		rpn->ic_fun = rpn->local_mem->fun_ptr;
-		rpn->ic_dim = rpn->local_mem->dim.next;
-		rpn->raw_type = rpn->ic_class->raw_type;
-		return rpn->raw_type;
-		break;
-	case IC_MOD_EQ:
-		goto abinop;
-		break;
-	case IC_I64:
-		rpn->raw_type = RT_I64i;
-		goto ret;
-		break;
-	case IC_F64:
-		rpn->raw_type = RT_F64;
-		goto ret;
-		break;
-	case IC_ARRAY_ACC:
-		b = AssignRawTypeToNode(ccmp, rpn->base.next);
-		a = AssignRawTypeToNode(ccmp, ICFwd(rpn->base.next));
-		if (ICFwd(rpn->base.next)->ic_class->ptr_star_cnt == 0 && !ICFwd(rpn->base.next)->ic_dim) {
-			ParseErr(ccmp, "Expected a pointer or array type for array access.");
-			return 0;
-		}
-		if (ICFwd(rpn->base.next)->ic_dim) {
-			rpn->ic_class = ICFwd(rpn->base.next)->ic_class;
-			rpn->ic_dim = ICFwd(rpn->base.next)->ic_dim->next;
-		} else
-			rpn->ic_class = ICFwd(rpn->base.next)->ic_class - 1;
-		rpn->ic_fun = ICFwd(rpn->base.next)->ic_fun;
-		return rpn->raw_type = rpn->ic_class->raw_type;
-	}
+int64_t AssignRawTypeToNode(CCmpCtrl *ccmp, CRPN *rpn) {
+  int64_t a, b, arg;
+  CMemberLst *mlst;
+  CHashFun *fun;
+  char *name;
+  CRPN *orig_rpn = rpn;
+  if (rpn->raw_type)
+    return rpn->raw_type;
+  switch (rpn->type) {
+    break;
+  case IC_BT:
+  case IC_BTR:
+  case IC_BTS:
+  case IC_BTC:
+  case IC_LBTR:
+  case IC_LBTS:
+  case IC_LBTC:
+    AssignRawTypeToNode(ccmp, ICArgN(rpn, 1));
+    AssignRawTypeToNode(ccmp, ICArgN(rpn, 0));
+    rpn->ic_class = HashFind("I64i", Fs->hash_table, HTT_CLASS, 1);
+    return rpn->raw_type = RT_I64i;
+    break;
+  case IC_SHORT_ADDR:
+  case IC_RELOC:
+    rpn->ic_class = HashFind("U8i", Fs->hash_table, HTT_CLASS, 1);
+    rpn->ic_class++;
+    return rpn->raw_type = RT_PTR;
+    break;
+  case __IC_VARGS:
+    rpn->ic_class = HashFind("I64i", Fs->hash_table, HTT_CLASS, 1);
+    return rpn->raw_type = RT_I64i;
+    break;
+  case IC_TO_I64:
+    rpn->ic_class = HashFind("I64i", Fs->hash_table, HTT_CLASS, 1);
+    return rpn->raw_type = RT_I64i;
+    break;
+  case IC_TO_F64:
+    rpn->ic_class = HashFind("F64", Fs->hash_table, HTT_CLASS, 1);
+    return rpn->raw_type = RT_F64;
+    break;
+  case IC_TYPECAST:
+    return rpn->raw_type = rpn->ic_class->raw_type;
+    break;
+  case __IC_CALL:
+    rpn = orig_rpn->base.next;
+    for (arg = 0; arg != orig_rpn->length + 1; arg++) {
+      if (rpn->type != IC_NOP)
+        AssignRawTypeToNode(ccmp, rpn);
+      rpn = ICFwd(rpn);
+    }
+    return rpn->raw_type = rpn->ic_class;
+  case IC_CALL:
+    rpn = orig_rpn->base.next;
+    for (arg = 0; arg != orig_rpn->length; arg++) {
+      if (rpn->type != IC_NOP)
+        AssignRawTypeToNode(ccmp, rpn);
+      rpn = ICFwd(rpn);
+    }
+    if (RT_PTR == AssignRawTypeToNode(ccmp, rpn)) {
+      if (rpn->ic_class->ptr_star_cnt > 1)
+        ParseErr(ccmp, "Can't call this pointer."); // TODO add type name
+    }
+    fun = rpn->ic_fun;
+  got_fun:
+    if (!fun)
+      ParseErr(ccmp, "Invalid type to call."); // TODO add type name
+    if (arg > fun->argc && !(fun->base.flags & CLSF_VARGS)) {
+      ParseErr(ccmp, "Excess arguments for function");
+    }
+    mlst = fun->base.members_lst;
+    rpn = orig_rpn->base.next;
+    for (arg = 0; arg != orig_rpn->length; arg++) {
+      if (arg >= fun->argc)
+        break;
+      rpn = ICArgN(orig_rpn, orig_rpn->length - arg - 1);
+      if (rpn->type == IC_NOP)
+        if (!(mlst->flags & MLF_DFT_AVAILABLE)) {
+          ParseErr(ccmp, "No default value for argument %d.", arg);
+        }
+      mlst = mlst->next;
+    }
+    for (; arg < fun->argc; arg++) {
+      if (fun->base.flags & CLSF_VARGS && arg >= fun->argc - 2)
+        break;
+      if (!(mlst->flags & MLF_DFT_AVAILABLE)) {
+        ParseErr(ccmp, "No default value for argument %d.", arg);
+      }
+      mlst = mlst->next;
+    }
+    orig_rpn->ic_class = fun->return_class;
+    orig_rpn->ic_dim = NULL;
+    orig_rpn->raw_type = orig_rpn->ic_class->raw_type;
+    break;
+  case IC_COMMA:
+    AssignRawTypeToNode(ccmp, rpn->base.next);
+    AssignRawTypeToNode(ccmp, ICFwd(rpn->base.next));
+    rpn->ic_class = ((CRPN *)rpn->base.next)->ic_class;
+    rpn->ic_dim = ((CRPN *)rpn->base.next)->ic_dim;
+    rpn->ic_fun = ((CRPN *)rpn->base.next)->ic_fun;
+    return rpn->raw_type = ((CRPN *)rpn->base.next)->raw_type;
+    break;
+  case IC_GLOBAL:
+    if (rpn->global_var->base.type & HTT_GLBL_VAR) {
+      rpn->ic_class = rpn->global_var->var_class;
+      rpn->ic_dim = rpn->global_var->dim.next;
+      rpn->ic_fun = rpn->global_var->fun_ptr;
+      return rpn->raw_type = rpn->ic_class->raw_type;
+    } else if (rpn->global_var->base.type & HTT_FUN) {
+      fun = rpn->global_var;
+      rpn->ic_class = &fun->base;
+      rpn->ic_dim = NULL;
+      rpn->ic_fun = fun;
+      return RT_FUNC;
+    }
+    abort();
+    break;
+  case IC_LOCAL:
+    rpn->ic_class = rpn->local_mem->member_class;
+    rpn->ic_dim = rpn->local_mem->dim.next;
+    rpn->ic_fun = rpn->local_mem->fun_ptr;
+    return rpn->raw_type = rpn->ic_class->raw_type;
+    break;
+  case IC_NEG:
+  unop:
+    AssignRawTypeToNode(ccmp, rpn->base.next);
+    if (BETWEEN(((CRPN *)rpn->base.next)->raw_type, RT_I8i, RT_U32i)) {
+      // Promote to 64bit
+      rpn->raw_type = RT_I64i;
+    } else {
+      rpn->raw_type = ((CRPN *)rpn->base.next)->raw_type;
+      rpn->ic_class = ((CRPN *)rpn->base.next)->ic_class;
+      rpn->ic_fun = ((CRPN *)rpn->base.next)->ic_fun;
+      rpn->ic_dim = NULL;
+    }
+    goto ret;
+    break;
+  case IC_POS:
+    goto unop;
+    break;
+  case IC_NAME:
+    abort();
+    break;
+  case IC_STR:
+    rpn->raw_type = RT_PTR;
+    goto ret;
+    break;
+  case IC_CHR:
+    rpn->raw_type = RT_U64i;
+    goto ret;
+    break;
+  case IC_POW:
+    rpn->raw_type = RT_F64;
+    goto ret;
+    break;
+  case IC_ADD:
+    a = AssignRawTypeToNode(ccmp, ICFwd(rpn->base.next));
+    b = AssignRawTypeToNode(ccmp, rpn->base.next);
+    if (a == RT_PTR || b == RT_PTR) {
+      if (a == RT_PTR) {
+        rpn->raw_type = RT_PTR;
+        rpn->ic_class = ICFwd(rpn->base.next)->ic_class;
+        rpn->ic_dim = ICFwd(rpn->base.next)->ic_dim;
+        rpn->ic_fun = ICFwd(rpn->base.next)->ic_fun;
+      } else {
+        rpn->raw_type = RT_PTR;
+        rpn->ic_class = ((CRPN *)rpn->base.next)->ic_class;
+        rpn->ic_fun = ((CRPN *)rpn->base.next)->ic_fun;
+        rpn->ic_dim = ((CRPN *)rpn->base.next)->ic_dim;
+      }
+      return rpn->raw_type;
+    } else if (BETWEEN(a, RT_I8i, RT_U32i) && BETWEEN(a, RT_I8i, RT_U32i)) {
+      // Promote to I64i
+      a = RT_I64i;
+    }
+    rpn->raw_type = (a > b) ? a : b;
+    goto ret;
+    break;
+  case IC_EQ:
+    goto abinop;
+    break;
+  case IC_SUB:
+    a = AssignRawTypeToNode(ccmp, ICFwd(rpn->base.next));
+    b = AssignRawTypeToNode(ccmp, rpn->base.next);
+    // PTR-idx
+    if (a == RT_PTR) {
+      rpn->raw_type = RT_PTR;
+      rpn->ic_class = ICFwd(rpn->base.next)->ic_class;
+      rpn->ic_dim = ICFwd(rpn->base.next)->ic_dim;
+      rpn->ic_fun = ICFwd(rpn->base.next)->ic_fun;
+      return rpn->raw_type;
+    } else if (BETWEEN(a, RT_I8i, RT_U32i) && BETWEEN(a, RT_I8i, RT_U32i)) {
+      // Promote to I64i
+      a = RT_I64i;
+    }
+    rpn->raw_type = (a > b) ? a : b;
+    goto ret;
+    break;
+  case IC_DIV:
+  binop:
+    a = AssignRawTypeToNode(ccmp, ICFwd(rpn->base.next));
+    b = AssignRawTypeToNode(ccmp, rpn->base.next);
+    if (BETWEEN(a, RT_I8i, RT_U32i) && BETWEEN(b, RT_I8i, RT_U32i)) {
+      // Promote to I64i
+      a = RT_I64i;
+    }
+    rpn->raw_type = (a > b) ? a : b;
+    goto ret;
+    break;
+  case IC_MUL:
+    goto binop;
+    break;
+  case IC_DEREF:
+    AssignRawTypeToNode(ccmp, rpn->base.next);
+    if (!((CRPN *)rpn->base.next)->ic_class->ptr_star_cnt) {
+      ParseErr(ccmp, "Can't derefernce a non-pointer/array.");
+      return 0;
+    }
+    rpn->ic_dim = ((CRPN *)rpn->base.next)->ic_dim;
+    rpn->ic_fun = ((CRPN *)rpn->base.next)->ic_fun;
+    if (!rpn->ic_dim)
+      goto no_dim;
+    if (!rpn->ic_dim->next) {
+    no_dim:
+      rpn->ic_class = ((CRPN *)rpn->base.next)->ic_class - 1;
+    } else {
+      rpn->ic_dim = rpn->ic_dim->next;
+    }
+    rpn->raw_type = rpn->ic_class->raw_type;
+    return rpn->raw_type;
+    break;
+  case IC_AND:
+    goto binop;
+    break;
+  case IC_DOT:
+    AssignRawTypeToNode(ccmp, rpn->base.next);
+    if (((CRPN *)rpn->base.next)->ic_class->ptr_star_cnt ||
+        ((CRPN *)rpn->base.next)->ic_dim) {
+      ParseErr(ccmp, "Must not be a pointer to use a '.' operator.");
+      return 0;
+    }
+    rpn->ic_class = rpn->local_mem->member_class;
+    rpn->ic_dim = rpn->local_mem->dim.next;
+    rpn->ic_fun = rpn->local_mem->fun_ptr;
+    return rpn->raw_type = rpn->ic_class->raw_type;
+    break;
+  case IC_ADDR_OF:
+    AssignRawTypeToNode(ccmp, rpn->base.next);
+    if (((CRPN *)rpn->base.next)->ic_class->ptr_star_cnt >= STAR_CNT) {
+      ParseErr(ccmp, "Too many pointer stars.");
+      return 0;
+    }
+    if (((CRPN *)rpn->base.next)->ic_dim) {
+      rpn->ic_class = ((CRPN *)rpn->base.next)->ic_class;
+      rpn->ic_dim = ((CRPN *)rpn->base.next)->ic_dim;
+    } else {
+      rpn->ic_class = ((CRPN *)rpn->base.next)->ic_class;
+      if (rpn->ic_class->raw_type == RT_FUNC)
+        rpn->ic_class = HashFind("U8i", Fs->hash_table, HTT_CLASS, 1);
+      rpn->ic_class++;
+    }
+    rpn->ic_fun = ((CRPN *)rpn->base.next)->ic_fun;
+    return rpn->raw_type = RT_PTR;
+    break;
+  case IC_XOR:
+    goto binop;
+    break;
+  case IC_MOD:
+    goto binop;
+    break;
+  case IC_OR:
+    goto binop;
+    break;
+  case IC_LT:
+    rpn->raw_type = RT_I64i;
+    goto ret;
+    break;
+  case IC_GT:
+    rpn->raw_type = RT_I64i;
+    goto ret;
+    break;
+  case IC_LNOT:
+    rpn->raw_type = RT_I64i;
+    goto ret;
+    break;
+  case IC_BNOT:
+    goto unop;
+    break;
+  case IC_POST_INC:
+    goto unop;
+    break;
+  case IC_POST_DEC:
+    goto unop;
+    break;
+  case IC_PRE_INC:
+    goto unop;
+    break;
+  case IC_PRE_DEC:
+    goto unop;
+    break;
+  case IC_AND_AND:
+  cmp:
+    rpn->raw_type = RT_I64i;
+    goto ret;
+    break;
+  case IC_OR_OR:
+    goto cmp;
+    break;
+  case IC_XOR_XOR:
+    goto cmp;
+    break;
+  case IC_EQ_EQ:
+    goto cmp;
+    break;
+  case IC_NE:
+    goto cmp;
+    break;
+  case IC_LE:
+    goto cmp;
+    break;
+  case IC_GE:
+    goto cmp;
+    break;
+  case IC_LSH:
+    goto binop;
+    break;
+  case IC_RSH:
+    goto binop;
+    break;
+  case IC_ADD_EQ:
+  abinop:
+    AssignRawTypeToNode(ccmp, rpn->base.next);
+    AssignRawTypeToNode(ccmp, ICFwd(rpn->base.next));
+    rpn->ic_class = ICFwd(rpn->base.next)->ic_class;
+    rpn->ic_fun = ICFwd(rpn->base.next)->ic_fun;
+    rpn->ic_dim = ICFwd(rpn->base.next)->ic_dim;
+    rpn->raw_type = rpn->ic_class->raw_type;
+    return rpn->raw_type;
+    break;
+  case IC_SUB_EQ:
+    goto abinop;
+    break;
+  case IC_MUL_EQ:
+    goto abinop;
+    break;
+  case IC_DIV_EQ:
+    goto abinop;
+    break;
+  case IC_LSH_EQ:
+    goto abinop;
+    break;
+  case IC_RSH_EQ:
+    goto abinop;
+    break;
+  case IC_AND_EQ:
+    goto abinop;
+    break;
+  case IC_OR_EQ:
+    goto abinop;
+    break;
+  case IC_XOR_EQ:
+    goto abinop;
+    break;
+  case IC_ARROW:
+    AssignRawTypeToNode(ccmp, rpn->base.next);
+    rpn->ic_class = rpn->local_mem->member_class;
+    rpn->ic_fun = rpn->local_mem->fun_ptr;
+    rpn->ic_dim = rpn->local_mem->dim.next;
+    rpn->raw_type = rpn->ic_class->raw_type;
+    return rpn->raw_type;
+    break;
+  case IC_MOD_EQ:
+    goto abinop;
+    break;
+  case IC_I64:
+    rpn->raw_type = RT_I64i;
+    goto ret;
+    break;
+  case IC_F64:
+    rpn->raw_type = RT_F64;
+    goto ret;
+    break;
+  case IC_ARRAY_ACC:
+    b = AssignRawTypeToNode(ccmp, rpn->base.next);
+    a = AssignRawTypeToNode(ccmp, ICFwd(rpn->base.next));
+    if (ICFwd(rpn->base.next)->ic_class->ptr_star_cnt == 0 &&
+        !ICFwd(rpn->base.next)->ic_dim) {
+      ParseErr(ccmp, "Expected a pointer or array type for array access.");
+      return 0;
+    }
+    if (ICFwd(rpn->base.next)->ic_dim) {
+      rpn->ic_class = ICFwd(rpn->base.next)->ic_class;
+      rpn->ic_dim = ICFwd(rpn->base.next)->ic_dim->next;
+    } else
+      rpn->ic_class = ICFwd(rpn->base.next)->ic_class - 1;
+    rpn->ic_fun = ICFwd(rpn->base.next)->ic_fun;
+    return rpn->raw_type = rpn->ic_class->raw_type;
+  }
 ret:
-	switch (rpn->raw_type) {
-		break;
-	case RT_U0:
-		name = "U0";
-		break;
-	case RT_I8i:
-		name = "I8i";
-		break;
-	case RT_U8i:
-		name = "U8i";
-		break;
-	case RT_I16i:
-		name = "I16i";
-		break;
-	case RT_U16i:
-		name = "U16i";
-		break;
-	case RT_I32i:
-		name = "I32i";
-		break;
-	case RT_U32i:
-		name = "U32i";
-		break;
-	case RT_I64i:
-		name = "I64i";
-		break;
-	case RT_U64i:
-		name = "U64i";
-		break;
-	case RT_F64:
-		name = "F64";
-		break;
-	case RT_PTR:
-		if (rpn->ic_class)
-			return rpn->raw_type;
-		else
-			name = "U8i";
-		break;
-	default:
-		return 0;
-	}
-	rpn->ic_class = HashFind(name, Fs->hash_table, HTT_CLASS, 1);
-	if (rpn->raw_type == RT_PTR)
-		rpn->ic_class++;
-	return rpn->raw_type;
+  switch (rpn->raw_type) {
+    break;
+  case RT_U0:
+    name = "U0";
+    break;
+  case RT_I8i:
+    name = "I8i";
+    break;
+  case RT_U8i:
+    name = "U8i";
+    break;
+  case RT_I16i:
+    name = "I16i";
+    break;
+  case RT_U16i:
+    name = "U16i";
+    break;
+  case RT_I32i:
+    name = "I32i";
+    break;
+  case RT_U32i:
+    name = "U32i";
+    break;
+  case RT_I64i:
+    name = "I64i";
+    break;
+  case RT_U64i:
+    name = "U64i";
+    break;
+  case RT_F64:
+    name = "F64";
+    break;
+  case RT_PTR:
+    if (rpn->ic_class)
+      return rpn->raw_type;
+    else
+      name = "U8i";
+    break;
+  default:
+    return 0;
+  }
+  rpn->ic_class = HashFind(name, Fs->hash_table, HTT_CLASS, 1);
+  if (rpn->raw_type == RT_PTR)
+    rpn->ic_class++;
+  return rpn->raw_type;
 }
 
-CHashClass* PrsClassNew()
-{
-	int64_t idx2 = 0;
-	CHashClass* cls = A_CALLOC((STAR_CNT + 1) * sizeof(CHashClass), NULL);
-	for (idx2 = 0; idx2 != STAR_CNT; idx2++) {
-		cls[idx2].base.str = NULL;
-		cls[idx2].raw_type = RT_PTR;
-		cls[idx2].ptr_star_cnt = idx2;
-		if (idx2)
-			cls[idx2].sz = 8;
-		cls[idx2].use_cnt++;
-	}
-	return cls;
+CHashClass *PrsClassNew() {
+  int64_t idx2 = 0;
+  CHashClass *cls = A_CALLOC((STAR_CNT + 1) * sizeof(CHashClass), NULL);
+  for (idx2 = 0; idx2 != STAR_CNT; idx2++) {
+    cls[idx2].base.str = NULL;
+    cls[idx2].raw_type = RT_PTR;
+    cls[idx2].ptr_star_cnt = idx2;
+    if (idx2)
+      cls[idx2].sz = 8;
+    cls[idx2].use_cnt++;
+  }
+  return cls;
 }
 
-static void PrsMembers(CCmpCtrl* cctrl, CHashClass* bungis, int64_t flags,
-	int64_t* off)
-{
-	int64_t is_func, union_end;
-	CMemberLst *last_m, *base_class;
-	union_end = *off;
-	if (cctrl->lex->cur_tok == '{') {
-		Lex(cctrl->lex);
-		for (; cctrl->lex->cur_tok != '}';) {
-			if (cctrl->lex->cur_tok == ';') {
-				Lex(cctrl->lex);
-			} else if (PrsKw(cctrl, TK_KW_UNION)) {
-				if (cctrl->lex->cur_tok == '{') {
-					PrsMembers(cctrl, bungis, flags | PRSF_UNION, off);
-				}
-			} else if (cctrl->lex->cur_tok == TK_NAME) {
-				base_class = HashFind(cctrl->lex->string, Fs->hash_table, HTT_CLASS, 1);
-				if (!base_class)
-					goto exp_member;
-				//
-				// Here's the deal,I store the last member in last_m,once I find the
-				// members I assign their offsets
-				//
-				for (last_m = bungis->members_lst; last_m; last_m = last_m->next)
-					if (!last_m->next)
-						break;
-				do {
-					Lex(cctrl->lex);
-					PrsDecl(cctrl, base_class, bungis, &is_func, PRSF_CLASS, NULL);
-				next_meta:
-					if (cctrl->lex->cur_tok == TK_NAME) {
-						// Nroot will parse the meta data but do nothing with it
-						switch (Lex(cctrl->lex)) {
-						case TK_STR:
-							while (Lex(cctrl->lex) == TK_STR)
-								;
-							if (cctrl->lex->cur_tok == ',')
-								break;
-							else
-								goto next_meta;
-						case TK_I64:
-						case TK_CHR:
+static void PrsMembers(CCmpCtrl *cctrl, CHashClass *bungis, int64_t flags,
+                       int64_t *off) {
+  int64_t is_func, union_end;
+  CMemberLst *last_m, *base_class;
+  union_end = *off;
+  if (cctrl->lex->cur_tok == '{') {
+    Lex(cctrl->lex);
+    for (; cctrl->lex->cur_tok != '}';) {
+      if (cctrl->lex->cur_tok == ';') {
+        Lex(cctrl->lex);
+      } else if (PrsKw(cctrl, TK_KW_UNION)) {
+        if (cctrl->lex->cur_tok == '{') {
+          PrsMembers(cctrl, bungis, flags | PRSF_UNION, off);
+        }
+      } else if (cctrl->lex->cur_tok == TK_NAME) {
+        base_class = HashFind(cctrl->lex->string, Fs->hash_table, HTT_CLASS, 1);
+        if (!base_class)
+          goto exp_member;
+        //
+        // Here's the deal,I store the last member in last_m,once I find the
+        // members I assign their offsets
+        //
+        for (last_m = bungis->members_lst; last_m; last_m = last_m->next)
+          if (!last_m->next)
+            break;
+        do {
+          Lex(cctrl->lex);
+          PrsDecl(cctrl, base_class, bungis, &is_func, PRSF_CLASS, NULL);
+        next_meta:
+          if (cctrl->lex->cur_tok == TK_NAME) {
+            // Nroot will parse the meta data but do nothing with it
+            switch (Lex(cctrl->lex)) {
+            case TK_STR:
+              while (Lex(cctrl->lex) == TK_STR)
+                ;
+              if (cctrl->lex->cur_tok == ',')
+                break;
+              else
+                goto next_meta;
+            case TK_I64:
+            case TK_CHR:
 
-							Lex(cctrl->lex);
-							if (cctrl->lex->cur_tok == ',')
-								break;
-							else
-								goto next_meta;
-							break;
-						default:
-							ParseErr(cctrl, "Unexpected meta-data!!!");
-						}
-					}
-				} while (cctrl->lex->cur_tok == ',');
-				if (last_m)
-					last_m = last_m->next;
-				else
-					last_m = bungis->members_lst;
-				for (; last_m; last_m = last_m->next) {
-					last_m->off = *off;
-					if (!(flags & PRSF_UNION)) {
-						*off += last_m->member_class->sz * last_m->dim.total_cnt;
-					} else {
-						if (union_end < *off + last_m->member_class->sz * last_m->dim.total_cnt) {
-							union_end = *off + last_m->member_class->sz * last_m->dim.total_cnt;
-						}
-					}
-				}
-				if (is_func)
-					goto exp_member;
-			} else {
-			exp_member:
-				ParseErr(cctrl, "Expected a member.");
-				return;
-			}
-		}
-		Lex(cctrl->lex);
-	}
-	if (flags & PRSF_UNION)
-		*off = union_end;
+              Lex(cctrl->lex);
+              if (cctrl->lex->cur_tok == ',')
+                break;
+              else
+                goto next_meta;
+              break;
+            default:
+              ParseErr(cctrl, "Unexpected meta-data!!!");
+            }
+          }
+        } while (cctrl->lex->cur_tok == ',');
+        if (last_m)
+          last_m = last_m->next;
+        else
+          last_m = bungis->members_lst;
+        for (; last_m; last_m = last_m->next) {
+          last_m->off = *off;
+          if (!(flags & PRSF_UNION)) {
+            *off += last_m->member_class->sz * last_m->dim.total_cnt;
+          } else {
+            if (union_end <
+                *off + last_m->member_class->sz * last_m->dim.total_cnt) {
+              union_end =
+                  *off + last_m->member_class->sz * last_m->dim.total_cnt;
+            }
+          }
+        }
+        if (is_func)
+          goto exp_member;
+      } else {
+      exp_member:
+        ParseErr(cctrl, "Expected a member.");
+        return;
+      }
+    }
+    Lex(cctrl->lex);
+  }
+  if (flags & PRSF_UNION)
+    *off = union_end;
 }
 
-CHashClass* PrsClass(CCmpCtrl* cctrl, int64_t _flags)
-{
-	CHashClass *bungis, *base_class;
-	CMemberLst* last_m;
-	int64_t flags = PRSF_CLASS;
-	int64_t is_func, off = 0, sz, add = 0;
-	if (!PrsKw(cctrl, TK_KW_CLASS)) {
-		if (PrsKw(cctrl, TK_KW_UNION))
-			flags |= PRSF_UNION;
-		else
-			return NULL;
-	}
-	if (cctrl->lex->cur_tok == TK_NAME) {
-		if (bungis = HashSingleTableFind(cctrl->lex->string, Fs->hash_table, HTT_CLASS, 1)) {
-			if (bungis->base.type & HTF_EXTERN) {
-				// We can fill in the extern class
-			} else {
-				bungis = NULL;
-			}
-		}
-		if (!bungis) {
-			bungis = PrsClassNew();
-			add = 1;
-		}
-		if (!bungis->base.str)
-			bungis->base.str = A_STRDUP(cctrl->lex->string, NULL);
-		bungis->base.type = HTT_CLASS;
-		if (_flags & PRSF_EXTERN)
-			bungis->base.type |= HTF_EXTERN;
-		bungis->src_link = LexSrcLink(cctrl->lex, NULL);
-		Lex(cctrl->lex);
-	} else {
-		ParseErr(cctrl, "Expected a class name.");
-	}
-	if (cctrl->lex->cur_tok == ':') {
-		Lex(cctrl->lex);
-		if (cctrl->lex->cur_tok != TK_NAME) {
-		want_inher:
-			ParseErr(cctrl, "Expected a class to inherit from.");
-			return NULL;
-		} else if (!(base_class = HashFind(cctrl->lex->string, Fs->hash_table,
-						 HTT_CLASS, 1)))
-			goto want_inher;
-		bungis->base_class = base_class;
-		off = bungis->sz += base_class->sz;
-		Lex(cctrl->lex);
-	}
-	if (bungis && add)
-		if (bungis->base.str && !bungis->base.next) // If we dont have  a next item in the chain,I would suppose we arent in a hashtable
-			HashAdd(bungis, Fs->hash_table);
-	PrsMembers(cctrl, bungis, flags, &off); // This consumes '{'
-	// Compute size
-	for (last_m = bungis->members_lst; last_m; last_m = last_m->next) {
-		if (bungis->sz < (off = last_m->off + last_m->member_class->sz * last_m->dim.total_cnt)) {
-			bungis->sz = off;
-		}
-	}
-	return bungis;
+CHashClass *PrsClass(CCmpCtrl *cctrl, int64_t _flags) {
+  CHashClass *bungis, *base_class;
+  CMemberLst *last_m;
+  int64_t flags = PRSF_CLASS;
+  int64_t is_func, off = 0, sz, add = 0;
+  if (!PrsKw(cctrl, TK_KW_CLASS)) {
+    if (PrsKw(cctrl, TK_KW_UNION))
+      flags |= PRSF_UNION;
+    else
+      return NULL;
+  }
+  if (cctrl->lex->cur_tok == TK_NAME) {
+    if (bungis = HashSingleTableFind(cctrl->lex->string, Fs->hash_table,
+                                     HTT_CLASS, 1)) {
+      if (bungis->base.type & HTF_EXTERN) {
+        // We can fill in the extern class
+      } else {
+        bungis = NULL;
+      }
+    }
+    if (!bungis) {
+      bungis = PrsClassNew();
+      add = 1;
+    }
+    if (!bungis->base.str)
+      bungis->base.str = A_STRDUP(cctrl->lex->string, NULL);
+    bungis->base.type = HTT_CLASS;
+    if (_flags & PRSF_EXTERN)
+      bungis->base.type |= HTF_EXTERN;
+    bungis->src_link = LexSrcLink(cctrl->lex, NULL);
+    Lex(cctrl->lex);
+  } else {
+    ParseErr(cctrl, "Expected a class name.");
+  }
+  if (cctrl->lex->cur_tok == ':') {
+    Lex(cctrl->lex);
+    if (cctrl->lex->cur_tok != TK_NAME) {
+    want_inher:
+      ParseErr(cctrl, "Expected a class to inherit from.");
+      return NULL;
+    } else if (!(base_class = HashFind(cctrl->lex->string, Fs->hash_table,
+                                       HTT_CLASS, 1)))
+      goto want_inher;
+    bungis->base_class = base_class;
+    off = bungis->sz += base_class->sz;
+    Lex(cctrl->lex);
+  }
+  if (bungis && add)
+    if (bungis->base.str &&
+        !bungis->base.next) // If we dont have  a next item in the chain,I would
+                            // suppose we arent in a hashtable
+      HashAdd(bungis, Fs->hash_table);
+  PrsMembers(cctrl, bungis, flags, &off); // This consumes '{'
+  // Compute size
+  for (last_m = bungis->members_lst; last_m; last_m = last_m->next) {
+    if (bungis->sz < (off = last_m->off +
+                            last_m->member_class->sz * last_m->dim.total_cnt)) {
+      bungis->sz = off;
+    }
+  }
+  return bungis;
 }
 
-void ICFree(CRPN* ic)
-{
-	QueRem(ic);
-	A_FREE(ic);
+void ICFree(CRPN *ic) {
+  QueRem(ic);
+  A_FREE(ic);
 }
 
-int64_t PrsReturn(CCmpCtrl* ccmp)
-{ // YES
-	if (!PrsKw(ccmp, TK_KW_RETURN))
-		return 0;
-	CRPN *ret = A_CALLOC(sizeof(CRPN), 0), *ic;
-	ret->type = IC_RET;
-	if (!ccmp->cur_fun)
-		ParseErr(ccmp, "Unexpected return(not in function).");
-	if (ccmp->lex->cur_tok == ';') {
-		if (ccmp->cur_fun->return_class->raw_type != RT_U0)
-			ParseWarn(ccmp, "Empty return in non-U0 function.");
-		ic = A_CALLOC(sizeof(CRPN), 0);
-		ic->type = IC_I64;
-		ic->integer = 0;
-		QueIns(ic, ccmp->code_ctrl->ir_code);
-		QueIns(ret, ccmp->code_ctrl->ir_code);
-		Lex(ccmp->lex);
-		return 1;
-	}
-	ParseExpr(ccmp, 0);
-	if ((ccmp->cur_fun->return_class->raw_type == RT_F64) // Check if they are not the same
-		^ (AssignRawTypeToNode(ccmp, ccmp->code_ctrl->ir_code->next) == RT_F64)) {
-		if (ccmp->cur_fun->return_class->raw_type == RT_F64) {
-			ic = A_CALLOC(sizeof(CRPN), 0);
-			ic->type = IC_TO_F64;
-			QueIns(ic, ccmp->code_ctrl->ir_code);
-		} else {
-			ic = A_CALLOC(sizeof(CRPN), 0);
-			ic->type = IC_TO_I64;
-			QueIns(ic, ccmp->code_ctrl->ir_code);
-		}
-	}
-	QueIns(ret, ccmp->code_ctrl->ir_code);
-	if (ccmp->lex->cur_tok != ';')
-		ParseErr(ccmp, "Expected a ';'");
-	Lex(ccmp->lex);
-	return 1;
+int64_t PrsReturn(CCmpCtrl *ccmp) { // YES
+  if (!PrsKw(ccmp, TK_KW_RETURN))
+    return 0;
+  CRPN *ret = A_CALLOC(sizeof(CRPN), 0), *ic;
+  ret->type = IC_RET;
+  if (!ccmp->cur_fun)
+    ParseErr(ccmp, "Unexpected return(not in function).");
+  if (ccmp->lex->cur_tok == ';') {
+    if (ccmp->cur_fun->return_class->raw_type != RT_U0)
+      ParseWarn(ccmp, "Empty return in non-U0 function.");
+    ic = A_CALLOC(sizeof(CRPN), 0);
+    ic->type = IC_I64;
+    ic->integer = 0;
+    QueIns(ic, ccmp->code_ctrl->ir_code);
+    QueIns(ret, ccmp->code_ctrl->ir_code);
+    Lex(ccmp->lex);
+    return 1;
+  }
+  ParseExpr(ccmp, 0);
+  if ((ccmp->cur_fun->return_class->raw_type ==
+       RT_F64) // Check if they are not the same
+      ^ (AssignRawTypeToNode(ccmp, ccmp->code_ctrl->ir_code->next) == RT_F64)) {
+    if (ccmp->cur_fun->return_class->raw_type == RT_F64) {
+      ic = A_CALLOC(sizeof(CRPN), 0);
+      ic->type = IC_TO_F64;
+      QueIns(ic, ccmp->code_ctrl->ir_code);
+    } else {
+      ic = A_CALLOC(sizeof(CRPN), 0);
+      ic->type = IC_TO_I64;
+      QueIns(ic, ccmp->code_ctrl->ir_code);
+    }
+  }
+  QueIns(ret, ccmp->code_ctrl->ir_code);
+  if (ccmp->lex->cur_tok != ';')
+    ParseErr(ccmp, "Expected a ';'");
+  Lex(ccmp->lex);
+  return 1;
 }
 typedef struct CSubSwitch {
-	CQue base;
-	CCodeMisc *lb_start, *lb_exit;
-	CCodeMisc* prev_break_to;
+  CQue base;
+  CCodeMisc *lb_start, *lb_exit;
+  CCodeMisc *prev_break_to;
 } CSubSwitch;
 typedef struct CSwitchCase {
-	struct CSwitchCase* next;
-	int64_t val;
-	CCodeMisc* label;
+  struct CSwitchCase *next;
+  int64_t val;
+  CCodeMisc *label;
 } CSwitchCase;
-int64_t PrsSwitch(CCmpCtrl* cctrl)
-{
-	if (!PrsKw(cctrl, TK_KW_SWITCH))
-		return 0;
-	int64_t old_flags = cctrl->flags;
-	CRPN *tmpir, *label, *switch_ir;
-	CSwitchCase *header = NULL, *tmps;
-	CSubSwitch subs, *tmpss;
-	CCodeMisc *lb_dft = CodeMiscNew(cctrl, CMT_LABEL),
-			  *lb_exit = CodeMiscNew(cctrl, CMT_LABEL), *old_break_to, *jmp_tab;
-	int64_t k_low = INT_MAX, k_hi = INT_MIN, last, lo, hi, idx;
-	old_break_to = cctrl->code_ctrl->break_to;
-	cctrl->code_ctrl->break_to = lb_exit;
-	//
-	// When we encounter the start: block,we enter a secret function call
-	// So when we `break` or we implictly break by hitting the first sub-switch
-	// case,we return
-	//
-	// in_start_code is set when he enter a a subswitch,and is set until we hit
-	// the first case while in_start_code,break's will trigger a return(so will
-	// hitting the first case)
-	//
-	//
-	int64_t in_start_code = 0;
-	last = k_low;
-	QueInit(&subs);
-	if (cctrl->lex->cur_tok == '[') {
-		Lex(cctrl->lex);
-		//
-		// Eat your wheaties because you are playing with the power of
-		// unbounded switches
-		//
-		if (!ParseExpr(cctrl, 0)) {
-			ParseErr(cctrl, "Expected an expression.");
-			return 0;
-		}
-		switch_ir = A_CALLOC(sizeof(CRPN), NULL);
-		switch_ir->type = IC_UNBOUNDED_SWITCH;
-		QueIns(switch_ir, cctrl->code_ctrl->ir_code);
-		if (cctrl->lex->cur_tok != ']') {
-			ParseErr(cctrl, "Expected a ']'.");
-			return 0;
-		} else
-			Lex(cctrl->lex);
-	} else if (cctrl->lex->cur_tok == '(') {
-		Lex(cctrl->lex);
-		if (!ParseExpr(cctrl, 0)) {
-			ParseErr(cctrl, "Expected an expression.");
-			return 0;
-		}
-		switch_ir = A_CALLOC(sizeof(CRPN), NULL);
-		switch_ir->type = IC_BOUNDED_SWITCH;
-		QueIns(switch_ir, cctrl->code_ctrl->ir_code);
-		// IR will be in reverse polish notation
-		// start,(cond),end,BOUNDED_SWITCH
-		if (cctrl->lex->cur_tok != ')') {
-			ParseErr(cctrl, "Expected a ')'.");
-			return 0;
-		} else
-			Lex(cctrl->lex);
-	}
-	if (cctrl->lex->cur_tok != '{') {
-		ParseErr(cctrl, "Expected a '{'.");
-		return 0;
-	} else
-		Lex(cctrl->lex);
-	while (cctrl->lex->cur_tok != '}') {
-		if (PrsKw(cctrl, TK_KW_CASE)) {
-			//
-			// Subswitchs IC_SUB_CALL the CSubSwitch.lb_start label,
-			// If are IN the start block,we IC_SUB_RET to return back to
-			// the case
-			//
-			// start:
-			// (IC_SUB_PROLOG) <===== ((CSubSwitch*)subs.base.last)->code_misc;
-			//    START-BLOCK
-			// (IC_SUB_RET)
-			// case 0xb00bie5: //My holy ears were burning,ok
-			// (IC_SUB_CALL) ->code_misc=((CSubSwitch*)subs.base.last)->code_misc
-			//
-			if (cctrl->flags & CCF_IN_SUBSWITCH_START_BLOCK) {
-				tmpir = A_CALLOC(sizeof(CRPN), NULL);
-				tmpir->type = IC_SUB_RET;
-				QueIns(tmpir, cctrl->code_ctrl->ir_code);
-				switch_ir->length++;
-				cctrl->flags &= ~CCF_IN_SUBSWITCH_START_BLOCK;
-			}
+int64_t PrsSwitch(CCmpCtrl *cctrl) {
+  if (!PrsKw(cctrl, TK_KW_SWITCH))
+    return 0;
+  int64_t old_flags = cctrl->flags;
+  CRPN *tmpir, *label, *switch_ir;
+  CSwitchCase *header = NULL, *tmps;
+  CSubSwitch subs, *tmpss;
+  CCodeMisc *lb_dft = CodeMiscNew(cctrl, CMT_LABEL),
+            *lb_exit = CodeMiscNew(cctrl, CMT_LABEL), *old_break_to, *jmp_tab;
+  int64_t k_low = INT_MAX, k_hi = INT_MIN, last, lo, hi, idx;
+  old_break_to = cctrl->code_ctrl->break_to;
+  cctrl->code_ctrl->break_to = lb_exit;
+  //
+  // When we encounter the start: block,we enter a secret function call
+  // So when we `break` or we implictly break by hitting the first sub-switch
+  // case,we return
+  //
+  // in_start_code is set when he enter a a subswitch,and is set until we hit
+  // the first case while in_start_code,break's will trigger a return(so will
+  // hitting the first case)
+  //
+  //
+  int64_t in_start_code = 0;
+  last = k_low;
+  QueInit(&subs);
+  if (cctrl->lex->cur_tok == '[') {
+    Lex(cctrl->lex);
+    //
+    // Eat your wheaties because you are playing with the power of
+    // unbounded switches
+    //
+    if (!ParseExpr(cctrl, 0)) {
+      ParseErr(cctrl, "Expected an expression.");
+      return 0;
+    }
+    switch_ir = A_CALLOC(sizeof(CRPN), NULL);
+    switch_ir->type = IC_UNBOUNDED_SWITCH;
+    QueIns(switch_ir, cctrl->code_ctrl->ir_code);
+    if (cctrl->lex->cur_tok != ']') {
+      ParseErr(cctrl, "Expected a ']'.");
+      return 0;
+    } else
+      Lex(cctrl->lex);
+  } else if (cctrl->lex->cur_tok == '(') {
+    Lex(cctrl->lex);
+    if (!ParseExpr(cctrl, 0)) {
+      ParseErr(cctrl, "Expected an expression.");
+      return 0;
+    }
+    switch_ir = A_CALLOC(sizeof(CRPN), NULL);
+    switch_ir->type = IC_BOUNDED_SWITCH;
+    QueIns(switch_ir, cctrl->code_ctrl->ir_code);
+    // IR will be in reverse polish notation
+    // start,(cond),end,BOUNDED_SWITCH
+    if (cctrl->lex->cur_tok != ')') {
+      ParseErr(cctrl, "Expected a ')'.");
+      return 0;
+    } else
+      Lex(cctrl->lex);
+  }
+  if (cctrl->lex->cur_tok != '{') {
+    ParseErr(cctrl, "Expected a '{'.");
+    return 0;
+  } else
+    Lex(cctrl->lex);
+  while (cctrl->lex->cur_tok != '}') {
+    if (PrsKw(cctrl, TK_KW_CASE)) {
+      //
+      // Subswitchs IC_SUB_CALL the CSubSwitch.lb_start label,
+      // If are IN the start block,we IC_SUB_RET to return back to
+      // the case
+      //
+      // start:
+      // (IC_SUB_PROLOG) <===== ((CSubSwitch*)subs.base.last)->code_misc;
+      //    START-BLOCK
+      // (IC_SUB_RET)
+      // case 0xb00bie5: //My holy ears were burning,ok
+      // (IC_SUB_CALL) ->code_misc=((CSubSwitch*)subs.base.last)->code_misc
+      //
+      if (cctrl->flags & CCF_IN_SUBSWITCH_START_BLOCK) {
+        tmpir = A_CALLOC(sizeof(CRPN), NULL);
+        tmpir->type = IC_SUB_RET;
+        QueIns(tmpir, cctrl->code_ctrl->ir_code);
+        switch_ir->length++;
+        cctrl->flags &= ~CCF_IN_SUBSWITCH_START_BLOCK;
+      }
 
-			// Make a label
-			label = A_CALLOC(sizeof(CRPN), NULL);
-			label->type = IC_LABEL;
-			label->code_misc = CodeMiscNew(cctrl, CMT_LABEL);
-			QueIns(label, cctrl->code_ctrl->ir_code);
-			// There is a subswitch if the last item in the CQue doesnt point to
-			// itself
-			if (&subs != (tmpss = subs.base.last)) {
-				tmpir = A_CALLOC(sizeof(CRPN), NULL);
-				tmpir->type = IC_SUB_CALL;
-				tmpir->code_misc = tmpss->lb_start;
-				QueIns(tmpir, cctrl->code_ctrl->ir_code);
-			}
-			tmps = A_MALLOC(sizeof(CSwitchCase), NULL);
-#define INS_TMPSS            \
-	{                        \
-		tmps->next = header; \
-		header = tmps;       \
-	}
-			tmps->label = label->code_misc;
-			if (cctrl->lex->cur_tok == ':') {
-				if (k_low == INT_MIN)
-					tmps->val = k_low = 0;
-				else
-					tmps->val = last++;
-			} else {
-				lo = last = tmps->val = PrsI64(cctrl);
-				if (lo < k_low)
-					k_low = lo;
-				if (lo > k_hi)
-					k_hi = lo;
-				if (cctrl->lex->cur_tok == TK_DOT_DOT_DOT) {
-					Lex(cctrl->lex);
-					hi = PrsI64(cctrl);
-					if (hi < k_low)
-						k_low = hi;
-					if (hi > k_hi)
-						k_hi = hi;
-					INS_TMPSS;
-					for (lo = lo + 1; lo <= hi; lo++) {
-						tmps = A_MALLOC(sizeof(CSwitchCase), NULL);
-						last = tmps->val = lo;
-						tmps->label = label->code_misc;
-						INS_TMPSS;
-					}
-					last++;
-				} else {
-					hi = lo;
-					INS_TMPSS;
-				}
-				if (cctrl->lex->cur_tok == ':') {
-					Lex(cctrl->lex);
-				} else {
-					ParseErr(cctrl, "Expected a ':'.");
-					return 0;
-				}
-			}
-			goto add_stmt;
-		} else if (PrsKw(cctrl, TK_KW_DEFUALT)) {
-			if (lb_dft->flags & CMF_DEFINED) {
-				ParseErr(cctrl, "Repeat default in switch!");
-			}
-			if (cctrl->lex->cur_tok != ':') {
-				ParseErr(cctrl, "Expected a ':'.");
-				return 0;
-			}
-			lb_dft->flags |= CMF_DEFINED;
-			Lex(cctrl->lex);
-			// We provide a IC_NOP as label's consume a statemnet
-			tmpir = A_CALLOC(sizeof(CRPN), NULL);
-			tmpir->type = IC_NOP;
-			QueIns(tmpir, cctrl->code_ctrl->ir_code);
-			// Make a start label(IC_LABEL consumed the next ir)
-			label = A_CALLOC(sizeof(CRPN), NULL);
-			label->type = IC_LABEL;
-			label->code_misc = lb_dft; // See me
-			QueIns(label, cctrl->code_ctrl->ir_code);
-			goto add_stmt;
-		} else if (PrsKw(cctrl, TK_KW_START)) {
-			if (cctrl->lex->cur_tok != ':') {
-				ParseErr(cctrl, "Expected a ':'.");
-				return 0;
-			} else
-				Lex(cctrl->lex);
-			cctrl->flags |= CCF_IN_SUBSWITCH_START_BLOCK;
-			tmpss = A_CALLOC(sizeof(CSubSwitch), NULL);
-			tmpss->prev_break_to = cctrl->code_ctrl->break_to;
-			tmpss->lb_exit = CodeMiscNew(cctrl, CMT_LABEL);
-			QueIns(tmpss, subs.base.last);
-			// set cctrl->code_ctrl->break_to to the exit of the subswitch
-			cctrl->code_ctrl->break_to = tmpss->lb_exit;
-			tmpir = A_CALLOC(sizeof(CRPN), NULL);
-			tmpir->type = IC_SUB_PROLOG;
-			QueIns(tmpir, cctrl->code_ctrl->ir_code);
-			// Make a start label(IC_LABEL consumed the next ir)
-			label = A_CALLOC(sizeof(CRPN), NULL);
-			label->type = IC_LABEL;
-			tmpss->lb_start = label->code_misc = CodeMiscNew(cctrl, CMT_LABEL);
-			QueIns(label, cctrl->code_ctrl->ir_code);
-			// look here
-			in_start_code = 1;
-		add_stmt:
-			switch_ir->length++;
-			continue;
-		} else if (PrsKw(cctrl, TK_KW_END)) {
-			if (subs.base.last == &subs) {
-				ParseErr(cctrl, "Unexpected 'end' statement.");
-				return 0;
-			}
-			QueRem(tmpss = subs.base.last);
-			// We provide a IC_NOP as label's consume a statemnet
-			tmpir = A_CALLOC(sizeof(CRPN), NULL);
-			tmpir->type = IC_NOP;
-			QueIns(tmpir, cctrl->code_ctrl->ir_code);
-			// Make a end label
-			label = A_CALLOC(sizeof(CRPN), NULL);
-			label->type = IC_LABEL;
-			label->code_misc = tmpss->lb_exit;
-			QueIns(label, cctrl->code_ctrl->ir_code);
-			cctrl->code_ctrl->break_to = tmpss->prev_break_to;
-			A_FREE(tmpss);
-			if (cctrl->lex->cur_tok != ':') {
-				ParseErr(cctrl, "Expected a ':'.");
-				return 0;
-			} else
-				Lex(cctrl->lex);
-			goto add_stmt;
-		} else if (PrsStmt(cctrl)) {
-			goto add_stmt;
-		} else {
-			ParseErr(cctrl, "Expected a statement.");
-			return 0;
-		}
-	}
+      // Make a label
+      label = A_CALLOC(sizeof(CRPN), NULL);
+      label->type = IC_LABEL;
+      label->code_misc = CodeMiscNew(cctrl, CMT_LABEL);
+      QueIns(label, cctrl->code_ctrl->ir_code);
+      // There is a subswitch if the last item in the CQue doesnt point to
+      // itself
+      if (&subs != (tmpss = subs.base.last)) {
+        tmpir = A_CALLOC(sizeof(CRPN), NULL);
+        tmpir->type = IC_SUB_CALL;
+        tmpir->code_misc = tmpss->lb_start;
+        QueIns(tmpir, cctrl->code_ctrl->ir_code);
+      }
+      tmps = A_MALLOC(sizeof(CSwitchCase), NULL);
+#define INS_TMPSS                                                              \
+  {                                                                            \
+    tmps->next = header;                                                       \
+    header = tmps;                                                             \
+  }
+      tmps->label = label->code_misc;
+      if (cctrl->lex->cur_tok == ':') {
+        if (k_low == INT_MIN)
+          tmps->val = k_low = 0;
+        else
+          tmps->val = last++;
+      } else {
+        lo = last = tmps->val = PrsI64(cctrl);
+        if (lo < k_low)
+          k_low = lo;
+        if (lo > k_hi)
+          k_hi = lo;
+        if (cctrl->lex->cur_tok == TK_DOT_DOT_DOT) {
+          Lex(cctrl->lex);
+          hi = PrsI64(cctrl);
+          if (hi < k_low)
+            k_low = hi;
+          if (hi > k_hi)
+            k_hi = hi;
+          INS_TMPSS;
+          for (lo = lo + 1; lo <= hi; lo++) {
+            tmps = A_MALLOC(sizeof(CSwitchCase), NULL);
+            last = tmps->val = lo;
+            tmps->label = label->code_misc;
+            INS_TMPSS;
+          }
+          last++;
+        } else {
+          hi = lo;
+          INS_TMPSS;
+        }
+        if (cctrl->lex->cur_tok == ':') {
+          Lex(cctrl->lex);
+        } else {
+          ParseErr(cctrl, "Expected a ':'.");
+          return 0;
+        }
+      }
+      goto add_stmt;
+    } else if (PrsKw(cctrl, TK_KW_DEFUALT)) {
+      if (lb_dft->flags & CMF_DEFINED) {
+        ParseErr(cctrl, "Repeat default in switch!");
+      }
+      if (cctrl->lex->cur_tok != ':') {
+        ParseErr(cctrl, "Expected a ':'.");
+        return 0;
+      }
+      lb_dft->flags |= CMF_DEFINED;
+      Lex(cctrl->lex);
+      // We provide a IC_NOP as label's consume a statemnet
+      tmpir = A_CALLOC(sizeof(CRPN), NULL);
+      tmpir->type = IC_NOP;
+      QueIns(tmpir, cctrl->code_ctrl->ir_code);
+      // Make a start label(IC_LABEL consumed the next ir)
+      label = A_CALLOC(sizeof(CRPN), NULL);
+      label->type = IC_LABEL;
+      label->code_misc = lb_dft; // See me
+      QueIns(label, cctrl->code_ctrl->ir_code);
+      goto add_stmt;
+    } else if (PrsKw(cctrl, TK_KW_START)) {
+      if (cctrl->lex->cur_tok != ':') {
+        ParseErr(cctrl, "Expected a ':'.");
+        return 0;
+      } else
+        Lex(cctrl->lex);
+      cctrl->flags |= CCF_IN_SUBSWITCH_START_BLOCK;
+      tmpss = A_CALLOC(sizeof(CSubSwitch), NULL);
+      tmpss->prev_break_to = cctrl->code_ctrl->break_to;
+      tmpss->lb_exit = CodeMiscNew(cctrl, CMT_LABEL);
+      QueIns(tmpss, subs.base.last);
+      // set cctrl->code_ctrl->break_to to the exit of the subswitch
+      cctrl->code_ctrl->break_to = tmpss->lb_exit;
+      tmpir = A_CALLOC(sizeof(CRPN), NULL);
+      tmpir->type = IC_SUB_PROLOG;
+      QueIns(tmpir, cctrl->code_ctrl->ir_code);
+      // Make a start label(IC_LABEL consumed the next ir)
+      label = A_CALLOC(sizeof(CRPN), NULL);
+      label->type = IC_LABEL;
+      tmpss->lb_start = label->code_misc = CodeMiscNew(cctrl, CMT_LABEL);
+      QueIns(label, cctrl->code_ctrl->ir_code);
+      // look here
+      in_start_code = 1;
+    add_stmt:
+      switch_ir->length++;
+      continue;
+    } else if (PrsKw(cctrl, TK_KW_END)) {
+      if (subs.base.last == &subs) {
+        ParseErr(cctrl, "Unexpected 'end' statement.");
+        return 0;
+      }
+      QueRem(tmpss = subs.base.last);
+      // We provide a IC_NOP as label's consume a statemnet
+      tmpir = A_CALLOC(sizeof(CRPN), NULL);
+      tmpir->type = IC_NOP;
+      QueIns(tmpir, cctrl->code_ctrl->ir_code);
+      // Make a end label
+      label = A_CALLOC(sizeof(CRPN), NULL);
+      label->type = IC_LABEL;
+      label->code_misc = tmpss->lb_exit;
+      QueIns(label, cctrl->code_ctrl->ir_code);
+      cctrl->code_ctrl->break_to = tmpss->prev_break_to;
+      A_FREE(tmpss);
+      if (cctrl->lex->cur_tok != ':') {
+        ParseErr(cctrl, "Expected a ':'.");
+        return 0;
+      } else
+        Lex(cctrl->lex);
+      goto add_stmt;
+    } else if (PrsStmt(cctrl)) {
+      goto add_stmt;
+    } else {
+      ParseErr(cctrl, "Expected a statement.");
+      return 0;
+    }
+  }
 ret:
-	if (!(lb_dft->flags & CMF_DEFINED)) {
-		// Make a end label
-		label = A_CALLOC(sizeof(CRPN), NULL);
-		label->type = IC_LABEL;
-		lb_dft = label->code_misc = CodeMiscNew(cctrl, CMT_LABEL);
-		QueIns(label, cctrl->code_ctrl->ir_code);
-		switch_ir->length++;
-	}
-	// Define lb_exit
-	// Make a end label
-	label = A_CALLOC(sizeof(CRPN), NULL);
-	label->type = IC_LABEL;
-	label->code_misc = lb_exit;
-	QueIns(label, cctrl->code_ctrl->ir_code);
-	switch_ir->length++;
+  if (!(lb_dft->flags & CMF_DEFINED)) {
+    // Make a end label
+    label = A_CALLOC(sizeof(CRPN), NULL);
+    label->type = IC_LABEL;
+    lb_dft = label->code_misc = CodeMiscNew(cctrl, CMT_LABEL);
+    QueIns(label, cctrl->code_ctrl->ir_code);
+    switch_ir->length++;
+  }
+  // Define lb_exit
+  // Make a end label
+  label = A_CALLOC(sizeof(CRPN), NULL);
+  label->type = IC_LABEL;
+  label->code_misc = lb_exit;
+  QueIns(label, cctrl->code_ctrl->ir_code);
+  switch_ir->length++;
 
-	Lex(cctrl->lex);
-	cctrl->code_ctrl->break_to = old_break_to;
-	if (header) {
-	gen_tab:
-		jmp_tab = CodeMiscNew(cctrl, CMT_JMP_TAB);
-		jmp_tab->jmp_tab = A_CALLOC((k_hi - k_low + 1) * sizeof(CCodeMisc*), NULL);
-		for (; header;) {
-			tmps = header->next;
-			jmp_tab->jmp_tab[header->val - k_low] = header->label;
-			A_FREE(header);
-			header = tmps;
-		}
-		jmp_tab->dft_lab = lb_dft;
-		jmp_tab->lo = k_low;
-		jmp_tab->hi = k_hi;
-		// Fill in the NULL's with default
-		for (idx = k_low; idx <= k_hi; idx++) {
-			if (!jmp_tab->jmp_tab[idx - k_low])
-				jmp_tab->jmp_tab[idx - k_low] = lb_dft;
-		}
-		switch_ir->code_misc = jmp_tab;
-	}
-	cctrl->flags = old_flags;
-	return 1;
+  Lex(cctrl->lex);
+  cctrl->code_ctrl->break_to = old_break_to;
+  if (header) {
+  gen_tab:
+    jmp_tab = CodeMiscNew(cctrl, CMT_JMP_TAB);
+    jmp_tab->jmp_tab = A_CALLOC((k_hi - k_low + 1) * sizeof(CCodeMisc *), NULL);
+    for (; header;) {
+      tmps = header->next;
+      jmp_tab->jmp_tab[header->val - k_low] = header->label;
+      A_FREE(header);
+      header = tmps;
+    }
+    jmp_tab->dft_lab = lb_dft;
+    jmp_tab->lo = k_low;
+    jmp_tab->hi = k_hi;
+    // Fill in the NULL's with default
+    for (idx = k_low; idx <= k_hi; idx++) {
+      if (!jmp_tab->jmp_tab[idx - k_low])
+        jmp_tab->jmp_tab[idx - k_low] = lb_dft;
+    }
+    switch_ir->code_misc = jmp_tab;
+  }
+  cctrl->flags = old_flags;
+  return 1;
 }
-static void __PrsBindCSymbol(char* name, void* ptr, int64_t naked,int64_t arity)
-{
-	CHashFun* fun;
-	CHashGlblVar* glbl;
-	CHashExport* exp;
-	if (fun = glbl = HashFind(name, Fs->hash_table, HTT_FUN | HTT_GLBL_VAR, 1)) {
-		if (glbl->base.type & HTT_GLBL_VAR) {
-			glbl->base.type &= ~HTF_EXTERN;
-			glbl->data_addr = ptr;
-		} else if (glbl->base.type & HTT_FUN) {
-			if(fun->argc!=arity) {
-				puts(name);
-				abort();
-			}
-			if (!fun->fun_ptr) {
-				fun->base.base.type &= ~HTF_EXTERN;
-				if (naked)
-					fun->fun_ptr = GenFFIBindingNaked(ptr, arity);
-				else
-					fun->fun_ptr = GenFFIBinding(ptr, arity);
-			}
-		}
-		SysSymImportsResolve(name, 0);
-	}
-	if (!HashFind(name, Fs->hash_table, HTT_EXPORT_SYS_SYM, 1)) {
-		// Here's the deal,for Load(in arm_loader.c),we can use HTT_EXPORT_SYS_SYM
-		exp = A_CALLOC(sizeof(CHashExport), NULL);
-		exp->base.str = A_STRDUP(name, NULL);
-		exp->base.type = HTT_EXPORT_SYS_SYM;
-		if (naked)
-			exp->val = GenFFIBindingNaked(ptr, arity);
-		else
-			exp->val = GenFFIBinding(ptr, arity);
-		HashAdd(exp, Fs->hash_table);
-	}
-}
-
-void PrsBindCSymbol(char* name, void* ptr,int64_t arity)
-{
-	__PrsBindCSymbol(name, ptr, 0,arity);
+static void __PrsBindCSymbol(char *name, void *ptr, int64_t naked,
+                             int64_t arity) {
+  CHashFun *fun;
+  CHashGlblVar *glbl;
+  CHashExport *exp;
+  if (fun = glbl = HashFind(name, Fs->hash_table, HTT_FUN | HTT_GLBL_VAR, 1)) {
+    if (glbl->base.type & HTT_GLBL_VAR) {
+      glbl->base.type &= ~HTF_EXTERN;
+      glbl->data_addr = ptr;
+    } else if (glbl->base.type & HTT_FUN) {
+      if (fun->argc != arity) {
+        puts(name);
+        abort();
+      }
+      if (!fun->fun_ptr) {
+        fun->base.base.type &= ~HTF_EXTERN;
+        if (naked)
+          fun->fun_ptr = GenFFIBindingNaked(ptr, arity);
+        else
+          fun->fun_ptr = GenFFIBinding(ptr, arity);
+      }
+    }
+    SysSymImportsResolve(name, 0);
+  }
+  if (!HashFind(name, Fs->hash_table, HTT_EXPORT_SYS_SYM, 1)) {
+    // Here's the deal,for Load(in arm_loader.c),we can use HTT_EXPORT_SYS_SYM
+    exp = A_CALLOC(sizeof(CHashExport), NULL);
+    exp->base.str = A_STRDUP(name, NULL);
+    exp->base.type = HTT_EXPORT_SYS_SYM;
+    if (naked)
+      exp->val = GenFFIBindingNaked(ptr, arity);
+    else
+      exp->val = GenFFIBinding(ptr, arity);
+    HashAdd(exp, Fs->hash_table);
+  }
 }
 
-void PrsBindCSymbolNaked(char* name, void* ptr,int64_t arity)
-{
-	__PrsBindCSymbol(name, ptr, 1,arity);
+void PrsBindCSymbol(char *name, void *ptr, int64_t arity) {
+  __PrsBindCSymbol(name, ptr, 0, arity);
 }
 
-int64_t PrsTry(CCmpCtrl* cctrl)
-{
-	CRPN* rpn;
-	CCodeMisc *catch_misc = CodeMiscNew(cctrl, CMT_LABEL),
-			  *exit_misc = CodeMiscNew(cctrl, CMT_LABEL);
-	if (!PrsKw(cctrl, TK_KW_TRY))
-		return 0;
-	// AIWNIOS_SetJmp(SysTry())
-	rpn = A_CALLOC(sizeof(CRPN), NULL);
-	rpn->type = IC_GLOBAL;
-	rpn->global_var = HashFind("AIWNIOS_SetJmp", Fs->hash_table, HTT_FUN, 1);
-	QueIns(rpn, cctrl->code_ctrl->ir_code);
-	rpn = A_CALLOC(sizeof(CRPN), NULL);
-	rpn->type = IC_GLOBAL;
-	rpn->global_var = HashFind("SysTry", Fs->hash_table, HTT_FUN, 1);
-	QueIns(rpn, cctrl->code_ctrl->ir_code);
-	rpn = A_CALLOC(sizeof(CRPN), NULL);
-	rpn->type = IC_CALL;
-	QueIns(rpn, cctrl->code_ctrl->ir_code);
-	rpn = A_CALLOC(sizeof(CRPN), NULL);
-	rpn->type = IC_CALL;
-	rpn->length = 1;
-	QueIns(rpn, cctrl->code_ctrl->ir_code);
-	rpn = A_CALLOC(sizeof(CRPN), NULL);
-	rpn->type = IC_GOTO_IF;
-	rpn->code_misc = catch_misc;
-	QueIns(rpn, cctrl->code_ctrl->ir_code);
-	// See below note
-	PrsStmt(cctrl);
-	// We will call SysUntry if we succesful got through the try block
-	rpn = A_CALLOC(sizeof(CRPN), NULL);
-	rpn->type = IC_GLOBAL;
-	rpn->global_var = HashFind("SysUntry", Fs->hash_table, HTT_FUN, 1);
-	QueIns(rpn, cctrl->code_ctrl->ir_code);
-	rpn = A_CALLOC(sizeof(CRPN), NULL);
-	rpn->type = IC_CALL;
-	QueIns(rpn, cctrl->code_ctrl->ir_code);
-	rpn = A_CALLOC(sizeof(CRPN), NULL);
-	rpn->type = IC_GOTO;
-	rpn->code_misc = exit_misc;
-	QueIns(rpn, cctrl->code_ctrl->ir_code);
-	//
-	if (!PrsKw(cctrl, TK_KW_CATCH))
-		ParseErr(cctrl, "Expected 'catch'.");
-	// Catch label is here
-	rpn = A_CALLOC(sizeof(CRPN), NULL);
-	rpn->type = IC_LABEL;
-	rpn->code_misc = catch_misc;
-	QueIns(rpn, cctrl->code_ctrl->ir_code);
-	// Our catch block
-	PrsStmt(cctrl);
-	// Call EndCatch
-	rpn = A_CALLOC(sizeof(CRPN), NULL);
-	rpn->type = IC_GLOBAL;
-	rpn->global_var = HashFind("EndCatch", Fs->hash_table, HTT_FUN, 1);
-	QueIns(rpn, cctrl->code_ctrl->ir_code);
-	rpn = A_CALLOC(sizeof(CRPN), NULL);
-	rpn->type = IC_CALL;
-	QueIns(rpn, cctrl->code_ctrl->ir_code);
-	// Exit label is here
-	rpn = A_CALLOC(sizeof(CRPN), NULL);
-	rpn->type = IC_LABEL;
-	rpn->code_misc = exit_misc;
-	QueIns(rpn, cctrl->code_ctrl->ir_code);
+void PrsBindCSymbolNaked(char *name, void *ptr, int64_t arity) {
+  __PrsBindCSymbol(name, ptr, 1, arity);
+}
 
-	return 1;
+int64_t PrsTry(CCmpCtrl *cctrl) {
+  CRPN *rpn;
+  CCodeMisc *catch_misc = CodeMiscNew(cctrl, CMT_LABEL),
+            *exit_misc = CodeMiscNew(cctrl, CMT_LABEL);
+  if (!PrsKw(cctrl, TK_KW_TRY))
+    return 0;
+  // AIWNIOS_SetJmp(SysTry())
+  rpn = A_CALLOC(sizeof(CRPN), NULL);
+  rpn->type = IC_GLOBAL;
+  rpn->global_var = HashFind("AIWNIOS_SetJmp", Fs->hash_table, HTT_FUN, 1);
+  QueIns(rpn, cctrl->code_ctrl->ir_code);
+  rpn = A_CALLOC(sizeof(CRPN), NULL);
+  rpn->type = IC_GLOBAL;
+  rpn->global_var = HashFind("SysTry", Fs->hash_table, HTT_FUN, 1);
+  QueIns(rpn, cctrl->code_ctrl->ir_code);
+  rpn = A_CALLOC(sizeof(CRPN), NULL);
+  rpn->type = IC_CALL;
+  QueIns(rpn, cctrl->code_ctrl->ir_code);
+  rpn = A_CALLOC(sizeof(CRPN), NULL);
+  rpn->type = IC_CALL;
+  rpn->length = 1;
+  QueIns(rpn, cctrl->code_ctrl->ir_code);
+  rpn = A_CALLOC(sizeof(CRPN), NULL);
+  rpn->type = IC_GOTO_IF;
+  rpn->code_misc = catch_misc;
+  QueIns(rpn, cctrl->code_ctrl->ir_code);
+  // See below note
+  PrsStmt(cctrl);
+  // We will call SysUntry if we succesful got through the try block
+  rpn = A_CALLOC(sizeof(CRPN), NULL);
+  rpn->type = IC_GLOBAL;
+  rpn->global_var = HashFind("SysUntry", Fs->hash_table, HTT_FUN, 1);
+  QueIns(rpn, cctrl->code_ctrl->ir_code);
+  rpn = A_CALLOC(sizeof(CRPN), NULL);
+  rpn->type = IC_CALL;
+  QueIns(rpn, cctrl->code_ctrl->ir_code);
+  rpn = A_CALLOC(sizeof(CRPN), NULL);
+  rpn->type = IC_GOTO;
+  rpn->code_misc = exit_misc;
+  QueIns(rpn, cctrl->code_ctrl->ir_code);
+  //
+  if (!PrsKw(cctrl, TK_KW_CATCH))
+    ParseErr(cctrl, "Expected 'catch'.");
+  // Catch label is here
+  rpn = A_CALLOC(sizeof(CRPN), NULL);
+  rpn->type = IC_LABEL;
+  rpn->code_misc = catch_misc;
+  QueIns(rpn, cctrl->code_ctrl->ir_code);
+  // Our catch block
+  PrsStmt(cctrl);
+  // Call EndCatch
+  rpn = A_CALLOC(sizeof(CRPN), NULL);
+  rpn->type = IC_GLOBAL;
+  rpn->global_var = HashFind("EndCatch", Fs->hash_table, HTT_FUN, 1);
+  QueIns(rpn, cctrl->code_ctrl->ir_code);
+  rpn = A_CALLOC(sizeof(CRPN), NULL);
+  rpn->type = IC_CALL;
+  QueIns(rpn, cctrl->code_ctrl->ir_code);
+  // Exit label is here
+  rpn = A_CALLOC(sizeof(CRPN), NULL);
+  rpn->type = IC_LABEL;
+  rpn->code_misc = exit_misc;
+  QueIns(rpn, cctrl->code_ctrl->ir_code);
+
+  return 1;
 }
 #ifdef AIWNIOS_TESTS
-void PrsTests()
-{
-	// TODO write test to validate
-	CLexer* lex = LexerNew("None", "I64i Foo(I64i a) {return a+10;}\n"
-								   "{\n"
-								   "  I64i a;\n"
-								   "  do {\n"
-								   "	 a--;\n"
-								   "    break;\n"
-								   "  } while(a);\n"
-								   "  while(0<=a<3) {\n"
-								   "    a+=1;\n"
-								   "    break;\n"
-								   "  }\n"
-								   ""
-								   "  for(a=0;a!=10;a++) {\n"
-								   "    if(a) {\n"
-								   "      break;\n"
-								   "    }\n"
-								   "    if(a) {\n"
-								   "      break;\n"
-								   "    } else {"
-								   "      goto next;\n"
-								   "    }\n"
-								   "    next:;\n"
-								   "  }\n"
-								   "  a*(a+1)+a*(a+2);\n"
-								   "  switch(a) {\n"
-								   "  case 0: Foo(0);\n"
-								   "  case 1: Foo(1);\n"
-								   "  case 2: Foo(2);\n"
-								   "  default: break;"
-								   "  }\n"
-								   "  switch(a) {\n"
-								   "  case 0: Foo(0);\n"
-								   "  case 1: Foo(1);\n"
-								   "  case 2: Foo(2);\n"
-								   "  }\n"
-								   "  switch(a) {\n"
-								   "  start:\n"
-								   "  Foo(-1);\n"
-								   "  if(a) break;\n"
-								   "  case 0: Foo(0);break;\n"
-								   "  case 1: Foo(1);break;\n"
-								   "  end:\n"
-								   "  case 2: Foo(2);break;\n"
-								   "  }\n"
-								   "}\n"
-								   "class CCls {\n"
-								   "	I64i a,*b,c[20][30];"
-								   "  union {I32i o1;U16i o2;};"
-								   "  U8i fin;"
-								   "};\n"
-								   "class CUn {\n"
-								   "	U8i u8[8];\n"
-								   "	I8i i8[8];\n"
-								   "	U16i u16[4];\n"
-								   "	I16i i16[4];\n"
-								   "	U16i u32[2];\n"
-								   "	I16i i32[2];\n"
-								   "};\n");
-	CCmpCtrl* ccmp = CmpCtrlNew(lex);
-	CodeCtrlPush(ccmp);
-	Lex(ccmp->lex);
-	PrsStmt(ccmp); // Function
-	PrsStmt(ccmp); // Scope with loads of stuff
-	PrsStmt(ccmp); // class
-	PrsStmt(ccmp); // union
-	CHashClass* cls = HashFind("CCls", Fs->hash_table, HTT_CLASS, 1);
-	CMemberLst* mlst;
-	assert(cls);
-	assert(cls->member_cnt == 6);
-	mlst = cls->members_lst;
-	assert(mlst->off == 0);
-	assert(mlst->member_class == HashFind("I64i", Fs->hash_table, HTT_CLASS, 1));
-	mlst = mlst->next;
-	assert(mlst->off == 8);
-	assert(mlst->member_class - 1 == HashFind("I64i", Fs->hash_table, HTT_CLASS, 1));
-	mlst = mlst->next;
-	assert(mlst->off == 16);
-	assert(mlst->member_class == HashFind("I64i", Fs->hash_table, HTT_CLASS, 1));
-	assert(mlst->dim.total_cnt == 20 * 30);
-	assert(mlst->dim.next->total_cnt == 30);
-	mlst = mlst->next;
-	assert(mlst->off == 16 + 20 * 30 * 8);
-	mlst = mlst->next;
-	assert(mlst->off == 16 + 20 * 30 * 8);
-	mlst = mlst->next;
-	assert(mlst->off == 16 + 20 * 30 * 8 + 4);
-	assert(cls->sz == 16 + 20 * 30 * 8 + 4 + 1);
+void PrsTests() {
+  // TODO write test to validate
+  CLexer *lex = LexerNew("None", "I64i Foo(I64i a) {return a+10;}\n"
+                                 "{\n"
+                                 "  I64i a;\n"
+                                 "  do {\n"
+                                 "	 a--;\n"
+                                 "    break;\n"
+                                 "  } while(a);\n"
+                                 "  while(0<=a<3) {\n"
+                                 "    a+=1;\n"
+                                 "    break;\n"
+                                 "  }\n"
+                                 ""
+                                 "  for(a=0;a!=10;a++) {\n"
+                                 "    if(a) {\n"
+                                 "      break;\n"
+                                 "    }\n"
+                                 "    if(a) {\n"
+                                 "      break;\n"
+                                 "    } else {"
+                                 "      goto next;\n"
+                                 "    }\n"
+                                 "    next:;\n"
+                                 "  }\n"
+                                 "  a*(a+1)+a*(a+2);\n"
+                                 "  switch(a) {\n"
+                                 "  case 0: Foo(0);\n"
+                                 "  case 1: Foo(1);\n"
+                                 "  case 2: Foo(2);\n"
+                                 "  default: break;"
+                                 "  }\n"
+                                 "  switch(a) {\n"
+                                 "  case 0: Foo(0);\n"
+                                 "  case 1: Foo(1);\n"
+                                 "  case 2: Foo(2);\n"
+                                 "  }\n"
+                                 "  switch(a) {\n"
+                                 "  start:\n"
+                                 "  Foo(-1);\n"
+                                 "  if(a) break;\n"
+                                 "  case 0: Foo(0);break;\n"
+                                 "  case 1: Foo(1);break;\n"
+                                 "  end:\n"
+                                 "  case 2: Foo(2);break;\n"
+                                 "  }\n"
+                                 "}\n"
+                                 "class CCls {\n"
+                                 "	I64i a,*b,c[20][30];"
+                                 "  union {I32i o1;U16i o2;};"
+                                 "  U8i fin;"
+                                 "};\n"
+                                 "class CUn {\n"
+                                 "	U8i u8[8];\n"
+                                 "	I8i i8[8];\n"
+                                 "	U16i u16[4];\n"
+                                 "	I16i i16[4];\n"
+                                 "	U16i u32[2];\n"
+                                 "	I16i i32[2];\n"
+                                 "};\n");
+  CCmpCtrl *ccmp = CmpCtrlNew(lex);
+  CodeCtrlPush(ccmp);
+  Lex(ccmp->lex);
+  PrsStmt(ccmp); // Function
+  PrsStmt(ccmp); // Scope with loads of stuff
+  PrsStmt(ccmp); // class
+  PrsStmt(ccmp); // union
+  CHashClass *cls = HashFind("CCls", Fs->hash_table, HTT_CLASS, 1);
+  CMemberLst *mlst;
+  assert(cls);
+  assert(cls->member_cnt == 6);
+  mlst = cls->members_lst;
+  assert(mlst->off == 0);
+  assert(mlst->member_class == HashFind("I64i", Fs->hash_table, HTT_CLASS, 1));
+  mlst = mlst->next;
+  assert(mlst->off == 8);
+  assert(mlst->member_class - 1 ==
+         HashFind("I64i", Fs->hash_table, HTT_CLASS, 1));
+  mlst = mlst->next;
+  assert(mlst->off == 16);
+  assert(mlst->member_class == HashFind("I64i", Fs->hash_table, HTT_CLASS, 1));
+  assert(mlst->dim.total_cnt == 20 * 30);
+  assert(mlst->dim.next->total_cnt == 30);
+  mlst = mlst->next;
+  assert(mlst->off == 16 + 20 * 30 * 8);
+  mlst = mlst->next;
+  assert(mlst->off == 16 + 20 * 30 * 8);
+  mlst = mlst->next;
+  assert(mlst->off == 16 + 20 * 30 * 8 + 4);
+  assert(cls->sz == 16 + 20 * 30 * 8 + 4 + 1);
 }
 #endif
 //
 // Nroot here,im about to make bindings for the IR stuff
 //
-#define HC_IC_BINDING(name, op)                     \
-	CRPN* __##name(CCodeCtrl* cc)                   \
-	{                                               \
-		CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc); \
-		rpn->type = op;                             \
-		QueIns(rpn, cc->ir_code);                   \
-		return rpn;                                 \
-	}
+#define HC_IC_BINDING(name, op)                                                \
+  CRPN *__##name(CCodeCtrl *cc) {                                              \
+    CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);                                \
+    rpn->type = op;                                                            \
+    QueIns(rpn, cc->ir_code);                                                  \
+    return rpn;                                                                \
+  }
 HC_IC_BINDING(HC_ICAdd_Pow, IC_POW);
 HC_IC_BINDING(HC_ICAdd_Eq, IC_EQ);
 HC_IC_BINDING(HC_ICAdd_Div, IC_DIV);
@@ -3954,53 +3928,47 @@ HC_IC_BINDING(HC_ICAdd_Neg, IC_NEG);
 HC_IC_BINDING(HC_ICAdd_And, IC_AND);
 HC_IC_BINDING(HC_ICAdd_Ret, IC_RET);
 
-CRPN* __HC_ICAdd_SetFrameSize(CCodeCtrl* cc, int64_t arg)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = __IC_SET_FRAME_SIZE;
-	rpn->integer = arg;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_SetFrameSize(CCodeCtrl *cc, int64_t arg) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = __IC_SET_FRAME_SIZE;
+  rpn->integer = arg;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
-CRPN* __HC_ICAdd_Arg(CCodeCtrl* cc, int64_t arg)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = __IC_ARG;
-	rpn->integer = arg;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_Arg(CCodeCtrl *cc, int64_t arg) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = __IC_ARG;
+  rpn->integer = arg;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
-CRPN* __HC_ICAdd_PostInc(CCodeCtrl* cc, int64_t amt)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = IC_POST_INC;
-	rpn->integer = amt;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_PostInc(CCodeCtrl *cc, int64_t amt) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = IC_POST_INC;
+  rpn->integer = amt;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
-CRPN* __HC_ICAdd_PostDec(CCodeCtrl* cc, int64_t amt)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = IC_POST_DEC;
-	rpn->integer = amt;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_PostDec(CCodeCtrl *cc, int64_t amt) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = IC_POST_DEC;
+  rpn->integer = amt;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
-CRPN* __HC_ICAdd_PreInc(CCodeCtrl* cc, int64_t amt)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = IC_PRE_INC;
-	rpn->integer = amt;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_PreInc(CCodeCtrl *cc, int64_t amt) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = IC_PRE_INC;
+  rpn->integer = amt;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
-CRPN* __HC_ICAdd_PreDec(CCodeCtrl* cc, int64_t amt)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = IC_PRE_DEC;
-	rpn->integer = amt;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_PreDec(CCodeCtrl *cc, int64_t amt) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = IC_PRE_DEC;
+  rpn->integer = amt;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
 HC_IC_BINDING(HC_ICAdd_AddEq, IC_ADD_EQ);
 HC_IC_BINDING(HC_ICAdd_SubEq, IC_SUB_EQ);
@@ -4014,362 +3982,331 @@ HC_IC_BINDING(HC_ICAdd_XorEq, IC_XOR_EQ);
 HC_IC_BINDING(HC_ICAdd_ModEq, IC_MOD_EQ);
 HC_IC_BINDING(HC_ICAdd_ToI64, IC_TO_I64);
 HC_IC_BINDING(HC_ICAdd_ToF64, IC_TO_F64);
-CRPN* __HC_ICAdd_I64(CCodeCtrl* cc, int64_t integer)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = IC_I64;
-	rpn->integer = integer;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_I64(CCodeCtrl *cc, int64_t integer) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = IC_I64;
+  rpn->integer = integer;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
-CRPN* __HC_ICAdd_F64(CCodeCtrl* cc, double f)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = IC_F64;
-	rpn->flt = f;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_F64(CCodeCtrl *cc, double f) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = IC_F64;
+  rpn->flt = f;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
-CRPN* __HC_ICAdd_Switch(CCodeCtrl* cc, CCodeMisc* misc, CCodeMisc* dft)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = IC_BOUNDED_SWITCH;
-	rpn->code_misc = misc;
-	rpn->code_misc->dft_lab = dft;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_Switch(CCodeCtrl *cc, CCodeMisc *misc, CCodeMisc *dft) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = IC_BOUNDED_SWITCH;
+  rpn->code_misc = misc;
+  rpn->code_misc->dft_lab = dft;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
-CRPN* __HC_ICAdd_UnboundedSwitch(CCodeCtrl* cc, CCodeMisc* misc)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = IC_UNBOUNDED_SWITCH;
-	rpn->code_misc = misc;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_UnboundedSwitch(CCodeCtrl *cc, CCodeMisc *misc) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = IC_UNBOUNDED_SWITCH;
+  rpn->code_misc = misc;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
 
-CRPN* __HC_ICAdd_SubRet(CCodeCtrl* cc)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = IC_SUB_RET;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_SubRet(CCodeCtrl *cc) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = IC_SUB_RET;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
-CRPN* __HC_ICAdd_SubProlog(CCodeCtrl* cc)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = IC_SUB_PROLOG;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_SubProlog(CCodeCtrl *cc) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = IC_SUB_PROLOG;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
-CRPN* __HC_ICAdd_SubCall(CCodeCtrl* cc, CCodeMisc* cm)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = IC_SUB_CALL;
-	rpn->code_misc = cm;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_SubCall(CCodeCtrl *cc, CCodeMisc *cm) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = IC_SUB_CALL;
+  rpn->code_misc = cm;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
-static CHashClass* rt2cls(int64_t rt, int64_t ptr_cnt)
-{
-	CHashClass* ic_class;
-	switch (rt) {
-		break;
-	case 3:
-		ic_class = HashFind("U0", Fs->hash_table, HTT_CLASS, 1);
-		break;
-	case 5:
-		ic_class = HashFind("U8i", Fs->hash_table, HTT_CLASS, 1);
-		break;
-	case 4:
-		ic_class = HashFind("I8i", Fs->hash_table, HTT_CLASS, 1);
-		break;
-	case 7:
-		ic_class = HashFind("U16i", Fs->hash_table, HTT_CLASS, 1);
-		break;
-	case 6:
-		ic_class = HashFind("I16i", Fs->hash_table, HTT_CLASS, 1);
-		break;
-	case 9:
-		ic_class = HashFind("U32i", Fs->hash_table, HTT_CLASS, 1);
-		break;
-	case 8:
-		ic_class = HashFind("I32i", Fs->hash_table, HTT_CLASS, 1);
-		break;
-	case 11:
-		ic_class = HashFind("U64i", Fs->hash_table, HTT_CLASS, 1);
-		break;
-	case 10:
-		ic_class = HashFind("I64i", Fs->hash_table, HTT_CLASS, 1);
-		break;
-	case 14:
-		ic_class = HashFind("F64", Fs->hash_table, HTT_CLASS, 1);
-		break;
-	default:
-		ic_class = HashFind("I64i", Fs->hash_table, HTT_CLASS, 1);
-	}
-	return ic_class + ptr_cnt;
+static CHashClass *rt2cls(int64_t rt, int64_t ptr_cnt) {
+  CHashClass *ic_class;
+  switch (rt) {
+    break;
+  case 3:
+    ic_class = HashFind("U0", Fs->hash_table, HTT_CLASS, 1);
+    break;
+  case 5:
+    ic_class = HashFind("U8i", Fs->hash_table, HTT_CLASS, 1);
+    break;
+  case 4:
+    ic_class = HashFind("I8i", Fs->hash_table, HTT_CLASS, 1);
+    break;
+  case 7:
+    ic_class = HashFind("U16i", Fs->hash_table, HTT_CLASS, 1);
+    break;
+  case 6:
+    ic_class = HashFind("I16i", Fs->hash_table, HTT_CLASS, 1);
+    break;
+  case 9:
+    ic_class = HashFind("U32i", Fs->hash_table, HTT_CLASS, 1);
+    break;
+  case 8:
+    ic_class = HashFind("I32i", Fs->hash_table, HTT_CLASS, 1);
+    break;
+  case 11:
+    ic_class = HashFind("U64i", Fs->hash_table, HTT_CLASS, 1);
+    break;
+  case 10:
+    ic_class = HashFind("I64i", Fs->hash_table, HTT_CLASS, 1);
+    break;
+  case 14:
+    ic_class = HashFind("F64", Fs->hash_table, HTT_CLASS, 1);
+    break;
+  default:
+    ic_class = HashFind("I64i", Fs->hash_table, HTT_CLASS, 1);
+  }
+  return ic_class + ptr_cnt;
 }
-CRPN* __HC_ICAdd_ShortAddr(CCmpCtrl* acc, CCodeCtrl* cc, char* name, CCodeMisc* ptr)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = IC_SHORT_ADDR;
-	rpn->code_misc = ptr;
-	ptr->type = CMT_SHORT_ADDR;
-	rpn->ic_class = HashFind("U8i", Fs->hash_table, HTT_CLASS, 1);
-	rpn->ic_class++;
-	rpn->raw_type = RT_PTR;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_ShortAddr(CCmpCtrl *acc, CCodeCtrl *cc, char *name,
+                           CCodeMisc *ptr) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = IC_SHORT_ADDR;
+  rpn->code_misc = ptr;
+  ptr->type = CMT_SHORT_ADDR;
+  rpn->ic_class = HashFind("U8i", Fs->hash_table, HTT_CLASS, 1);
+  rpn->ic_class++;
+  rpn->raw_type = RT_PTR;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
-CRPN* __HC_ICAdd_Deref(CCodeCtrl* cc, int64_t rt, int64_t ptr_cnt)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = IC_DEREF;
-	rpn->ic_class = rt2cls(rt, ptr_cnt);
-	rpn->raw_type = rpn->ic_class->raw_type;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_Deref(CCodeCtrl *cc, int64_t rt, int64_t ptr_cnt) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = IC_DEREF;
+  rpn->ic_class = rt2cls(rt, ptr_cnt);
+  rpn->raw_type = rpn->ic_class->raw_type;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
 
-CRPN* __HC_ICAdd_Call(CCodeCtrl* cc, int64_t arity, int64_t rt, int64_t ptr_cnt)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = __IC_CALL;
-	rpn->length = arity;
-	rpn->ic_class = rt2cls(rt, ptr_cnt);
-	rpn->raw_type = rpn->ic_class->raw_type;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_Call(CCodeCtrl *cc, int64_t arity, int64_t rt,
+                      int64_t ptr_cnt) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = __IC_CALL;
+  rpn->length = arity;
+  rpn->ic_class = rt2cls(rt, ptr_cnt);
+  rpn->raw_type = rpn->ic_class->raw_type;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
-CRPN* __HC_ICAdd_FReg(CCodeCtrl* cc, int64_t r)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = IC_FREG;
-	rpn->integer = r;
-	rpn->ic_class = HashFind("F64", Fs->hash_table, HTT_CLASS, 1);
-	rpn->raw_type = RT_F64;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_FReg(CCodeCtrl *cc, int64_t r) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = IC_FREG;
+  rpn->integer = r;
+  rpn->ic_class = HashFind("F64", Fs->hash_table, HTT_CLASS, 1);
+  rpn->raw_type = RT_F64;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
-CRPN* __HC_ICAdd_IReg(CCodeCtrl* cc, int64_t r, int64_t rt, int64_t ptr_cnt)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = IC_IREG;
-	rpn->integer = r;
-	rpn->ic_class = rt2cls(rt, ptr_cnt);
-	if (ptr_cnt)
-		rt = RT_PTR;
-	rpn->raw_type = rpn->ic_class->raw_type;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_IReg(CCodeCtrl *cc, int64_t r, int64_t rt, int64_t ptr_cnt) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = IC_IREG;
+  rpn->integer = r;
+  rpn->ic_class = rt2cls(rt, ptr_cnt);
+  if (ptr_cnt)
+    rt = RT_PTR;
+  rpn->raw_type = rpn->ic_class->raw_type;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
 
-CRPN* __HC_ICAdd_Frame(CCodeCtrl* cc, int64_t off, int64_t rt, int64_t ptr_cnt)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = IC_BASE_PTR;
-	rpn->integer = off;
-	rpn->ic_class = rt2cls(rt, ptr_cnt);
-	if (ptr_cnt)
-		rt = RT_PTR;
-	rpn->raw_type = rpn->ic_class->raw_type;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_Frame(CCodeCtrl *cc, int64_t off, int64_t rt,
+                       int64_t ptr_cnt) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = IC_BASE_PTR;
+  rpn->integer = off;
+  rpn->ic_class = rt2cls(rt, ptr_cnt);
+  if (ptr_cnt)
+    rt = RT_PTR;
+  rpn->raw_type = rpn->ic_class->raw_type;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
-CRPN* __HC_ICAdd_Typecast(CCodeCtrl* cc, int64_t rt, int64_t ptr_cnt)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = IC_TYPECAST;
-	rpn->ic_class = rt2cls(rt, ptr_cnt);
-	if (ptr_cnt)
-		rt = RT_PTR;
-	rpn->raw_type = rpn->ic_class->raw_type;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
-}
-
-CCmpCtrl* __HC_CmpCtrlNew()
-{
-	return CmpCtrlNew(NULL);
-}
-CCodeCtrl* __HC_CodeCtrlPush(CCmpCtrl* ccmp)
-{
-	return CodeCtrlPush(ccmp);
-}
-CCodeCtrl* __HC_CodeCtrlPop(CCmpCtrl* ccmp)
-{
-	CodeCtrlPop(ccmp);
-}
-char* __HC_Compile(CCmpCtrl* ccmp, int64_t* sz, char** dbg_info)
-{
-	return Compile(ccmp, sz, dbg_info);
-}
-CCodeMisc* __HC_CodeMiscLabelNew(CCmpCtrl* ccmp,void **patch_addr)
-{
-	CCodeMisc *misc=CodeMiscNew(ccmp, CMT_LABEL);
-	misc->patch_addr=patch_addr;
-	return misc;
-}
-CCodeMisc* __HC_CodeMiscStrNew(CCmpCtrl* ccmp, char* str, int64_t sz)
-{
-	CCodeMisc* misc = CodeMiscNew(ccmp, CMT_STRING);
-	misc->str = A_CALLOC(sz + 1, NULL);
-	memcpy(misc->str, str, sz);
-	misc->str_len = sz;
-	return misc;
-}
-CCodeMisc* __HC_CodeMiscJmpTableNew(CCmpCtrl* ccmp, CCodeMisc* labels, void** table_address, int64_t hi)
-{
-	CCodeMisc* misc = CodeMiscNew(ccmp, CMT_JMP_TAB);
-	misc->jmp_tab = A_MALLOC((hi - 0) * sizeof(CCodeMisc*), NULL);
-	memcpy(misc->jmp_tab, labels, (hi - 0) * sizeof(CCodeMisc*));
-	misc->hi = hi - 1;
-	misc->lo = 0;
-	misc->patch_addr = table_address;
-	return misc;
+CRPN *__HC_ICAdd_Typecast(CCodeCtrl *cc, int64_t rt, int64_t ptr_cnt) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = IC_TYPECAST;
+  rpn->ic_class = rt2cls(rt, ptr_cnt);
+  if (ptr_cnt)
+    rt = RT_PTR;
+  rpn->raw_type = rpn->ic_class->raw_type;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
 
-CRPN* __HC_ICAdd_Label(CCodeCtrl* cc, CCodeMisc* misc)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = IC_NOP;
-	// Label must consume something
-	QueIns(rpn, cc->ir_code);
-	rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = IC_LABEL;
-	rpn->code_misc = misc;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CCmpCtrl *__HC_CmpCtrlNew() {
+  return CmpCtrlNew(NULL);
+}
+CCodeCtrl *__HC_CodeCtrlPush(CCmpCtrl *ccmp) {
+  return CodeCtrlPush(ccmp);
+}
+CCodeCtrl *__HC_CodeCtrlPop(CCmpCtrl *ccmp) {
+  CodeCtrlPop(ccmp);
+}
+char *__HC_Compile(CCmpCtrl *ccmp, int64_t *sz, char **dbg_info) {
+  return Compile(ccmp, sz, dbg_info);
+}
+CCodeMisc *__HC_CodeMiscLabelNew(CCmpCtrl *ccmp, void **patch_addr) {
+  CCodeMisc *misc = CodeMiscNew(ccmp, CMT_LABEL);
+  misc->patch_addr = patch_addr;
+  return misc;
+}
+CCodeMisc *__HC_CodeMiscStrNew(CCmpCtrl *ccmp, char *str, int64_t sz) {
+  CCodeMisc *misc = CodeMiscNew(ccmp, CMT_STRING);
+  misc->str = A_CALLOC(sz + 1, NULL);
+  memcpy(misc->str, str, sz);
+  misc->str_len = sz;
+  return misc;
+}
+CCodeMisc *__HC_CodeMiscJmpTableNew(CCmpCtrl *ccmp, CCodeMisc *labels,
+                                    void **table_address, int64_t hi) {
+  CCodeMisc *misc = CodeMiscNew(ccmp, CMT_JMP_TAB);
+  misc->jmp_tab = A_MALLOC((hi - 0) * sizeof(CCodeMisc *), NULL);
+  memcpy(misc->jmp_tab, labels, (hi - 0) * sizeof(CCodeMisc *));
+  misc->hi = hi - 1;
+  misc->lo = 0;
+  misc->patch_addr = table_address;
+  return misc;
 }
 
-CRPN* __HC_ICAdd_Goto(CCodeCtrl* cc, CCodeMisc* cm)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = IC_GOTO;
-	rpn->code_misc = cm;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_Label(CCodeCtrl *cc, CCodeMisc *misc) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = IC_NOP;
+  // Label must consume something
+  QueIns(rpn, cc->ir_code);
+  rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = IC_LABEL;
+  rpn->code_misc = misc;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
 
-CRPN* __HC_ICAdd_GotoIf(CCodeCtrl* cc, CCodeMisc* cm)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = IC_GOTO_IF;
-	rpn->code_misc = cm;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_Goto(CCodeCtrl *cc, CCodeMisc *cm) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = IC_GOTO;
+  rpn->code_misc = cm;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
 
-CRPN* __HC_ICAdd_RawBytes(CCodeCtrl* cc,char *bytes,int64_t cnt)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = IC_RAW_BYTES;
-	rpn->length = cnt;
-	rpn->raw_bytes=A_MALLOC(cnt,cc->hc);
-	memcpy(rpn->raw_bytes,bytes,cnt);
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_GotoIf(CCodeCtrl *cc, CCodeMisc *cm) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = IC_GOTO_IF;
+  rpn->code_misc = cm;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
 
-
-CRPN* __HC_ICAdd_Vargs(CCodeCtrl* cc, int64_t arity)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = __IC_VARGS;
-	rpn->length = arity;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_RawBytes(CCodeCtrl *cc, char *bytes, int64_t cnt) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = IC_RAW_BYTES;
+  rpn->length = cnt;
+  rpn->raw_bytes = A_MALLOC(cnt, cc->hc);
+  memcpy(rpn->raw_bytes, bytes, cnt);
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
 
-CRPN* __HC_ICAdd_Str(CCodeCtrl* cc, CCodeMisc* cm)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = IC_STR;
-	rpn->code_misc = cm;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_Vargs(CCodeCtrl *cc, int64_t arity) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = __IC_VARGS;
+  rpn->length = arity;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
 
-CCodeMisc* AddRelocMisc(CCmpCtrl* cctrl, char* name)
-{
-	CCodeMisc *reloc, *head = cctrl->code_ctrl->code_misc;
-	for (reloc = head->base.next; reloc != head; reloc = reloc->base.next) {
-		if (reloc->type == CMT_RELOC_U64) {
-			if (!strcmp(reloc->str, name))
-				return reloc;
-		}
-	}
-	reloc = CodeMiscNew(cctrl, CMT_RELOC_U64);
-	reloc->str = A_STRDUP(name, cctrl->hc);
-	return reloc;
-}
-void __HC_ICSetLine(CRPN* r, int64_t ln)
-{
-	r->ic_line = ln;
+CRPN *__HC_ICAdd_Str(CCodeCtrl *cc, CCodeMisc *cm) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = IC_STR;
+  rpn->code_misc = cm;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
 
-CRPN* __HC_ICAdd_Reloc(CCmpCtrl* cmpc, CCodeCtrl* cc, int64_t* pat_addr, char* sym, int64_t rt, int64_t ptrs)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = IC_RELOC;
-	rpn->ic_class = rt2cls(rt, ptrs);
-	rpn->code_misc = AddRelocMisc(cmpc, sym);
-	rpn->code_misc->patch_addr = pat_addr;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CCodeMisc *AddRelocMisc(CCmpCtrl *cctrl, char *name) {
+  CCodeMisc *reloc, *head = cctrl->code_ctrl->code_misc;
+  for (reloc = head->base.next; reloc != head; reloc = reloc->base.next) {
+    if (reloc->type == CMT_RELOC_U64) {
+      if (!strcmp(reloc->str, name))
+        return reloc;
+    }
+  }
+  reloc = CodeMiscNew(cctrl, CMT_RELOC_U64);
+  reloc->str = A_STRDUP(name, cctrl->hc);
+  return reloc;
+}
+void __HC_ICSetLine(CRPN *r, int64_t ln) {
+  r->ic_line = ln;
+}
+
+CRPN *__HC_ICAdd_Reloc(CCmpCtrl *cmpc, CCodeCtrl *cc, int64_t *pat_addr,
+                       char *sym, int64_t rt, int64_t ptrs) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = IC_RELOC;
+  rpn->ic_class = rt2cls(rt, ptrs);
+  rpn->code_misc = AddRelocMisc(cmpc, sym);
+  rpn->code_misc->patch_addr = pat_addr;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
 
 // Sets how many bytes before function start a symbol starts at
 // Symbol    <=====RIP-off
 // some...code
 // Fun Start <==== RIP
-void __HC_SetAOTRelocBeforeRIP(CRPN* r, int64_t off)
-{
-	r->code_misc->aot_before_hint = off;
+void __HC_SetAOTRelocBeforeRIP(CRPN *r, int64_t off) {
+  r->code_misc->aot_before_hint = off;
 }
 
-int64_t __HC_CodeMiscIsUsed(CCodeMisc* cm)
-{
-	return cm->use_cnt != 0;
+int64_t __HC_CodeMiscIsUsed(CCodeMisc *cm) {
+  return cm->use_cnt != 0;
 }
 
-CRPN* __HC_ICAdd_StaticData(CCmpCtrl* cmp, CCodeCtrl* cc, int64_t at, char* d, int64_t len)
-{
-	CCodeMisc* misc = CodeMiscNew(cmp, CMT_STATIC_DATA);
-	misc->integer = at;
-	misc->str_len = len;
-	memcpy(misc->str = A_MALLOC(len, cmp->hc), d, len);
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = __IC_SET_STATIC_DATA;
-	rpn->code_misc = misc;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_StaticData(CCmpCtrl *cmp, CCodeCtrl *cc, int64_t at, char *d,
+                            int64_t len) {
+  CCodeMisc *misc = CodeMiscNew(cmp, CMT_STATIC_DATA);
+  misc->integer = at;
+  misc->str_len = len;
+  memcpy(misc->str = A_MALLOC(len, cmp->hc), d, len);
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = __IC_SET_STATIC_DATA;
+  rpn->code_misc = misc;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
 
-CRPN* __HC_ICAdd_SetStaticsSize(CCodeCtrl* cc, int64_t len)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = __IC_STATICS_SIZE;
-	rpn->integer = len;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_SetStaticsSize(CCodeCtrl *cc, int64_t len) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = __IC_STATICS_SIZE;
+  rpn->integer = len;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
 
-CRPN* __HC_ICAdd_StaticRef(CCodeCtrl* cc, int64_t off, int64_t rt, int64_t ptrs)
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = __IC_STATIC_REF;
-	rpn->integer = off;
-	rpn->ic_class = rt2cls(rt, ptrs);
-	rpn->raw_type = rpn->ic_class->raw_type;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+CRPN *__HC_ICAdd_StaticRef(CCodeCtrl *cc, int64_t off, int64_t rt,
+                           int64_t ptrs) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = __IC_STATIC_REF;
+  rpn->integer = off;
+  rpn->ic_class = rt2cls(rt, ptrs);
+  rpn->raw_type = rpn->ic_class->raw_type;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
 
-void __HC_CmpCtrl_SetAOT(CCmpCtrl* cc)
-{
-	cc->flags |= CCF_AOT_COMPILE;
+void __HC_CmpCtrl_SetAOT(CCmpCtrl *cc) {
+  cc->flags |= CCF_AOT_COMPILE;
 }
 
 HC_IC_BINDING(HC_ICAdd_BT, IC_BT);
@@ -4380,121 +4317,263 @@ HC_IC_BINDING(HC_ICAdd_LBTC, IC_LBTC);
 HC_IC_BINDING(HC_ICAdd_LBTS, IC_LBTS);
 HC_IC_BINDING(HC_ICAdd_LBTR, IC_LBTR);
 
-CCodeMiscRef* CodeMiscAddRef(CCodeMisc* misc, int32_t* addr)
-{
-	CCodeMiscRef* ref = A_CALLOC(sizeof(CCodeMiscRef), NULL);
-	ref->add_to = addr;
-	ref->next = misc->refs;
-	misc->refs = ref;
-	return ref;
+CCodeMiscRef *CodeMiscAddRef(CCodeMisc *misc, int32_t *addr) {
+  CCodeMiscRef *ref = A_CALLOC(sizeof(CCodeMiscRef), NULL);
+  ref->add_to = addr;
+  ref->next = misc->refs;
+  misc->refs = ref;
+  return ref;
 }
 
-void __HC_ICAdd_GetVargsPtr(CCodeCtrl *cc) 
-{
-	CRPN* rpn = A_CALLOC(sizeof(CRPN), cc->hc);
-	rpn->type = IC_GET_VARGS_PTR;
-	rpn->ic_class = NULL;
-	rpn->raw_type = RT_I64i;
-	QueIns(rpn, cc->ir_code);
-	return rpn;
+void __HC_ICAdd_GetVargsPtr(CCodeCtrl *cc) {
+  CRPN *rpn = A_CALLOC(sizeof(CRPN), cc->hc);
+  rpn->type = IC_GET_VARGS_PTR;
+  rpn->ic_class = NULL;
+  rpn->raw_type = RT_I64i;
+  QueIns(rpn, cc->ir_code);
+  return rpn;
 }
 
-void __HC_CodeMiscInterateThroughRefs(CCodeMisc* cm, void (*fptr)(void* addr, void* user_data), void* user_data)
-{
-	CCodeMiscRef* refs = cm->refs;
-	while (refs) {
+void __HC_CodeMiscInterateThroughRefs(CCodeMisc *cm,
+                                      void (*fptr)(void *addr, void *user_data),
+                                      void *user_data) {
+  CCodeMiscRef *refs = cm->refs;
+  while (refs) {
 #ifdef USE_TEMPLEOS_ABI
-		FFI_CALL_TOS_2(fptr, refs->add_to, user_data);
+    FFI_CALL_TOS_2(fptr, refs->add_to, user_data);
 #else
-		fptr(refs->add_to, user_data);
+    fptr(refs->add_to, user_data);
 #endif
-		refs = refs->next;
-	}
+    refs = refs->next;
+  }
 }
 void CmpCtrlCacheArgTrees(CCmpCtrl *cctrl) {
-	CRPN *rpn;
-	for(rpn=cctrl->code_ctrl->ir_code->next;rpn!=cctrl->code_ctrl->ir_code;rpn=rpn->base.next) {
-		rpn->ic_fwd=ICFwd(rpn);
-		switch(rpn->type) {
-		break;case IC_GOTO:
-		unop:
-		rpn->tree1=rpn->base.next;
-		continue;
-		break;case IC_GOTO_IF: goto unop;
-		break;case IC_TO_I64: goto unop;
-		break;case IC_TO_F64: goto unop;
-		break;case IC_PAREN: goto unop;
-		break;case IC_NEG: goto unop;
-		break;case IC_POS: goto unop;
-	break;case IC_POW:
-	binop:
-	rpn->tree1=rpn->base.next;
-	rpn->tree2=ICFwd(rpn->tree1);
-	continue;
-	break;case IC_ADD: goto binop;
-	break;case IC_EQ: goto binop;
-	break;case IC_SUB: goto binop;
-	break;case IC_DIV: goto binop;
-	break;case IC_MUL: goto binop;
-	break;case IC_DEREF: goto binop;
-	break;case IC_AND: goto binop;
-	break;case IC_ADDR_OF: goto unop;
-	break;case IC_XOR: goto binop;
-	break;case IC_MOD: goto binop;
-	break;case IC_OR: goto binop;
-	break;case IC_LT: goto binop;
-	break;case IC_GT: goto binop;
-	break;case IC_LNOT: goto unop;
-	break;case IC_BNOT: goto unop;
-	break;case IC_POST_INC:goto unop;
-	break;case IC_POST_DEC: goto unop;
-	break;case IC_PRE_INC: goto unop;
-	break;case IC_PRE_DEC: goto unop;
-	break;case IC_AND_AND: goto binop;
-	break;case IC_OR_OR: goto binop;
-	break;case IC_XOR_XOR: goto binop;
-	break;case IC_EQ_EQ: goto binop;
-	break;case IC_NE: goto binop;
-	break;case IC_LE: goto binop;
-	break;case IC_GE: goto binop;
-	break;case IC_LSH: goto binop;
-	break;case IC_RSH: goto binop;
-	break;case IC_ADD_EQ: goto binop;
-	break;case IC_SUB_EQ: goto binop;
-	break;case IC_MUL_EQ: goto binop;
-	break;case IC_DIV_EQ: goto binop;
-	break;case IC_LSH_EQ: goto binop;
-	break;case IC_RSH_EQ: goto binop;
-	break;case IC_AND_EQ: goto binop;
-	break;case IC_OR_EQ: goto binop;
-	break;case IC_XOR_EQ: goto binop;
-	break;case IC_MOD_EQ: goto binop;
-	break;case IC_RET: goto unop;
-	break;case IC_COMMA: goto binop;
-	break;case IC_UNBOUNDED_SWITCH: goto unop;
-	break;case IC_BOUNDED_SWITCH: goto unop;
-	break;case IC_TYPECAST: goto unop;
-	break;case IC_BT: goto binop;
-	break;case IC_BTC: goto binop;
-	break;case IC_BTS: goto binop;
-	break;case IC_BTR: goto binop;
-	break;case IC_LBTC: goto binop;
-	break;case IC_LBTS: goto binop;
-	break;case IC_LBTR: goto binop;
-	break;case IC_MAX_I64: goto binop;
-	break;case IC_MIN_I64: goto binop;
-	break;case IC_MAX_U64: goto binop;
-	break;case IC_MIN_U64: goto binop;
-	break;case IC_SIGN_I64: goto unop;
-	break;case IC_SQR_I64: goto unop;
-	break;case IC_SQR_U64: goto unop;
-	break;case IC_SQR: goto unop;
-	break;case IC_ABS: goto unop;
-	break;case IC_SQRT: goto unop;
-	break;case IC_SIN: goto unop;
-	break;case IC_COS: goto unop;
-	break;case IC_TAN: goto unop;
-	break;case IC_ATAN: goto unop;
-	}
-	}
+  CRPN *rpn;
+  for (rpn = cctrl->code_ctrl->ir_code->next; rpn != cctrl->code_ctrl->ir_code;
+       rpn = rpn->base.next) {
+    rpn->ic_fwd = ICFwd(rpn);
+    switch (rpn->type) {
+      break;
+    case IC_GOTO:
+    unop:
+      rpn->tree1 = rpn->base.next;
+      continue;
+      break;
+    case IC_GOTO_IF:
+      goto unop;
+      break;
+    case IC_TO_I64:
+      goto unop;
+      break;
+    case IC_TO_F64:
+      goto unop;
+      break;
+    case IC_PAREN:
+      goto unop;
+      break;
+    case IC_NEG:
+      goto unop;
+      break;
+    case IC_POS:
+      goto unop;
+      break;
+    case IC_POW:
+    binop:
+      rpn->tree1 = rpn->base.next;
+      rpn->tree2 = ICFwd(rpn->tree1);
+      continue;
+      break;
+    case IC_ADD:
+      goto binop;
+      break;
+    case IC_EQ:
+      goto binop;
+      break;
+    case IC_SUB:
+      goto binop;
+      break;
+    case IC_DIV:
+      goto binop;
+      break;
+    case IC_MUL:
+      goto binop;
+      break;
+    case IC_DEREF:
+      goto binop;
+      break;
+    case IC_AND:
+      goto binop;
+      break;
+    case IC_ADDR_OF:
+      goto unop;
+      break;
+    case IC_XOR:
+      goto binop;
+      break;
+    case IC_MOD:
+      goto binop;
+      break;
+    case IC_OR:
+      goto binop;
+      break;
+    case IC_LT:
+      goto binop;
+      break;
+    case IC_GT:
+      goto binop;
+      break;
+    case IC_LNOT:
+      goto unop;
+      break;
+    case IC_BNOT:
+      goto unop;
+      break;
+    case IC_POST_INC:
+      goto unop;
+      break;
+    case IC_POST_DEC:
+      goto unop;
+      break;
+    case IC_PRE_INC:
+      goto unop;
+      break;
+    case IC_PRE_DEC:
+      goto unop;
+      break;
+    case IC_AND_AND:
+      goto binop;
+      break;
+    case IC_OR_OR:
+      goto binop;
+      break;
+    case IC_XOR_XOR:
+      goto binop;
+      break;
+    case IC_EQ_EQ:
+      goto binop;
+      break;
+    case IC_NE:
+      goto binop;
+      break;
+    case IC_LE:
+      goto binop;
+      break;
+    case IC_GE:
+      goto binop;
+      break;
+    case IC_LSH:
+      goto binop;
+      break;
+    case IC_RSH:
+      goto binop;
+      break;
+    case IC_ADD_EQ:
+      goto binop;
+      break;
+    case IC_SUB_EQ:
+      goto binop;
+      break;
+    case IC_MUL_EQ:
+      goto binop;
+      break;
+    case IC_DIV_EQ:
+      goto binop;
+      break;
+    case IC_LSH_EQ:
+      goto binop;
+      break;
+    case IC_RSH_EQ:
+      goto binop;
+      break;
+    case IC_AND_EQ:
+      goto binop;
+      break;
+    case IC_OR_EQ:
+      goto binop;
+      break;
+    case IC_XOR_EQ:
+      goto binop;
+      break;
+    case IC_MOD_EQ:
+      goto binop;
+      break;
+    case IC_RET:
+      goto unop;
+      break;
+    case IC_COMMA:
+      goto binop;
+      break;
+    case IC_UNBOUNDED_SWITCH:
+      goto unop;
+      break;
+    case IC_BOUNDED_SWITCH:
+      goto unop;
+      break;
+    case IC_TYPECAST:
+      goto unop;
+      break;
+    case IC_BT:
+      goto binop;
+      break;
+    case IC_BTC:
+      goto binop;
+      break;
+    case IC_BTS:
+      goto binop;
+      break;
+    case IC_BTR:
+      goto binop;
+      break;
+    case IC_LBTC:
+      goto binop;
+      break;
+    case IC_LBTS:
+      goto binop;
+      break;
+    case IC_LBTR:
+      goto binop;
+      break;
+    case IC_MAX_I64:
+      goto binop;
+      break;
+    case IC_MIN_I64:
+      goto binop;
+      break;
+    case IC_MAX_U64:
+      goto binop;
+      break;
+    case IC_MIN_U64:
+      goto binop;
+      break;
+    case IC_SIGN_I64:
+      goto unop;
+      break;
+    case IC_SQR_I64:
+      goto unop;
+      break;
+    case IC_SQR_U64:
+      goto unop;
+      break;
+    case IC_SQR:
+      goto unop;
+      break;
+    case IC_ABS:
+      goto unop;
+      break;
+    case IC_SQRT:
+      goto unop;
+      break;
+    case IC_SIN:
+      goto unop;
+      break;
+    case IC_COS:
+      goto unop;
+      break;
+    case IC_TAN:
+      goto unop;
+      break;
+    case IC_ATAN:
+      goto unop;
+    }
+  }
 }

--- a/socket.c
+++ b/socket.c
@@ -1,134 +1,136 @@
 #include "aiwn.h"
 #if !defined(_WIN32) && !defined(WIN32)
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <netdb.h>
-#include <poll.h>
+  #include <netdb.h>
+  #include <netinet/in.h>
+  #include <poll.h>
+  #include <sys/socket.h>
+  #include <sys/types.h>
+  #include <unistd.h>
 #else
-#include <windows.h>
-#include <winsock2.h>
-#include <ws2tcpip.h>
-#include <iphlpapi.h>
-static int64_t was_init=0;
+  #include <iphlpapi.h>
+  #include <windows.h>
+  #include <winsock2.h>
+  #include <ws2tcpip.h>
+static int64_t was_init = 0;
 WSADATA ws_data;
 static void InitWS2() {
-	WSAStartup(MAKEWORD(2,2),&ws_data);
-	was_init=1;
+  WSAStartup(MAKEWORD(2, 2), &ws_data);
+  was_init = 1;
 }
 #endif
 typedef struct CInAddr {
-	char *address;
-	int64_t port;
-	struct sockaddr_in sa;
+  char *address;
+  int64_t port;
+  struct sockaddr_in sa;
 } CInAddr;
 typedef struct CNetAddr {
-	struct addrinfo *ai;
+  struct addrinfo *ai;
 } CNetAddr;
 int64_t NetSocketNew() {
-	#if defined(_WIN32) || defined (WIN32) 
-	if(!was_init)
-		InitWS2();
-	#endif
-	int64_t s=socket(AF_INET,SOCK_STREAM,IPPROTO_TCP);
-	#if defined (__FreeBSD__) || defined (__linux__)
-	int yes=1;
-	//On FreeBSD the port will stay in use for awhile after death,so reuse the address
-	setsockopt(s,SOL_SOCKET,SO_REUSEADDR,&yes,sizeof(yes));
-	#endif
-	return s;
+#if defined(_WIN32) || defined(WIN32)
+  if (!was_init)
+    InitWS2();
+#endif
+  int64_t s = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+#if defined(__FreeBSD__) || defined(__linux__)
+  int yes = 1;
+  // On FreeBSD the port will stay in use for awhile after death,so reuse the
+  // address
+  setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+#endif
+  return s;
 }
 
-CNetAddr *NetAddrNew(char *host,int64_t port) {
-	CNetAddr *ret=A_CALLOC(sizeof(CNetAddr),NULL);
-	char buf[1024];
-	struct addrinfo hints;
-	memset(&hints,0,sizeof(hints));
-	hints.ai_family=AF_UNSPEC;
-	hints.ai_socktype=SOCK_STREAM;
-	hints.ai_flags=AI_PASSIVE;
-	sprintf(buf,"%d",port);
-	getaddrinfo(host,buf,&hints,&ret->ai);
-	return ret;
+CNetAddr *NetAddrNew(char *host, int64_t port) {
+  CNetAddr *ret = A_CALLOC(sizeof(CNetAddr), NULL);
+  char buf[1024];
+  struct addrinfo hints;
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
+  hints.ai_flags = AI_PASSIVE;
+  sprintf(buf, "%d", port);
+  getaddrinfo(host, buf, &hints, &ret->ai);
+  return ret;
 }
 
 void NetAddrDel(CNetAddr *addr) {
-	freeaddrinfo(addr->ai);
-	A_FREE(addr);
+  freeaddrinfo(addr->ai);
+  A_FREE(addr);
 }
 
-void NetBindIn(int64_t socket,CNetAddr *address) {
-	bind(socket,address->ai->ai_addr,address->ai->ai_addrlen);
+void NetBindIn(int64_t socket, CNetAddr *address) {
+  bind(socket, address->ai->ai_addr, address->ai->ai_addrlen);
 }
-void NetListen(int64_t socket,int64_t max) {
-	listen(socket,max);
+void NetListen(int64_t socket, int64_t max) {
+  listen(socket, max);
 }
-int64_t NetAccept(int64_t socket,CNetAddr **addr) {
-	struct sockaddr sa;
-	socklen_t ul=sizeof(sa);
-	int64_t con=accept(socket,&sa,&ul);
-	if(addr) *addr=NULL;
-/*	if(addr) {
-		*addr=A_CALLOC(sizeof(CNetAddr),NULL);
-		addr[0]->sa=sa;
-	}*/
-	return con;
+int64_t NetAccept(int64_t socket, CNetAddr **addr) {
+  struct sockaddr sa;
+  socklen_t ul = sizeof(sa);
+  int64_t con = accept(socket, &sa, &ul);
+  if (addr)
+    *addr = NULL;
+  /*	if(addr) {
+      *addr=A_CALLOC(sizeof(CNetAddr),NULL);
+      addr[0]->sa=sa;
+    }*/
+  return con;
 }
 void NetClose(int64_t s) {
-	#if !(defined(_WIN32) || defined (WIN32))
-	//https://stackoverflow.com/questions/48208236/tcp-close-vs-shutdown-in-linux-os
-	shutdown(s,SHUT_WR);
-	shutdown(s,SHUT_RD);
-	close(s);
-	#else
-	closesocket(s);
-	#endif
+#if !(defined(_WIN32) || defined(WIN32))
+  // https://stackoverflow.com/questions/48208236/tcp-close-vs-shutdown-in-linux-os
+  shutdown(s, SHUT_WR);
+  shutdown(s, SHUT_RD);
+  close(s);
+#else
+  closesocket(s);
+#endif
 }
-int64_t NetWrite(int64_t s,char *data,int64_t len) {
-	#if defined (_WIN32) || defined (WIN32)
-	return send(s,data,len,0);
-	#else
-	return write(s,data,len);
-	#endif
-} 
-int64_t NetRead(int64_t s,char *data,int64_t len) {
-	#if defined (_WIN32) || defined (WIN32)
-	return recv(s,data,len,0);
-	#else
-	return read(s,data,len);
-	#endif
+int64_t NetWrite(int64_t s, char *data, int64_t len) {
+#if defined(_WIN32) || defined(WIN32)
+  return send(s, data, len, 0);
+#else
+  return write(s, data, len);
+#endif
 }
-static int64_t _PollFor(int64_t _for,int64_t argc,int64_t *argv) {
-	struct pollfd poll_for[argc];
-	int64_t idx;
-	for(idx=0;idx!=argc;idx++) {
-		poll_for[idx].fd=argv[0];
-		poll_for[idx].events=_for;
-		poll_for[idx].revents=0;
-	}
-	#if defined(_WIN32) || defined (WIN32)
-	WSAPoll(poll_for,argc,0);
-	#else
-	poll(poll_for,argc,0);
-	#endif
-	for(idx=0;idx!=argc;idx++) {
-		if(poll_for[idx].revents&POLLHUP) {
-			if(_for&POLLHUP)
-				return idx;
-			continue;
-		}
-		if(poll_for[idx].revents&_for)
-			return idx;
-	}
-	return -1;
+int64_t NetRead(int64_t s, char *data, int64_t len) {
+#if defined(_WIN32) || defined(WIN32)
+  return recv(s, data, len, 0);
+#else
+  return read(s, data, len);
+#endif
 }
-int64_t NetPollForRead(int64_t argc,int64_t *argv) {
-	return _PollFor(POLLIN,argc,argv);
+static int64_t _PollFor(int64_t _for, int64_t argc, int64_t *argv) {
+  struct pollfd poll_for[argc];
+  int64_t idx;
+  for (idx = 0; idx != argc; idx++) {
+    poll_for[idx].fd = argv[0];
+    poll_for[idx].events = _for;
+    poll_for[idx].revents = 0;
+  }
+#if defined(_WIN32) || defined(WIN32)
+  WSAPoll(poll_for, argc, 0);
+#else
+  poll(poll_for, argc, 0);
+#endif
+  for (idx = 0; idx != argc; idx++) {
+    if (poll_for[idx].revents & POLLHUP) {
+      if (_for & POLLHUP)
+        return idx;
+      continue;
+    }
+    if (poll_for[idx].revents & _for)
+      return idx;
+  }
+  return -1;
 }
-int64_t NetPollForWrite(int64_t argc,int64_t *argv) {
-	return _PollFor(POLLOUT,argc,argv);
+int64_t NetPollForRead(int64_t argc, int64_t *argv) {
+  return _PollFor(POLLIN, argc, argv);
 }
-int64_t NetPollForHangup(int64_t argc,int64_t *argv) {
-	return _PollFor(POLLHUP,argc,argv);
+int64_t NetPollForWrite(int64_t argc, int64_t *argv) {
+  return _PollFor(POLLOUT, argc, argv);
+}
+int64_t NetPollForHangup(int64_t argc, int64_t *argv) {
+  return _PollFor(POLLHUP, argc, argv);
 }

--- a/sound.c
+++ b/sound.c
@@ -3,38 +3,37 @@ static SDL_AudioDeviceID output;
 static int64_t sample, freq;
 static SDL_AudioSpec have;
 static double vol = .1;
-static void AudioCB(void* ul, int8_t* out, int64_t len)
-{
-	unsigned int i, i2;
-	int64_t fpb = len / have.channels;
-	for (i = 0; i < fpb; i++) {
-		double t = (double)++sample / have.freq;
-		double amp = -1.0 + 2.0 * round(fmod(2.0 * t * freq, 1.0));
-		int64_t maxed = (amp > 0) ? 127 : -127;
-		maxed *= vol;
-		if (!freq)
-			maxed = 0;
-		for (i2 = 0; i2 != have.channels; i2++)
-			out[have.channels * i + i2] = maxed;
-	}
+static void AudioCB(void *ul, int8_t *out, int64_t len) {
+  unsigned int i, i2;
+  int64_t fpb = len / have.channels;
+  for (i = 0; i < fpb; i++) {
+    double t = (double)++sample / have.freq;
+    double amp = -1.0 + 2.0 * round(fmod(2.0 * t * freq, 1.0));
+    int64_t maxed = (amp > 0) ? 127 : -127;
+    maxed *= vol;
+    if (!freq)
+      maxed = 0;
+    for (i2 = 0; i2 != have.channels; i2++)
+      out[have.channels * i + i2] = maxed;
+  }
 }
-void SndFreq(int64_t f)
-{
-	freq = f;
+void SndFreq(int64_t f) {
+  freq = f;
 }
-void InitSound()
-{
-	SDL_AudioSpec want;
-	if(SDL_Init(SDL_INIT_AUDIO)) {
-	    //Audio failed to initailize
-	    return;
-	}
-	memset(&want, 0, sizeof(SDL_AudioSpec));
-	want.freq = 24000;
-	want.format = AUDIO_S8;
-	want.channels = 2;
-	want.samples = 64;
-	want.callback = AudioCB;
-	output = SDL_OpenAudioDevice(NULL, 0, &want, &have, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE | SDL_AUDIO_ALLOW_CHANNELS_CHANGE);
-	SDL_PauseAudioDevice(output, 0);
+void InitSound() {
+  SDL_AudioSpec want;
+  if (SDL_Init(SDL_INIT_AUDIO)) {
+    // Audio failed to initailize
+    return;
+  }
+  memset(&want, 0, sizeof(SDL_AudioSpec));
+  want.freq = 24000;
+  want.format = AUDIO_S8;
+  want.channels = 2;
+  want.samples = 64;
+  want.callback = AudioCB;
+  output = SDL_OpenAudioDevice(NULL, 0, &want, &have,
+                               SDL_AUDIO_ALLOW_FREQUENCY_CHANGE |
+                                   SDL_AUDIO_ALLOW_CHANNELS_CHANGE);
+  SDL_PauseAudioDevice(output, 0);
 }

--- a/swapctxWIN.s
+++ b/swapctxWIN.s
@@ -1,59 +1,62 @@
-SECTION .text
-GLOBAL AIWNIOS_getcontext
-GLOBAL AIWNIOS_setcontext
-GLOBAL AIWNIOS_makecontext
+.intel_syntax noprefix
+.global AIWNIOS_getcontext
+.global AIWNIOS_setcontext
+.global AIWNIOS_makecontext
+
 AIWNIOS_getcontext:
-	POP RDX
-	POP RAX
-	MOV QWORD [RAX+0*8],RDX
-	MOV QWORD [RAX+1*8],RSP
-	MOV QWORD [RAX+2*8],RBP
-	MOV QWORD [RAX+3*8],R11
-	MOV QWORD [RAX+4*8],R12
-	MOV QWORD [RAX+5*8],R13
-	MOV QWORD [RAX+6*8],R14
-	MOV QWORD [RAX+7*8],R15
-	MOVSD QWORD [RAX+9*8],XMM6
-	MOVSD QWORD [RAX+10*8],XMM7
-	MOVSD QWORD [RAX+11*8],XMM8
-	MOVSD QWORD [RAX+12*8],XMM9
-	MOVSD QWORD [RAX+13*8],XMM10
-	MOVSD QWORD [RAX+14*8],XMM11
-	MOVSD QWORD [RAX+15*8],XMM12
-	MOVSD QWORD [RAX+16*8],XMM13
-	MOVSD QWORD [RAX+17*8],XMM14
-	MOVSD QWORD [RAX+19*8],XMM15
-	MOV QWORD [RAX+20*8],R10
-	MOV QWORD [RAX+21*8],RDI
-	MOV QWORD [RAX+22*8],RSI
-	MOV RAX,0
-	JMP RDX
+  pop rdx
+  pop rax
+  mov qword ptr [rax+0*8],rdx
+  mov qword ptr [rax+1*8],rsp
+  mov qword ptr [rax+2*8],rbp
+  mov qword ptr [rax+3*8],r11
+  mov qword ptr [rax+4*8],r12
+  mov qword ptr [rax+5*8],r13
+  mov qword ptr [rax+6*8],r14
+  mov qword ptr [rax+7*8],r15
+  movsd qword ptr [rax+9*8],xmm6
+  movsd qword ptr [rax+10*8],xmm7
+  movsd qword ptr [rax+11*8],xmm8
+  movsd qword ptr [rax+12*8],xmm9
+  movsd qword ptr [rax+13*8],xmm10
+  movsd qword ptr [rax+14*8],xmm11
+  movsd qword ptr [rax+15*8],xmm12
+  movsd qword ptr [rax+16*8],xmm13
+  movsd qword ptr [rax+17*8],xmm14
+  movsd qword ptr [rax+19*8],xmm15
+  mov qword ptr [rax+20*8],r10
+  mov qword ptr [rax+21*8],rdi
+  mov qword ptr [rax+22*8],rsi
+  mov rax,0
+  jmp rdx
+
 AIWNIOS_setcontext:
-	MOV RAX,QWORD [RSP+8]
-	MOV RCX,QWORD [RAX+0*8]
-	MOV RSP,QWORD [RAX+1*8]
-	MOV RBP,QWORD [RAX+2*8]
-	MOV R11,QWORD [RAX+3*8]
-	MOV R12,QWORD [RAX+4*8]
-	MOV R13,QWORD [RAX+5*8]
-	MOV R14,QWORD [RAX+6*8]
-	MOV R15,QWORD [RAX+7*8]
-	MOVSD XMM6,QWORD [RAX+9*8]
-	MOVSD XMM7,QWORD [RAX+10*8]
-	MOVSD XMM8,QWORD [RAX+11*8]
-	MOVSD XMM9,QWORD [RAX+12*8]
-	MOVSD XMM10,QWORD [RAX+13*8]
-	MOVSD XMM11,QWORD [RAX+14*8]
-	MOVSD XMM12,QWORD [RAX+15*8]
-	MOVSD XMM13,QWORD [RAX+16*8]
-	MOVSD XMM14,QWORD [RAX+17*8]
-	MOVSD XMM15,QWORD [RAX+19*8]
-	MOV R10,QWORD [RAX+20*8]
-	MOV RDI,QWORD [RAX+21*8]
-	MOV RSI,QWORD [RAX+22*8]
-	MOV RAX,1
-	JMP RCX
+  mov rax,qword ptr [rsp+8]
+  mov rcx,qword ptr [rax+0*8]
+  mov rsp,qword ptr [rax+1*8]
+  mov rbp,qword ptr [rax+2*8]
+  mov r11,qword ptr [rax+3*8]
+  mov r12,qword ptr [rax+4*8]
+  mov r13,qword ptr [rax+5*8]
+  mov r14,qword ptr [rax+6*8]
+  mov r15,qword ptr [rax+7*8]
+  movsd xmm6,qword ptr [rax+9*8]
+  movsd xmm7,qword ptr [rax+10*8]
+  movsd xmm8,qword ptr [rax+11*8]
+  movsd xmm9,qword ptr [rax+12*8]
+  movsd xmm10,qword ptr [rax+13*8]
+  movsd xmm11,qword ptr [rax+14*8]
+  movsd xmm12,qword ptr [rax+15*8]
+  movsd xmm13,qword ptr [rax+16*8]
+  movsd xmm14,qword ptr [rax+17*8]
+  movsd xmm15,qword ptr [rax+19*8]
+  mov r10,qword ptr [rax+20*8]
+  mov rdi,qword ptr [rax+21*8]
+  mov rsi,qword ptr [rax+22*8]
+  mov rax,1
+  jmp rcx
+
 AIWNIOS_makecontext:
-	MOV QWORD [RCX+0*8],RDX
-	MOV QWORD [RCX+1*8],R8
-	RET
+  mov qword ptr [rcx+0*8],rdx
+  mov qword ptr [rcx+1*8],r8
+  ret

--- a/swapctxX86.s
+++ b/swapctxX86.s
@@ -14,7 +14,7 @@ AIWNIOS_getcontext:
   mov qword ptr [rax+5*8],r13
   mov qword ptr [rax+6*8],r14
   mov qword ptr [rax+7*8],r15
-  movsd qword ptr [rax+9*8],xmm6
+  movsd qword ptr [rax+9*8],xmm6 # qword because double
   movsd qword ptr [rax+10*8],xmm7
   movsd qword ptr [rax+11*8],xmm8
   movsd qword ptr [rax+12*8],xmm9

--- a/swapctxX86.s
+++ b/swapctxX86.s
@@ -1,59 +1,62 @@
-SECTION .text
-GLOBAL AIWNIOS_getcontext
-GLOBAL AIWNIOS_setcontext
-GLOBAL AIWNIOS_makecontext
+.intel_syntax noprefix
+.global AIWNIOS_getcontext
+.global AIWNIOS_setcontext
+.global AIWNIOS_makecontext
+
 AIWNIOS_getcontext:
-	POP RDX
-	POP RAX
-	MOV QWORD [RAX+0*8],RDX
-	MOV QWORD [RAX+1*8],RSP
-	MOV QWORD [RAX+2*8],RBP
-	MOV QWORD [RAX+3*8],R11
-	MOV QWORD [RAX+4*8],R12
-	MOV QWORD [RAX+5*8],R13
-	MOV QWORD [RAX+6*8],R14
-	MOV QWORD [RAX+7*8],R15
-	MOVSD QWORD [RAX+9*8],XMM6
-	MOVSD QWORD [RAX+10*8],XMM7
-	MOVSD QWORD [RAX+11*8],XMM8
-	MOVSD QWORD [RAX+12*8],XMM9
-	MOVSD QWORD [RAX+13*8],XMM10
-	MOVSD QWORD [RAX+14*8],XMM11
-	MOVSD QWORD [RAX+15*8],XMM12
-	MOVSD QWORD [RAX+16*8],XMM13
-	MOVSD QWORD [RAX+17*8],XMM14
-	MOVSD QWORD [RAX+19*8],XMM15
-	MOV QWORD [RAX+20*8],R10
-	MOV QWORD [RAX+21*8],RDI
-	MOV QWORD [RAX+22*8],RSI
-	MOV RAX,0
-	JMP RDX
+  pop rdx
+  pop rax
+  mov qword ptr [rax+0*8],rdx
+  mov qword ptr [rax+1*8],rsp
+  mov qword ptr [rax+2*8],rbp
+  mov qword ptr [rax+3*8],r11
+  mov qword ptr [rax+4*8],r12
+  mov qword ptr [rax+5*8],r13
+  mov qword ptr [rax+6*8],r14
+  mov qword ptr [rax+7*8],r15
+  movsd qword ptr [rax+9*8],xmm6
+  movsd qword ptr [rax+10*8],xmm7
+  movsd qword ptr [rax+11*8],xmm8
+  movsd qword ptr [rax+12*8],xmm9
+  movsd qword ptr [rax+13*8],xmm10
+  movsd qword ptr [rax+14*8],xmm11
+  movsd qword ptr [rax+15*8],xmm12
+  movsd qword ptr [rax+16*8],xmm13
+  movsd qword ptr [rax+17*8],xmm14
+  movsd qword ptr [rax+19*8],xmm15
+  mov qword ptr [rax+20*8],r10
+  mov qword ptr [rax+21*8],rdi
+  mov qword ptr [rax+22*8],rsi
+  mov rax,0
+  jmp rdx
+
 AIWNIOS_setcontext:
-	MOV RAX,QWORD [RSP+8]
-	MOV RCX,QWORD [RAX+0*8]
-	MOV RSP,QWORD [RAX+1*8]
-	MOV RBP,QWORD [RAX+2*8]
-	MOV R11,QWORD [RAX+3*8]
-	MOV R12,QWORD [RAX+4*8]
-	MOV R13,QWORD [RAX+5*8]
-	MOV R14,QWORD [RAX+6*8]
-	MOV R15,QWORD [RAX+7*8]
-	MOVSD XMM6,QWORD [RAX+9*8]
-	MOVSD XMM7,QWORD [RAX+10*8]
-	MOVSD XMM8,QWORD [RAX+11*8]
-	MOVSD XMM9,QWORD [RAX+12*8]
-	MOVSD XMM10,QWORD [RAX+13*8]
-	MOVSD XMM11,QWORD [RAX+14*8]
-	MOVSD XMM12,QWORD [RAX+15*8]
-	MOVSD XMM13,QWORD [RAX+16*8]
-	MOVSD XMM14,QWORD [RAX+17*8]
-	MOVSD XMM15,QWORD [RAX+19*8]
-	MOV R10,QWORD [RAX+20*8]
-	MOV RDI,QWORD [RAX+21*8]
-	MOV RSI,QWORD [RAX+22*8]
-	MOV RAX,1
-	JMP RCX
+  mov rax,qword ptr [rsp+8]
+  mov rcx,qword ptr [rax+0*8]
+  mov rsp,qword ptr [rax+1*8]
+  mov rbp,qword ptr [rax+2*8]
+  mov r11,qword ptr [rax+3*8]
+  mov r12,qword ptr [rax+4*8]
+  mov r13,qword ptr [rax+5*8]
+  mov r14,qword ptr [rax+6*8]
+  mov r15,qword ptr [rax+7*8]
+  movsd xmm6,qword ptr [rax+9*8]
+  movsd xmm7,qword ptr [rax+10*8]
+  movsd xmm8,qword ptr [rax+11*8]
+  movsd xmm9,qword ptr [rax+12*8]
+  movsd xmm10,qword ptr [rax+13*8]
+  movsd xmm11,qword ptr [rax+14*8]
+  movsd xmm12,qword ptr [rax+15*8]
+  movsd xmm13,qword ptr [rax+16*8]
+  movsd xmm14,qword ptr [rax+17*8]
+  movsd xmm15,qword ptr [rax+19*8]
+  mov r10,qword ptr [rax+20*8]
+  mov rdi,qword ptr [rax+21*8]
+  mov rsi,qword ptr [rax+22*8]
+  mov rax,1
+  jmp rcx
+
 AIWNIOS_makecontext:
-	MOV QWORD [RDI+0*8],RSI
-	MOV QWORD [RDI+1*8],RDX
-	RET
+  mov qword ptr [rdi+0*8],rsi
+  mov qword ptr [rdi+1*8],rdx
+  ret

--- a/windows.c
+++ b/windows.c
@@ -4,132 +4,130 @@
 #include <SDL2/SDL_render.h>
 #include <SDL2/SDL_surface.h>
 #include <SDL2/SDL_video.h>
-static SDL_Palette* sdl_p;
-static SDL_Surface* screen;
-static SDL_Window* window;
+static SDL_Palette *sdl_p;
+static SDL_Surface *screen;
+static SDL_Window *window;
 static SDL_Rect view_port;
-static SDL_Renderer* renderer;
+static SDL_Renderer *renderer;
 static uint32_t palette[0x100];
-static SDL_Thread* sdl_main_thread;
+static SDL_Thread *sdl_main_thread;
 int64_t user_ev_num;
 static SDL_mutex *screen_mutex, *screen_mutex2;
-static SDL_cond* screen_done_cond;
+static SDL_cond *screen_done_cond;
 static int64_t screen_ready = 0;
 #define USER_CODE_DRAW_WIN_NEW 1
 #define USER_CODE_UPDATE 2
 
-static void _DrawWindowNew()
-{
-	if(SDL_Init(SDL_INIT_VIDEO)) {
-		return;
-	}
-	int rends;
-	SDL_SetHintWithPriority(SDL_HINT_RENDER_SCALE_QUALITY, "linear", SDL_HINT_OVERRIDE);
-	SDL_SetHintWithPriority(SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR, "0", SDL_HINT_OVERRIDE);
-	SDL_RendererInfo info;
-	screen_mutex = SDL_CreateMutex();
-	screen_mutex2 = SDL_CreateMutex();
-	screen_done_cond = SDL_CreateCond();
-	SDL_LockMutex(screen_mutex);
-	window = SDL_CreateWindow("AIWNIOS", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, 640, 480, SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE);
-	screen = SDL_CreateRGBSurface(0, 640, 480, 8, 0, 0, 0, 0);
-	SDL_SetWindowMinimumSize(window, 640, 480);
-	SDL_ShowCursor(SDL_DISABLE);
-	renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
-	SDL_UnlockMutex(screen_mutex);
-	Misc_LBts(&screen_ready, 0);
+static void _DrawWindowNew() {
+  if (SDL_Init(SDL_INIT_VIDEO)) {
+    return;
+  }
+  int rends;
+  SDL_SetHintWithPriority(SDL_HINT_RENDER_SCALE_QUALITY, "linear",
+                          SDL_HINT_OVERRIDE);
+  SDL_SetHintWithPriority(SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR, "0",
+                          SDL_HINT_OVERRIDE);
+  SDL_RendererInfo info;
+  screen_mutex = SDL_CreateMutex();
+  screen_mutex2 = SDL_CreateMutex();
+  screen_done_cond = SDL_CreateCond();
+  SDL_LockMutex(screen_mutex);
+  window = SDL_CreateWindow("AIWNIOS", SDL_WINDOWPOS_UNDEFINED,
+                            SDL_WINDOWPOS_UNDEFINED, 640, 480,
+                            SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE);
+  screen = SDL_CreateRGBSurface(0, 640, 480, 8, 0, 0, 0, 0);
+  SDL_SetWindowMinimumSize(window, 640, 480);
+  SDL_ShowCursor(SDL_DISABLE);
+  renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
+  SDL_UnlockMutex(screen_mutex);
+  Misc_LBts(&screen_ready, 0);
 }
 
-static void UpdateViewPort()
-{
-	int w, h, margin_x = 0, margin_y = 0, w2, h2;
-	SDL_GetWindowSize(window, &w, &h);
-	if (w > h) {
-		h2 = w * 480. / 640;
-		w2 = w;
-		margin_y = (h - h2) / 2;
-		if (h < h2) {
-			margin_y = 0;
-			goto use_h;
-		}
-	} else {
-	use_h:
-		w2 = h * 640. / 480;
-		h2 = h;
-		margin_x = (w - w2) / 2;
-	}
-	view_port.x = margin_x;
-	view_port.y = margin_y;
-	view_port.w = w2;
-	view_port.h = h2;
+static void UpdateViewPort() {
+  int w, h, margin_x = 0, margin_y = 0, w2, h2;
+  SDL_GetWindowSize(window, &w, &h);
+  if (w > h) {
+    h2 = w * 480. / 640;
+    w2 = w;
+    margin_y = (h - h2) / 2;
+    if (h < h2) {
+      margin_y = 0;
+      goto use_h;
+    }
+  } else {
+  use_h:
+    w2 = h * 640. / 480;
+    h2 = h;
+    margin_x = (w - w2) / 2;
+  }
+  view_port.x = margin_x;
+  view_port.y = margin_y;
+  view_port.w = w2;
+  view_port.h = h2;
 }
 
-void DrawWindowNew()
-{
-	SDL_Event event;
-	memset(&event, 0, sizeof event);
-	event.user.code = USER_CODE_DRAW_WIN_NEW;
-	event.type = user_ev_num;
-	SDL_PushEvent(&event);
-	while (!Misc_Bt(&screen_ready, 0))
-		SDL_Delay(1);
-	return;
+void DrawWindowNew() {
+  SDL_Event event;
+  memset(&event, 0, sizeof event);
+  event.user.code = USER_CODE_DRAW_WIN_NEW;
+  event.type = user_ev_num;
+  SDL_PushEvent(&event);
+  while (!Misc_Bt(&screen_ready, 0))
+    SDL_Delay(1);
+  return;
 }
-void UpdateScreen(char* px, int64_t w, int64_t h, int64_t w_internal)
-{
-	SDL_Event event;
-	memset(&event, 0, sizeof event);
-	event.user.code = USER_CODE_UPDATE;
-	event.user.data1 = px;
-	event.user.data2 = w_internal;
-	event.type = user_ev_num;
-	SDL_LockMutex(screen_mutex);
-	SDL_PushEvent(&event);
-	SDL_UnlockMutex(screen_mutex);
-	SDL_LockMutex(screen_mutex2);
-	SDL_CondWaitTimeout(screen_done_cond, screen_mutex2, 33);
-	SDL_UnlockMutex(screen_mutex2);
-	return;
+void UpdateScreen(char *px, int64_t w, int64_t h, int64_t w_internal) {
+  SDL_Event event;
+  memset(&event, 0, sizeof event);
+  event.user.code = USER_CODE_UPDATE;
+  event.user.data1 = px;
+  event.user.data2 = w_internal;
+  event.type = user_ev_num;
+  SDL_LockMutex(screen_mutex);
+  SDL_PushEvent(&event);
+  SDL_UnlockMutex(screen_mutex);
+  SDL_LockMutex(screen_mutex2);
+  SDL_CondWaitTimeout(screen_done_cond, screen_mutex2, 33);
+  SDL_UnlockMutex(screen_mutex2);
+  return;
 }
-static void _UpdateScreen(char* px, int64_t w, int64_t h, int64_t w_internal)
-{
-	int64_t idx;
-	SDL_Texture* text;
-	SDL_LockMutex(screen_mutex);
-	SDL_LockSurface(screen);
-	char* dst = screen->pixels;
-	for (idx = 0; idx != h; idx++) {
-		memcpy(dst, px, w);
-		px += w_internal;
-		dst += screen->pitch;
-	}
-	SDL_UnlockSurface(screen);
-	SDL_RenderClear(renderer);
-	UpdateViewPort();
-	text = SDL_CreateTextureFromSurface(renderer, screen);
-	SDL_RenderCopy(renderer, text, NULL, &view_port);
-	SDL_RenderPresent(renderer);
-	SDL_DestroyTexture(text);
-	SDL_CondBroadcast(screen_done_cond);
-	SDL_UnlockMutex(screen_mutex);
+static void _UpdateScreen(char *px, int64_t w, int64_t h, int64_t w_internal) {
+  int64_t idx;
+  SDL_Texture *text;
+  SDL_LockMutex(screen_mutex);
+  SDL_LockSurface(screen);
+  char *dst = screen->pixels;
+  for (idx = 0; idx != h; idx++) {
+    memcpy(dst, px, w);
+    px += w_internal;
+    dst += screen->pitch;
+  }
+  SDL_UnlockSurface(screen);
+  SDL_RenderClear(renderer);
+  UpdateViewPort();
+  text = SDL_CreateTextureFromSurface(renderer, screen);
+  SDL_RenderCopy(renderer, text, NULL, &view_port);
+  SDL_RenderPresent(renderer);
+  SDL_DestroyTexture(text);
+  SDL_CondBroadcast(screen_done_cond);
+  SDL_UnlockMutex(screen_mutex);
 }
 
-void GrPaletteColorSet(int64_t i, uint64_t bgr48)
-{
-	if (!screen)
-		return;
-	int64_t repeat = 256 / 16;
-	int64_t i2;
-	int64_t b = (bgr48 & 0xffff) / (double)0xffff * 0xff;
-	int64_t g = ((bgr48 >> 16) & 0xffff) / (double)0xffff * 0xff;
-	int64_t r = ((bgr48 >> 32) & 0xffff) / (double)0xffff * 0xff;
-	palette[i] = r | (g << 8) | (b << 16);
-	SDL_Color c = { r, g, b, 0x0 };
-	SDL_LockSurface(screen);
-	// I will repeat the color to simulate ignoring the upper 4 bits
-	for (i2 = 0; i2 != repeat; i2++)
-		SDL_SetPaletteColors(screen->format->palette, &c, i2 * 16 + i, 1);
-	SDL_UnlockSurface(screen);
+void GrPaletteColorSet(int64_t i, uint64_t bgr48) {
+  if (!screen)
+    return;
+  int64_t repeat = 256 / 16;
+  int64_t i2;
+  int64_t b = (bgr48 & 0xffff) / (double)0xffff * 0xff;
+  int64_t g = ((bgr48 >> 16) & 0xffff) / (double)0xffff * 0xff;
+  int64_t r = ((bgr48 >> 32) & 0xffff) / (double)0xffff * 0xff;
+  palette[i] = r | (g << 8) | (b << 16);
+  SDL_Color c = {r, g, b, 0x0};
+  SDL_LockSurface(screen);
+  // I will repeat the color to simulate ignoring the upper 4 bits
+  for (i2 = 0; i2 != repeat; i2++)
+    SDL_SetPaletteColors(screen->format->palette, &c, i2 * 16 + i, 1);
+  SDL_UnlockSurface(screen);
 }
 
 #define CH_CTRLA 0x01
@@ -240,353 +238,343 @@ void GrPaletteColorSet(int64_t i, uint64_t bgr48)
 #define IS_CAPS(x) (x & (KMOD_RSHIFT | KMOD_LSHIFT | KMOD_CAPS))
 // http://www.rohitab.com/discuss/topic/39438-keyboard-driver/
 static char keys[] = {
-	0, CH_ESC, '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '-', '=', '\b', '\t', 'q',
-	'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p', '[', ']', '\n', 0, 'a', 's', 'd',
-	'f', 'g', 'h', 'j', 'k', 'l', ';', '\'', '`', 0, '\\', 'z', 'x', 'c', 'v', 'b',
-	'n', 'm', ',', '.', '/', 0, '*', 0, ' ', 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, '-', 0, '5', 0, '+', 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0
-};
-static int64_t K2SC(char ch)
-{
-	int64_t i = 0;
-	for (; i != sizeof(keys) / sizeof(*keys); i++) {
-		if (keys[i] == ch)
-			return i;
-	}
+    0,   CH_ESC, '1',  '2', '3',  '4', '5', '6', '7', '8', '9', '0', '-',
+    '=', '\b',   '\t', 'q', 'w',  'e', 'r', 't', 'y', 'u', 'i', 'o', 'p',
+    '[', ']',    '\n', 0,   'a',  's', 'd', 'f', 'g', 'h', 'j', 'k', 'l',
+    ';', '\'',   '`',  0,   '\\', 'z', 'x', 'c', 'v', 'b', 'n', 'm', ',',
+    '.', '/',    0,    '*', 0,    ' ', 0,   0,   0,   0,   0,   0,   0,
+    0,   0,      0,    0,   0,    0,   0,   0,   0,   '-', 0,   '5', 0,
+    '+', 0,      0,    0,   0,    0,   0,   0,   0,   0,   0,   0};
+static int64_t K2SC(char ch) {
+  int64_t i = 0;
+  for (; i != sizeof(keys) / sizeof(*keys); i++) {
+    if (keys[i] == ch)
+      return i;
+  }
 }
-static int32_t __ScanKey(int64_t* ch, int64_t* sc, SDL_Event* _e)
-{
-	SDL_Event e = *_e;
-	int64_t mod = 0, cond, dummy;
-	if (!ch)
-		ch = &dummy;
-	if (!sc)
-		sc = &dummy;
-	cond = 1;
-	if (cond) {
-		if (e.type == SDL_KEYDOWN) {
-		ent:
-			*ch = *sc = 0;
-			if (e.key.keysym.mod & (KMOD_LSHIFT | KMOD_RSHIFT))
-				mod |= SCF_SHIFT;
-			else
-				mod |= SCF_NO_SHIFT;
-			if (e.key.keysym.mod & (KMOD_LCTRL | KMOD_RCTRL))
-				mod |= SCF_CTRL;
-			if (e.key.keysym.mod & (KMOD_LALT | KMOD_RALT))
-				mod |= SCF_ALT;
-			if (e.key.keysym.mod & (KMOD_CAPS))
-				mod |= SCF_CAPS;
-			if (e.key.keysym.mod & (KMOD_NUM))
-				mod |= SCF_NUM;
-			*sc = e.key.keysym.scancode;
-			switch (e.key.keysym.scancode) {
-			case SDL_SCANCODE_SPACE:
-				return *sc = K2SC(' ') | mod;
-			case SDL_SCANCODE_APOSTROPHE:
-				return *sc = K2SC('\'') | mod;
-			case SDL_SCANCODE_COMMA:
-				return *sc = K2SC(',') | mod;
-			case SDL_SCANCODE_MINUS:
-				return *sc = K2SC('-') | mod;
-			case SDL_SCANCODE_PERIOD:
-				return *sc = K2SC('.') | mod;
-			case SDL_SCANCODE_GRAVE:
-				return *sc = K2SC('`') | mod;
-			case SDL_SCANCODE_SLASH:
-				return *sc = K2SC('/') | mod;
-			case SDL_SCANCODE_0:
-				return *sc = K2SC('0') | mod;
-			case SDL_SCANCODE_1:
-				return *sc = K2SC('1') | mod;
-			case SDL_SCANCODE_2:
-				return *sc = K2SC('2') | mod;
-			case SDL_SCANCODE_3:
-				return *sc = K2SC('3') | mod;
-			case SDL_SCANCODE_4:
-				return *sc = K2SC('4') | mod;
-			case SDL_SCANCODE_5:
-				return *sc = K2SC('5') | mod;
-			case SDL_SCANCODE_6:
-				return *sc = K2SC('6') | mod;
-			case SDL_SCANCODE_7:
-				return *sc = K2SC('7') | mod;
-			case SDL_SCANCODE_8:
-				return *sc = K2SC('8') | mod;
-			case SDL_SCANCODE_9:
-				return *sc = K2SC('9') | mod;
-			case SDL_SCANCODE_SEMICOLON:
-				return *sc = K2SC(';') | mod;
-			case SDL_SCANCODE_EQUALS:
-				return *sc = K2SC('=') | mod;
-			case SDL_SCANCODE_LEFTBRACKET:
-				return *sc = K2SC('[') | mod;
-			case SDL_SCANCODE_RIGHTBRACKET:
-				return *sc = K2SC(']') | mod;
-			case SDL_SCANCODE_BACKSLASH:
-				return *sc = K2SC('\\') | mod;
-			case SDL_SCANCODE_Q:
-				return *sc = K2SC('q') | mod;
-			case SDL_SCANCODE_W:
-				return *sc = K2SC('w') | mod;
-			case SDL_SCANCODE_E:
-				return *sc = K2SC('e') | mod;
-			case SDL_SCANCODE_R:
-				return *sc = K2SC('r') | mod;
-			case SDL_SCANCODE_T:
-				return *sc = K2SC('t') | mod;
-			case SDL_SCANCODE_Y:
-				return *sc = K2SC('y') | mod;
-			case SDL_SCANCODE_U:
-				return *sc = K2SC('u') | mod;
-			case SDL_SCANCODE_I:
-				return *sc = K2SC('i') | mod;
-			case SDL_SCANCODE_O:
-				return *sc = K2SC('o') | mod;
-			case SDL_SCANCODE_P:
-				return *sc = K2SC('p') | mod;
-			case SDL_SCANCODE_A:
-				return *sc = K2SC('a') | mod;
-			case SDL_SCANCODE_S:
-				return *sc = K2SC('s') | mod;
-			case SDL_SCANCODE_D:
-				return *sc = K2SC('d') | mod;
-			case SDL_SCANCODE_F:
-				return *sc = K2SC('f') | mod;
-			case SDL_SCANCODE_G:
-				return *sc = K2SC('g') | mod;
-			case SDL_SCANCODE_H:
-				return *sc = K2SC('h') | mod;
-			case SDL_SCANCODE_J:
-				return *sc = K2SC('j') | mod;
-			case SDL_SCANCODE_K:
-				return *sc = K2SC('k') | mod;
-			case SDL_SCANCODE_L:
-				return *sc = K2SC('l') | mod;
-			case SDL_SCANCODE_Z:
-				return *sc = K2SC('z') | mod;
-			case SDL_SCANCODE_X:
-				return *sc = K2SC('x') | mod;
-			case SDL_SCANCODE_C:
-				return *sc = K2SC('c') | mod;
-			case SDL_SCANCODE_V:
-				return *sc = K2SC('v') | mod;
-			case SDL_SCANCODE_B:
-				return *sc = K2SC('b') | mod;
-			case SDL_SCANCODE_N:
-				return *sc = K2SC('n') | mod;
-			case SDL_SCANCODE_M:
-				return *sc = K2SC('m') | mod;
-			case SDL_SCANCODE_ESCAPE:
-				*sc = mod | SC_ESC;
-				return 1;
-			case SDL_SCANCODE_BACKSPACE:
-				*sc = mod | SC_BACKSPACE;
-				return 1;
-			case SDL_SCANCODE_TAB:
-				*sc = mod | SC_TAB;
-				return 1;
-			case SDL_SCANCODE_RETURN:
-				*sc = mod | SC_ENTER;
-				return 1;
-			case SDL_SCANCODE_LSHIFT:
-			case SDL_SCANCODE_RSHIFT:
-				*sc = mod | SC_SHIFT;
-				return 1;
-			case SDL_SCANCODE_LALT:
-				*sc = mod | SC_ALT;
-				return 1;
-			case SDL_SCANCODE_RALT:
-				*sc = mod | SC_ALT;
-				return 1;
-			case SDL_SCANCODE_LCTRL:
-				*sc = mod | SC_CTRL;
-				return 1;
-			case SDL_SCANCODE_RCTRL:
-				*sc = mod | SC_CTRL;
-				return 1;
-			case SDL_SCANCODE_CAPSLOCK:
-				*sc = mod | SC_CAPS;
-				return 1;
-			case SDL_SCANCODE_NUMLOCKCLEAR:
-				*sc = mod | SC_NUM;
-				return 1;
-			case SDL_SCANCODE_SCROLLLOCK:
-				*sc = mod | SC_SCROLL;
-				return 1;
-			case SDL_SCANCODE_DOWN:
-				*sc = mod | SC_CURSOR_DOWN;
-				return 1;
-			case SDL_SCANCODE_UP:
-				*sc = mod | SC_CURSOR_UP;
-				return 1;
-			case SDL_SCANCODE_RIGHT:
-				*sc = mod | SC_CURSOR_RIGHT;
-				return 1;
-			case SDL_SCANCODE_LEFT:
-				*sc = mod | SC_CURSOR_LEFT;
-				return 1;
-			case SDL_SCANCODE_PAGEDOWN:
-				*sc = mod | SC_PAGE_DOWN;
-				return 1;
-			case SDL_SCANCODE_PAGEUP:
-				*sc = mod | SC_PAGE_UP;
-				return 1;
-			case SDL_SCANCODE_HOME:
-				*sc = mod | SC_HOME;
-				return 1;
-			case SDL_SCANCODE_END:
-				*sc = mod | SC_END;
-				return 1;
-			case SDL_SCANCODE_INSERT:
-				*sc = mod | SC_INS;
-				return 1;
-			case SDL_SCANCODE_DELETE:
-				*sc = mod | SC_DELETE;
-				return 1;
-			case SDL_SCANCODE_LGUI:
-			case SDL_SCANCODE_RGUI:
-				*sc = mod | SC_GUI;
-				return 1;
-			case SDL_SCANCODE_PRINTSCREEN:
-				*sc = mod | SC_PRTSCRN1;
-				return 1;
-			case SDL_SCANCODE_PAUSE:
-				*sc = mod | SC_PAUSE;
-				return 1;
-			case SDL_SCANCODE_F1 ... SDL_SCANCODE_F12:
-				*sc = mod | (SC_F1 + e.key.keysym.scancode - SDL_SCANCODE_F1);
-				return 1;
-			}
-		} else if (e.type == SDL_KEYUP) {
-			mod |= SCF_KEY_UP;
-			goto ent;
-		}
-	}
-	return -1;
+static int32_t __ScanKey(int64_t *ch, int64_t *sc, SDL_Event *_e) {
+  SDL_Event e = *_e;
+  int64_t mod = 0, cond, dummy;
+  if (!ch)
+    ch = &dummy;
+  if (!sc)
+    sc = &dummy;
+  cond = 1;
+  if (cond) {
+    if (e.type == SDL_KEYDOWN) {
+    ent:
+      *ch = *sc = 0;
+      if (e.key.keysym.mod & (KMOD_LSHIFT | KMOD_RSHIFT))
+        mod |= SCF_SHIFT;
+      else
+        mod |= SCF_NO_SHIFT;
+      if (e.key.keysym.mod & (KMOD_LCTRL | KMOD_RCTRL))
+        mod |= SCF_CTRL;
+      if (e.key.keysym.mod & (KMOD_LALT | KMOD_RALT))
+        mod |= SCF_ALT;
+      if (e.key.keysym.mod & (KMOD_CAPS))
+        mod |= SCF_CAPS;
+      if (e.key.keysym.mod & (KMOD_NUM))
+        mod |= SCF_NUM;
+      *sc = e.key.keysym.scancode;
+      switch (e.key.keysym.scancode) {
+      case SDL_SCANCODE_SPACE:
+        return *sc = K2SC(' ') | mod;
+      case SDL_SCANCODE_APOSTROPHE:
+        return *sc = K2SC('\'') | mod;
+      case SDL_SCANCODE_COMMA:
+        return *sc = K2SC(',') | mod;
+      case SDL_SCANCODE_MINUS:
+        return *sc = K2SC('-') | mod;
+      case SDL_SCANCODE_PERIOD:
+        return *sc = K2SC('.') | mod;
+      case SDL_SCANCODE_GRAVE:
+        return *sc = K2SC('`') | mod;
+      case SDL_SCANCODE_SLASH:
+        return *sc = K2SC('/') | mod;
+      case SDL_SCANCODE_0:
+        return *sc = K2SC('0') | mod;
+      case SDL_SCANCODE_1:
+        return *sc = K2SC('1') | mod;
+      case SDL_SCANCODE_2:
+        return *sc = K2SC('2') | mod;
+      case SDL_SCANCODE_3:
+        return *sc = K2SC('3') | mod;
+      case SDL_SCANCODE_4:
+        return *sc = K2SC('4') | mod;
+      case SDL_SCANCODE_5:
+        return *sc = K2SC('5') | mod;
+      case SDL_SCANCODE_6:
+        return *sc = K2SC('6') | mod;
+      case SDL_SCANCODE_7:
+        return *sc = K2SC('7') | mod;
+      case SDL_SCANCODE_8:
+        return *sc = K2SC('8') | mod;
+      case SDL_SCANCODE_9:
+        return *sc = K2SC('9') | mod;
+      case SDL_SCANCODE_SEMICOLON:
+        return *sc = K2SC(';') | mod;
+      case SDL_SCANCODE_EQUALS:
+        return *sc = K2SC('=') | mod;
+      case SDL_SCANCODE_LEFTBRACKET:
+        return *sc = K2SC('[') | mod;
+      case SDL_SCANCODE_RIGHTBRACKET:
+        return *sc = K2SC(']') | mod;
+      case SDL_SCANCODE_BACKSLASH:
+        return *sc = K2SC('\\') | mod;
+      case SDL_SCANCODE_Q:
+        return *sc = K2SC('q') | mod;
+      case SDL_SCANCODE_W:
+        return *sc = K2SC('w') | mod;
+      case SDL_SCANCODE_E:
+        return *sc = K2SC('e') | mod;
+      case SDL_SCANCODE_R:
+        return *sc = K2SC('r') | mod;
+      case SDL_SCANCODE_T:
+        return *sc = K2SC('t') | mod;
+      case SDL_SCANCODE_Y:
+        return *sc = K2SC('y') | mod;
+      case SDL_SCANCODE_U:
+        return *sc = K2SC('u') | mod;
+      case SDL_SCANCODE_I:
+        return *sc = K2SC('i') | mod;
+      case SDL_SCANCODE_O:
+        return *sc = K2SC('o') | mod;
+      case SDL_SCANCODE_P:
+        return *sc = K2SC('p') | mod;
+      case SDL_SCANCODE_A:
+        return *sc = K2SC('a') | mod;
+      case SDL_SCANCODE_S:
+        return *sc = K2SC('s') | mod;
+      case SDL_SCANCODE_D:
+        return *sc = K2SC('d') | mod;
+      case SDL_SCANCODE_F:
+        return *sc = K2SC('f') | mod;
+      case SDL_SCANCODE_G:
+        return *sc = K2SC('g') | mod;
+      case SDL_SCANCODE_H:
+        return *sc = K2SC('h') | mod;
+      case SDL_SCANCODE_J:
+        return *sc = K2SC('j') | mod;
+      case SDL_SCANCODE_K:
+        return *sc = K2SC('k') | mod;
+      case SDL_SCANCODE_L:
+        return *sc = K2SC('l') | mod;
+      case SDL_SCANCODE_Z:
+        return *sc = K2SC('z') | mod;
+      case SDL_SCANCODE_X:
+        return *sc = K2SC('x') | mod;
+      case SDL_SCANCODE_C:
+        return *sc = K2SC('c') | mod;
+      case SDL_SCANCODE_V:
+        return *sc = K2SC('v') | mod;
+      case SDL_SCANCODE_B:
+        return *sc = K2SC('b') | mod;
+      case SDL_SCANCODE_N:
+        return *sc = K2SC('n') | mod;
+      case SDL_SCANCODE_M:
+        return *sc = K2SC('m') | mod;
+      case SDL_SCANCODE_ESCAPE:
+        *sc = mod | SC_ESC;
+        return 1;
+      case SDL_SCANCODE_BACKSPACE:
+        *sc = mod | SC_BACKSPACE;
+        return 1;
+      case SDL_SCANCODE_TAB:
+        *sc = mod | SC_TAB;
+        return 1;
+      case SDL_SCANCODE_RETURN:
+        *sc = mod | SC_ENTER;
+        return 1;
+      case SDL_SCANCODE_LSHIFT:
+      case SDL_SCANCODE_RSHIFT:
+        *sc = mod | SC_SHIFT;
+        return 1;
+      case SDL_SCANCODE_LALT:
+        *sc = mod | SC_ALT;
+        return 1;
+      case SDL_SCANCODE_RALT:
+        *sc = mod | SC_ALT;
+        return 1;
+      case SDL_SCANCODE_LCTRL:
+        *sc = mod | SC_CTRL;
+        return 1;
+      case SDL_SCANCODE_RCTRL:
+        *sc = mod | SC_CTRL;
+        return 1;
+      case SDL_SCANCODE_CAPSLOCK:
+        *sc = mod | SC_CAPS;
+        return 1;
+      case SDL_SCANCODE_NUMLOCKCLEAR:
+        *sc = mod | SC_NUM;
+        return 1;
+      case SDL_SCANCODE_SCROLLLOCK:
+        *sc = mod | SC_SCROLL;
+        return 1;
+      case SDL_SCANCODE_DOWN:
+        *sc = mod | SC_CURSOR_DOWN;
+        return 1;
+      case SDL_SCANCODE_UP:
+        *sc = mod | SC_CURSOR_UP;
+        return 1;
+      case SDL_SCANCODE_RIGHT:
+        *sc = mod | SC_CURSOR_RIGHT;
+        return 1;
+      case SDL_SCANCODE_LEFT:
+        *sc = mod | SC_CURSOR_LEFT;
+        return 1;
+      case SDL_SCANCODE_PAGEDOWN:
+        *sc = mod | SC_PAGE_DOWN;
+        return 1;
+      case SDL_SCANCODE_PAGEUP:
+        *sc = mod | SC_PAGE_UP;
+        return 1;
+      case SDL_SCANCODE_HOME:
+        *sc = mod | SC_HOME;
+        return 1;
+      case SDL_SCANCODE_END:
+        *sc = mod | SC_END;
+        return 1;
+      case SDL_SCANCODE_INSERT:
+        *sc = mod | SC_INS;
+        return 1;
+      case SDL_SCANCODE_DELETE:
+        *sc = mod | SC_DELETE;
+        return 1;
+      case SDL_SCANCODE_LGUI:
+      case SDL_SCANCODE_RGUI:
+        *sc = mod | SC_GUI;
+        return 1;
+      case SDL_SCANCODE_PRINTSCREEN:
+        *sc = mod | SC_PRTSCRN1;
+        return 1;
+      case SDL_SCANCODE_PAUSE:
+        *sc = mod | SC_PAUSE;
+        return 1;
+      case SDL_SCANCODE_F1 ... SDL_SCANCODE_F12:
+        *sc = mod | (SC_F1 + e.key.keysym.scancode - SDL_SCANCODE_F1);
+        return 1;
+      }
+    } else if (e.type == SDL_KEYUP) {
+      mod |= SCF_KEY_UP;
+      goto ent;
+    }
+  }
+  return -1;
 }
 static void (*kb_cb)(int64_t, int64_t);
-static void* kb_cb_data;
-static int SDLCALL KBCallback(void* d, SDL_Event* e)
-{
-	int64_t c, s;
-	if (kb_cb && (-1 != __ScanKey(&c, &s, e)))
+static void *kb_cb_data;
+static int SDLCALL KBCallback(void *d, SDL_Event *e) {
+  int64_t c, s;
+  if (kb_cb && (-1 != __ScanKey(&c, &s, e)))
 #ifdef USE_TEMPLEOS_ABI
-		FFI_CALL_TOS_2(kb_cb, c, s);
+    FFI_CALL_TOS_2(kb_cb, c, s);
 #else
-		(*kb_cb)(c, s);
+    (*kb_cb)(c, s);
 #endif
-	return 0;
+  return 0;
 }
-void SetKBCallback(void* fptr)
-{
-	kb_cb = fptr;
-	static init;
-	if (!init) {
-		init = 1;
-		SDL_AddEventWatch(KBCallback, NULL);
-	}
+void SetKBCallback(void *fptr) {
+  kb_cb = fptr;
+  static init;
+  if (!init) {
+    init = 1;
+    SDL_AddEventWatch(KBCallback, NULL);
+  }
 }
 // x,y,z,(l<<1)|r
 static void (*ms_cb)(int64_t, int64_t, int64_t, int64_t);
-static int SDLCALL MSCallback(void* d, SDL_Event* e)
-{
-	static int64_t x, y;
-	static int state = 0;
-	static int z;
-	int x2, y2;
-	if (ms_cb)
-		switch (e->type) {
-		case SDL_MOUSEBUTTONDOWN:
-			x = e->button.x, y = e->button.y;
-			if (e->button.button == SDL_BUTTON_LEFT)
-				state |= 2;
-			else
-				state |= 1;
-			goto ent;
-		case SDL_MOUSEBUTTONUP:
-			x = e->button.x, y = e->button.y;
-			if (e->button.button == SDL_BUTTON_LEFT)
-				state &= ~2;
-			else
-				state &= ~1;
-			goto ent;
-		case SDL_MOUSEWHEEL:
-			z -= e->wheel.y; //???,inverted otherwise
-			goto ent;
-		case SDL_MOUSEMOTION:
-			x = e->motion.x, y = e->motion.y;
-		ent:;
-			if (x < view_port.x)
-				x2 = 0;
-			else if (x >= view_port.x + view_port.w)
-				x2 = 639;
-			else
-				x2 = (x - view_port.x) * 640. / view_port.w;
-			if (y < view_port.y)
-				y2 = 0;
-			else if (y >= view_port.y + view_port.h)
-				y2 = 479;
-			else
-				y2 = (y - view_port.y) * 480. / view_port.h;
+static int SDLCALL MSCallback(void *d, SDL_Event *e) {
+  static int64_t x, y;
+  static int state = 0;
+  static int z;
+  int x2, y2;
+  if (ms_cb)
+    switch (e->type) {
+    case SDL_MOUSEBUTTONDOWN:
+      x = e->button.x, y = e->button.y;
+      if (e->button.button == SDL_BUTTON_LEFT)
+        state |= 2;
+      else
+        state |= 1;
+      goto ent;
+    case SDL_MOUSEBUTTONUP:
+      x = e->button.x, y = e->button.y;
+      if (e->button.button == SDL_BUTTON_LEFT)
+        state &= ~2;
+      else
+        state &= ~1;
+      goto ent;
+    case SDL_MOUSEWHEEL:
+      z -= e->wheel.y; //???,inverted otherwise
+      goto ent;
+    case SDL_MOUSEMOTION:
+      x = e->motion.x, y = e->motion.y;
+    ent:;
+      if (x < view_port.x)
+        x2 = 0;
+      else if (x >= view_port.x + view_port.w)
+        x2 = 639;
+      else
+        x2 = (x - view_port.x) * 640. / view_port.w;
+      if (y < view_port.y)
+        y2 = 0;
+      else if (y >= view_port.y + view_port.h)
+        y2 = 479;
+      else
+        y2 = (y - view_port.y) * 480. / view_port.h;
 #ifdef USE_TEMPLEOS_ABI
-			FFI_CALL_TOS_4(ms_cb, x2, y2, z, state);
+      FFI_CALL_TOS_4(ms_cb, x2, y2, z, state);
 #else
-			(*ms_cb)(x2, y2, z, state);
+      (*ms_cb)(x2, y2, z, state);
 #endif
-		}
-	return 0;
+    }
+  return 0;
 }
 
-void SetMSCallback(void* fptr)
-{
-	ms_cb = fptr;
-	static int init;
-	if (!init) {
-		init = 1;
-		SDL_AddEventWatch(MSCallback, NULL);
-	}
+void SetMSCallback(void *fptr) {
+  ms_cb = fptr;
+  static int init;
+  if (!init) {
+    init = 1;
+    SDL_AddEventWatch(MSCallback, NULL);
+  }
 }
-static void UserEvHandler(void* ul, SDL_Event* ev)
-{
-	if (ev->type == SDL_USEREVENT) {
-		switch (ev->user.code) {
-			break;
-		case USER_CODE_DRAW_WIN_NEW:
-			_DrawWindowNew();
-			break;
-		case USER_CODE_UPDATE:
-			_UpdateScreen(ev->user.data1, 640, 480, ev->user.data2);
-		}
-	}
+static void UserEvHandler(void *ul, SDL_Event *ev) {
+  if (ev->type == SDL_USEREVENT) {
+    switch (ev->user.code) {
+      break;
+    case USER_CODE_DRAW_WIN_NEW:
+      _DrawWindowNew();
+      break;
+    case USER_CODE_UPDATE:
+      _UpdateScreen(ev->user.data1, 640, 480, ev->user.data2);
+    }
+  }
 }
-void InputLoop(void* ul)
-{
-	SDL_Event e;
-	for (; !*(int64_t*)ul;) {
-		if (SDL_WaitEvent(&e)) {
-			if (e.type == SDL_QUIT) {
-				break;
-			}
-			if (e.type == SDL_USEREVENT)
-				UserEvHandler(NULL, &e);
-		} else
-puts(SDL_GetError());
-	}
+void InputLoop(void *ul) {
+  SDL_Event e;
+  for (; !*(int64_t *)ul;) {
+    if (SDL_WaitEvent(&e)) {
+      if (e.type == SDL_QUIT) {
+        break;
+      }
+      if (e.type == SDL_USEREVENT)
+        UserEvHandler(NULL, &e);
+    } else
+      puts(SDL_GetError());
+  }
 }
 
-void LaunchSDL(void (*boot_ptr)(void* data), void* data)
-{
-	SDL_Init(SDL_INIT_EVERYTHING);
-	InitSound();
-	int64_t quit = 0;
-	user_ev_num = SDL_RegisterEvents(1);
-	SDL_CreateThread(boot_ptr, "Boot thread", data);
-	InputLoop(&quit);
+void LaunchSDL(void (*boot_ptr)(void *data), void *data) {
+  SDL_Init(SDL_INIT_EVERYTHING);
+  InitSound();
+  int64_t quit = 0;
+  user_ev_num = SDL_RegisterEvents(1);
+  SDL_CreateThread(boot_ptr, "Boot thread", data);
+  InputLoop(&quit);
 }
 
-void WaitForSDLQuit()
-{
-	SDL_WaitThread(sdl_main_thread, NULL);
+void WaitForSDLQuit() {
+  SDL_WaitThread(sdl_main_thread, NULL);
 }

--- a/x86_64_backend.c
+++ b/x86_64_backend.c
@@ -12,2099 +12,2154 @@
 //
 // I am putting in the pooping computed goto's May 27,2024
 //
-static int64_t IsCompoundCompare(CRPN* r);
-static int64_t IsSavedFReg(int64_t r)
-{
-	if (r >= AIWNIOS_FREG_START)
-		if (r - AIWNIOS_FREG_START < AIWNIOS_FREG_CNT)
-			return 1;
-	return 0;
+static int64_t IsCompoundCompare(CRPN *r);
+static int64_t IsSavedFReg(int64_t r) {
+  if (r >= AIWNIOS_FREG_START)
+    if (r - AIWNIOS_FREG_START < AIWNIOS_FREG_CNT)
+      return 1;
+  return 0;
 }
-static int64_t ModeIsDerefToSIB(CRPN* m)
-{
-	if (m->type == IC_DEREF) {
-		if (m->res.mode == __MD_X86_64_SIB || m->res.mode == MD_INDIR_REG)
-			return 1;
-	} else if (m->res.mode == MD_FRAME)
-		return 1;
-	return 0;
+static int64_t ModeIsDerefToSIB(CRPN *m) {
+  if (m->type == IC_DEREF) {
+    if (m->res.mode == __MD_X86_64_SIB || m->res.mode == MD_INDIR_REG)
+      return 1;
+  } else if (m->res.mode == MD_FRAME)
+    return 1;
+  return 0;
 }
 
-static int64_t RawTypeIs64(int64_t r)
-{
-	switch (r) {
-	case RT_U64i:
-	case RT_I64i:
-	case RT_F64:
-	case RT_PTR:
-		return 1;
-	}
-	return 0;
+static int64_t RawTypeIs64(int64_t r) {
+  switch (r) {
+  case RT_U64i:
+  case RT_I64i:
+  case RT_F64:
+  case RT_PTR:
+    return 1;
+  }
+  return 0;
 }
 //
 // Assembly section
 //
 
-extern int64_t ICMov(CCmpCtrl* cctrl, CICArg* dst, CICArg* src, char* bin,
-	int64_t code_off);
-extern int64_t __OptPassFinal(CCmpCtrl* cctrl, CRPN* rpn, char* bin,
-	int64_t code_off);
+extern int64_t ICMov(CCmpCtrl *cctrl, CICArg *dst, CICArg *src, char *bin,
+                     int64_t code_off);
+extern int64_t __OptPassFinal(CCmpCtrl *cctrl, CRPN *rpn, char *bin,
+                              int64_t code_off);
 
 #define X86_64_BASE_REG 5
 #define X86_64_STACK_REG 4
 
-#define AIWNIOS_ADD_CODE(func, ...)                        \
-	{                                                      \
-		if (bin)                                           \
-			code_off += func(bin + code_off, __VA_ARGS__); \
-		else                                               \
-			code_off += func(NULL, __VA_ARGS__);           \
-	}
-
-static uint8_t ErectREX(int64_t big, int64_t reg, int64_t index, int64_t base)
-{
-	if (index == -1)
-		index = 0;
-	if (base == -1)
-		base = 0;
-	return 0b01000000 | (big << 3) | (!!(reg & 0b1000) << 2) | (!!(index & 0b1000) << 1) | !!(base & 0b1000);
-}
-#define ADD_U8(v)            \
-			to[len++] = (v);
-#define ADD_U16(v)                       \
-			*(int16_t*)(to + len) = (v); \
-			len += 2;
-#define ADD_U32(v)                       \
-			*(int32_t*)(to + len) = (v); \
-			len += 4;
-#define ADD_U64(v)                       \
-			*(int64_t*)(to + len) = (v); \
-			len += 8;
-
-#define SIB_BEGIN(_64, r, s, i, b, o)                                \
-	do {                                                             \
-		int64_t R = (r), S = (s), I = (i), B = (b), O = (o);         \
-		switch (S) {                                                 \
-		default:                                                     \
-			S = -1;                                                  \
-			break;                                                   \
-		case 1:                                                      \
-			S = 0;                                                   \
-			break;                                                   \
-		case 2:                                                      \
-			S = 1;                                                   \
-			break;                                                   \
-		case 4:                                                      \
-			S = 2;                                                   \
-			break;                                                   \
-		case 8:                                                      \
-			S = 3;                                                   \
-		}                                                            \
-		if (B == RIP) {                                              \
-			if (_64 || (I & 0b1000) || (B & 0b1000) || (R & 0b1000)) \
-				ADD_U8(ErectREX(_64, R, 0, 0));                      \
-		} else if (I != -1 || B == R12) {                            \
-			if (S == -1)                                             \
-				I = RSP;                                             \
-			if (_64 || (I & 0b1000) || (B & 0b1000) || (R & 0b1000)) \
-				ADD_U8(ErectREX(_64, R, I, B));                      \
-		} else {                                                     \
-			if (_64 || (I & 0b1000) || (B & 0b1000) || (R & 0b1000)) \
-				ADD_U8(ErectREX(_64, R, I, B));                      \
-		}
-#define SIB_END()                                                                        \
-	if (I == -1 && R12 != B && B != RIP && B != RSP) {                                   \
-		if (!O && B != RBP)                                                              \
-			ADD_U8(((R & 0b111) << 3) | (B & 0b111))                                     \
-		else if (-0x7f <= O && O <= 0x7f) {                                              \
-			ADD_U8(0b01000000 | ((R & 0b111) << 3) | (B & 0b111));                       \
-			ADD_U8(O);                                                                   \
-		} else {                                                                         \
-			ADD_U8(0b10000000 | ((R & 0b111) << 3) | (B & 0b111));                       \
-			ADD_U32(O);                                                                  \
-		}                                                                                \
-		break;                                                                           \
-	}                                                                                    \
-	if (B == RIP) {                                                                      \
-		ADD_U8(((R & 0b111) << 3) | 0b101)                                               \
-		ADD_U32(O - (len + 4));                                                          \
-		break;                                                                           \
-	} else {                                                                             \
-		ADD_U8(MODRMSIB((R & 0b111)) | (((-0x7f <= O && O <= 0x7f) ? 0b01 : 0b10) << 6)) \
-	}                                                                                    \
-	if (S == -1) {                                                                       \
-		ADD_U8((RSP << 3) | (B & 0b111));                                                \
-	} else if (B == -1) {                                                                \
-		ADD_U8((S << 6) | ((I & 0b111) << 3) | RBP);                                     \
-	} else {                                                                             \
-		ADD_U8((S << 6) | ((I & 0b111) << 3) | (B & 0b111));                             \
-	}                                                                                    \
-	if ((-0x7f <= O && O <= 0x7f) && B != -1) {                                          \
-		ADD_U8(O);                                                                       \
-	} else {                                                                             \
-		ADD_U32(O);                                                                      \
-	}                                                                                    \
-	}                                                                                    \
-	while (0)                                                                            \
-		;
-
-static int64_t Is32Bit(int64_t num)
-{
-	if (num > -0x7fFFffFFll)
-		if (num < 0x7fFFffFFll)
-			return 1;
-	return 0;
-}
-static uint8_t MODRMRegReg(int64_t a, int64_t b)
-{
-	return (0b11 << 6) | ((a & 0b111) << 3) | (b & 0b111);
-}
-static uint8_t MODRMRip32(int64_t a)
-{
-	return (0b00 << 6) | ((a & 0b111) << 4) | 0b101;
-}
-
-static uint8_t MODRMSIB(int64_t a)
-{
-	return ((a & 0b111) << 3) | 0b100;
-}
-
-static int64_t X86CmpRegReg(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, a, 0, b));
-	ADD_U8(0x3b);
-	ADD_U8(MODRMRegReg(a, b));
-	return len;
-}
-
-static int64_t X86CmpSIB64Imm(char* to, int64_t imm,int64_t s,int64_t i,int64_t b,int64_t o) {
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1,7,s,i,b,o);
-	ADD_U8(0x81);
-	SIB_END();
-	ADD_U32(imm);
-	return len;	
-}
-
-static int64_t X86CmpSIB32Imm(char* to, int64_t imm,int64_t s,int64_t i,int64_t b,int64_t o) {
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(0,7,s,i,b,o);
-	ADD_U8(0x81);
-	SIB_END();
-	ADD_U32(imm);
-	return len;	
-}
-
-
-
-static int64_t X86CmpSIB16Imm(char* to, int64_t imm,int64_t s,int64_t i,int64_t b,int64_t o) {
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0x66);
-	SIB_BEGIN(0,7,s,i,b,o);
-	ADD_U8(0x81);
-	SIB_END();
-	ADD_U16(imm);
-	return len;	
-}
-
-static int64_t X86CmpSIB8Imm(char* to, int64_t imm,int64_t s,int64_t i,int64_t b,int64_t o) {
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(0,7,s,i,b,o);
-	ADD_U8(0x80);
-	SIB_END();
-	ADD_U8(imm);
-	return len;	
-}
-
-static int64_t X86CmpRegImm(char* to, int64_t a, int64_t imm)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, 0, 0, a));
-	ADD_U8(0x81);
-	ADD_U8(MODRMRegReg(7, a));
-	ADD_U32(imm);
-	return len;
-}
-
-static int64_t X86MovRegReg(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, b, 0, a));
-	ADD_U8(0x89);
-	ADD_U8(MODRMRegReg(b, a));
-	return len;
-}
-
-static int64_t X86Leave(char* to, int64_t ul)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0xc9);
-	return len;
-}
-
-static int64_t X86Ret(char* to, int64_t ul)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	if(!ul) {
-		ADD_U8(0xc3);
-	} else {
-		ADD_U8(0xc2);
-		ADD_U16(ul);
-	}
-	return len;
-}
-
-int64_t X86MovImm(char* to, int64_t a, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	if (((1ll << 32) - 1) >= off && off >= 0) {
-		// Is unsigned 32bit
-		ADD_U8(ErectREX(0, a, 0, a));
-		ADD_U8(0xB8 + (a & 0x7));
-		ADD_U32(off);
-		return len;
-	}
-	if (((1ll << 32) - 1) / 2 >= off) {
-		if (-((1ll << 32) - 1) / 2 <= off) {
-			// Is Signed 32bit
-			ADD_U8(ErectREX(1, 0, 0, a));
-			ADD_U8(0xc7);
-			ADD_U8(MODRMRegReg(0, a));
-			ADD_U32(off);
-			return len;
-		}
-	}
-	ADD_U8(ErectREX(1, a, 0, a));
-	ADD_U8(0xB8 + (a & 0x7));
-	ADD_U64(off);
-	return len;
-}
-static int64_t X86MovF64RIP(char* to, int64_t a, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0xF2);
-	SIB_BEGIN(1, a, -1, -1, RIP, off);
-	ADD_U8(0x0F);
-	ADD_U8(0x10);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86AddImm32(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, 0, 0, a));
-	ADD_U8(0x81);
-	ADD_U8(MODRMRegReg(0, a));
-	ADD_U32(b);
-	return len;
-}
-
-static int64_t X86SubImm32(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, a, 0, a));
-	ADD_U8(0x81);
-	ADD_U8(MODRMRegReg(5, a));
-	ADD_U32(b);
-	return len;
-}
-
-static int64_t X86SubReg(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, a, 0, b));
-	ADD_U8(0x2b);
-	ADD_U8(MODRMRegReg(a, b));
-	return len;
-}
-
-static int64_t X86AddReg(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, a, 0, b));
-	ADD_U8(0x03);
-	ADD_U8(MODRMRegReg(a, b));
-	return len;
-}
-
-static int64_t X86AddSIB64(char* to, int64_t a, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, a, s, i, b, off);
-	ADD_U8(0x03);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86SubSIB64(char* to, int64_t a, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, a, s, i, b, off);
-	ADD_U8(0x2b);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86IncReg(char* to, int64_t a)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, 0, 0, a));
-	ADD_U8(0xff);
-	ADD_U8(MODRMRegReg(0, a));
-	return len;
-}
-
-static int64_t X86IncSIB64(char* to, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, 0, s, i, b, off);
-	ADD_U8(0xff);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86DecReg(char* to, int64_t a)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, 0, 0, a));
-	ADD_U8(0xff);
-	ADD_U8(MODRMRegReg(1, a));
-	return len;
-}
-
-static int64_t X86DecSIB64(char* to, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, 1, s, i, b, off);
-	ADD_U8(0xff);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86CVTTSD2SIRegSIB64(char* to, int64_t a, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0xf2);
-	SIB_BEGIN(1, a, s, i, b, off);
-	ADD_U8(0x0f);
-	ADD_U8(0x2c);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86CVTTSD2SIRegReg(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0xf2);
-	ADD_U8(ErectREX(1, a, 0, b));
-	ADD_U8(0x0f);
-	ADD_U8(0x2c);
-	ADD_U8(MODRMRegReg(a, b));
-	return len;
-}
-
-static int64_t X86CVTTSI2SDRegReg(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0xf2);
-	ADD_U8(ErectREX(1, a, 0, b));
-	ADD_U8(0x0f);
-	ADD_U8(0x2a);
-	ADD_U8(MODRMRegReg(a, b));
-	return len;
-}
-
-static int64_t X86CVTTSI2SDRegSIB64(char* to, int64_t a, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0xf2);
-	SIB_BEGIN(1, a, s, i, b, off);
-	ADD_U8(0x0f);
-	ADD_U8(0x2a);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86AndPDReg(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0x66);
-	if ((a & 0b1000) || (b & 0b1000))
-		ADD_U8(ErectREX(0, a, 0, b));
-	ADD_U8(0x0f);
-	ADD_U8(0x54);
-	ADD_U8(MODRMRegReg(a, b));
-	return len;
-}
-
-static int64_t X86AndPDSIB64(char* to, int64_t a, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0x66);
-	SIB_BEGIN(0, a, s, i, b, off);
-	ADD_U8(0x0f);
-	ADD_U8(0x54);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86OrPDReg(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0x66);
-	if ((a & 0b1000) || (b & 0b1000))
-		ADD_U8(ErectREX(0, a, 0, b));
-	ADD_U8(0x0f);
-	ADD_U8(0x56);
-	ADD_U8(MODRMRegReg(a, b));
-	return len;
-}
-
-static int64_t X86OrPDSIB64(char* to, int64_t a, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0x66);
-	SIB_BEGIN(0, a, s, i, b, off);
-	ADD_U8(0x0f);
-	ADD_U8(0x56);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86XorPDReg(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0x66);
-	if ((a & 0b1000) || (b & 0b1000))
-		ADD_U8(ErectREX(0, a, 0, b));
-	ADD_U8(0x0f);
-	ADD_U8(0x57);
-	ADD_U8(MODRMRegReg(a, b));
-	return len;
-}
-
-static int64_t X86XorPDSIB64(char* to, int64_t a, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0x66);
-	SIB_BEGIN(0, a, s, i, b, off);
-	ADD_U8(0x0f);
-	ADD_U8(0x57);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86COMISDRegReg(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0x66);
-	if ((a & 0b1000) || (b & 0b1000))
-		ADD_U8(ErectREX(0, a, 0, b));
-	ADD_U8(0x0f);
-	ADD_U8(0x2f);
-	ADD_U8(MODRMRegReg(a, b));
-	return len;
-}
-
-static int64_t X86Test(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, a, 0, b));
-	ADD_U8(0x85);
-	ADD_U8(MODRMRegReg(a, b));
-	return len;
-}
-
-static int64_t X86AddSDReg(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0xf2);
-	if ((a & 0b1000) || (b & 0b1000))
-		ADD_U8(ErectREX(0, a, 0, b));
-	ADD_U8(0x0f);
-	ADD_U8(0x58);
-	ADD_U8(MODRMRegReg(a, b));
-	return len;
-}
-
-static int64_t X86AddSDSIB64(char* to, int64_t a, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0xf2);
-	SIB_BEGIN(0, a, s, i, b, off);
-	ADD_U8(0x0f);
-	ADD_U8(0x58);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86SubSDReg(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0xf2);
-	if ((a & 0b1000) || (b & 0b1000))
-		ADD_U8(ErectREX(0, a, 0, b));
-	ADD_U8(0x0f);
-	ADD_U8(0x5c);
-	ADD_U8(MODRMRegReg(a, b));
-	return len;
-}
-
-static int64_t X86SubSDSIB64(char* to, int64_t a, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0xf2);
-	SIB_BEGIN(0, a, s, i, b, off);
-	ADD_U8(0x0f);
-	ADD_U8(0x5c);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86RoundSD(char* to, int64_t a, int64_t b, int64_t mode)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0x66);
-	ADD_U8(ErectREX(0, a, 0, b));
-	ADD_U8(0x0f);
-	ADD_U8(0x3a);
-	ADD_U8(0x0b);
-	ADD_U8(MODRMRegReg(a, b));
-	ADD_U8(mode);
-	return len;
-}
-
-static int64_t X86MulSDReg(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0xf2);
-	if ((a & 0b1000) || (b & 0b1000))
-		ADD_U8(ErectREX(0, a, 0, b));
-	ADD_U8(0x0f);
-	ADD_U8(0x59);
-	ADD_U8(MODRMRegReg(a, b));
-	return len;
-}
-
-static int64_t X86MulSDSIB64(char* to, int64_t a, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0xf2);
-	SIB_BEGIN(0, a, s, i, b, off);
-	ADD_U8(0x0f);
-	ADD_U8(0x59);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86DivSDReg(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0xf2);
-	if ((a & 0b1000) || (b & 0b1000))
-		ADD_U8(ErectREX(0, a, 0, b));
-	ADD_U8(0x0f);
-	ADD_U8(0x5E);
-	ADD_U8(MODRMRegReg(a, b));
-	return len;
-}
-
-static int64_t X86DivSDSIB64(char* to, int64_t a, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0xf2);
-	SIB_BEGIN(0, a, s, i, b, off);
-	ADD_U8(0x0f);
-	ADD_U8(0x5e);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86AndReg(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, a, 0, b));
-	ADD_U8(0x23);
-	ADD_U8(MODRMRegReg(a, b));
-	return len;
-}
-
-static int64_t X86AndImm(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, 0, 0, a));
-	ADD_U8(0x81);
-	ADD_U8(MODRMRegReg(4, a));
-	ADD_U32(b);
-	return len;
-}
-
-static int64_t X86AndSIB64(char* to, int64_t a, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, a, s, i, b, off);
-	ADD_U8(0x23);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86OrReg(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, a, 0, b));
-	ADD_U8(0x0b);
-	ADD_U8(MODRMRegReg(a, b));
-	return len;
-}
-
-static int64_t X86OrSIB64(char* to, int64_t a, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, a, s, i, b, off);
-	ADD_U8(0xb);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86OrImm(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, 0, 0, a));
-	ADD_U8(0x81);
-	ADD_U8(MODRMRegReg(1, a));
-	ADD_U32(b);
-	return len;
-}
-
-static int64_t X86XorReg(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, a, 0, b));
-	ADD_U8(0x33);
-	ADD_U8(MODRMRegReg(a, b));
-	return len;
-}
-
-static int64_t X86XorSIB64(char* to, int64_t a, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, a, s, i, b, off);
-	ADD_U8(0x33);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86XorImm(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, 0, 0, a));
-	ADD_U8(0x81);
-	ADD_U8(MODRMRegReg(6, a));
-	ADD_U32(b);
-	return len;
-}
-
-static int64_t X86Cqo(char* to, int64_t unused)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, 0, 0, 0));
-	ADD_U8(0x99);
-	return len;
-}
-
-static int64_t X86DivReg(char* to, int64_t a)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, 6, 0, a));
-	ADD_U8(0xf7);
-	ADD_U8(MODRMRegReg(6, a));
-	return len;
-}
-
-static int64_t X86DivSIB64(char* to, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, 6, s, i, b, off);
-	ADD_U8(0xf7);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86IDivReg(char* to, int64_t a)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, 0, 0, a));
-	ADD_U8(0xf7);
-	ADD_U8(MODRMRegReg(7, a));
-	return len;
-}
-
-static int64_t X86IDivSIB64(char* to, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, 7, s, i, b, off);
-	ADD_U8(0xf7);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86SarRCX(char* to, int64_t a)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, 0, 0, a));
-	ADD_U8(0xd3);
-	ADD_U8(MODRMRegReg(7, a));
-	return len;
-}
-
-static int64_t X86SarRCXSIB64(char* to, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, 7, s, i, b, off);
-	ADD_U8(0xd3);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86SarImm(char* to, int64_t a, int64_t imm)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, 0, 0, a));
-	ADD_U8(0xc1);
-	ADD_U8(MODRMRegReg(7, a));
-	ADD_U8(imm);
-	return len;
-}
-
-static int64_t X86SarImmSIB64(char* to, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, 7, s, i, b, off);
-	ADD_U8(0xc1);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86ShrRCX(char* to, int64_t a)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, 0, 0, a));
-	ADD_U8(0xd3);
-	ADD_U8(MODRMRegReg(5, a));
-	return len;
-}
-
-static int64_t X86ShrImm(char* to, int64_t a, int64_t imm)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, 0, 0, a));
-	ADD_U8(0xc1);
-	ADD_U8(MODRMRegReg(5, a));
-	ADD_U8(imm);
-	return len;
-}
-
-static int64_t X86ShlRCX(char* to, int64_t a)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, 0, 0, a));
-	ADD_U8(0xd3);
-	ADD_U8(MODRMRegReg(4, a));
-	return len;
-}
-
-static int64_t X86ShlImm(char* to, int64_t a, int64_t imm)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, 0, 0, a));
-	ADD_U8(0xc1);
-	ADD_U8(MODRMRegReg(4, a));
-	ADD_U8(imm);
-	return len;
-}
-
-static int64_t X86MulReg(char* to, int64_t a)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, 0, 0, a));
-	ADD_U8(0xf7);
-	ADD_U8(MODRMRegReg(4, a));
-	return len;
-}
-
-static int64_t X86MulSIB64(char* to, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, 4, s, i, b, off);
-	ADD_U8(0xf7);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86IMulReg(char* to, int64_t a)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, 0, 0, a));
-	ADD_U8(0xf7);
-	ADD_U8(MODRMRegReg(5, a));
-	return len;
-}
-static int64_t X86IMulSIB64(char* to, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, 5, s, i, b, off);
-	ADD_U8(0xf7);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86IMul2Reg(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, a, 0, b));
-	ADD_U8(0x0f);
-	ADD_U8(0xaf);
-	ADD_U8(MODRMRegReg(a, b));
-	return len;
-}
-
-static int64_t X86IMul2SIB64(char* to, int64_t r, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, r, s, i, b, off);
-	ADD_U8(0x0f);
-	ADD_U8(0xaf);
-	SIB_END();
-	return len;
-}
-
-int64_t X86Call32(char* to, int64_t off)
-{
-	int64_t len = 0;char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0xe8);
-	ADD_U32(off - 5);
-	return len;
-}
-
-int64_t X86CallReg(char* to, int64_t reg)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, 2, 0, reg));
-	ADD_U8(0xff);
-	ADD_U8(MODRMRegReg(2, reg));
-	return len;
-}
-
-int64_t X86CallSIB64(char* to, int64_t s, int64_t i, int64_t b, int64_t o)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, 2, s, i, b, o);
-	ADD_U8(0xff);
-	SIB_END();
-	return len;
-}
-
-int64_t X86PushReg(char* to, int64_t reg)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, reg, 0, reg));
-	ADD_U8(0x50 + (reg & 0x7));
-	return len;
-}
-
-int64_t X86PushM16(char* to, int64_t s,int64_t i,int64_t b,int64_t off) {
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(0,6,s,i,b,off);
-	ADD_U8(0x66);
-	ADD_U8(0xff);
-	SIB_END();
-	return len;
-}
-int64_t X86PushM32(char* to, int64_t s,int64_t i,int64_t b,int64_t off) {
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(0,6,s,i,b,off);
-	ADD_U8(0xff);
-	SIB_END();
-	return len;
-}
-int64_t X86PushM64(char* to, int64_t s,int64_t i,int64_t b,int64_t off) {
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1,6,s,i,b,off);
-	ADD_U8(0xff);
-	SIB_END();
-	return len;
-}
-int64_t X86PushImm(char* to, int64_t imm)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0x68);
-	ADD_U32(imm);
-	return len;
-}
-
-int64_t X86PopReg(char* to, int64_t reg)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, reg, 0, reg));
-	ADD_U8(0x58 + (reg & 0x7));
-	return len;
-}
-
-static int64_t X86CmpRegSIB64(char* to, int64_t a, int64_t s, int64_t i, int64_t b, int64_t o)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, a, s, i, b, o);
-	ADD_U8(0x3b);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86CmpSIBReg64(char* to, int64_t a, int64_t s, int64_t i, int64_t b, int64_t o)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, a, s, i, b, o);
-	ADD_U8(0x39);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86MovQF64I64(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0x66);
-	ADD_U8(ErectREX(1, a, 0, b));
-	ADD_U8(0x0F)
-	ADD_U8(0x6e);
-	ADD_U8(MODRMRegReg(a, b));
-	return len;
-}
-
-static int64_t X86LeaSIB(char* to, int64_t a, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, a, s, i, b, off);
-	ADD_U8(0x8D);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86MovQI64F64(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0x66);
-	ADD_U8(ErectREX(1, b, 0, a));
-	ADD_U8(0x0F)
-	ADD_U8(0x7e);
-	ADD_U8(MODRMRegReg(b, a));
-	return len;
-}
-
-static int64_t X86Jmp(char* to, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0xe9);
-	ADD_U32(off - 5);
-	return len;
-}
-
-static int64_t X86JmpSIB(char* to, int64_t scale, int64_t idx, int64_t base, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(0, 4, scale, idx, base, off);
-	ADD_U8(0xff);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86JmpReg(char* to, int64_t r)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, 0, 0, r));
-	ADD_U8(0xff);
-	ADD_U8(MODRMRegReg(4, r));
-	return len;
-}
-
-static int64_t X86NegReg(char* to, int64_t r)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, 3, 0, r));
-	ADD_U8(0xf7);
-	ADD_U8(MODRMRegReg(3, r));
-	return len;
-}
-
-static int64_t X86NegSIB64(char* to, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, 3, s, i, b, off);
-	ADD_U8(0xf7);
-	SIB_END();
-	return len;
-}
-
-static int64_t X86NotReg(char* to, int64_t r)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, 2, 0, r));
-	ADD_U8(0xf7);
-	ADD_U8(MODRMRegReg(2, r));
-	return len;
-}
-
-static int64_t X86NotSIB64(char* to, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, 2, s, i, b, off);
-	ADD_U8(0xf7);
-	SIB_END();
-	return len;
+#define AIWNIOS_ADD_CODE(func, ...)                                            \
+  {                                                                            \
+    if (bin)                                                                   \
+      code_off += func(bin + code_off, __VA_ARGS__);                           \
+    else                                                                       \
+      code_off += func(NULL, __VA_ARGS__);                                     \
+  }
+
+static uint8_t ErectREX(int64_t big, int64_t reg, int64_t index, int64_t base) {
+  if (index == -1)
+    index = 0;
+  if (base == -1)
+    base = 0;
+  return 0b01000000 | (big << 3) | (!!(reg & 0b1000) << 2) |
+         (!!(index & 0b1000) << 1) | !!(base & 0b1000);
+}
+#define ADD_U8(v) to[len++] = (v);
+#define ADD_U16(v)                                                             \
+  *(int16_t *)(to + len) = (v);                                                \
+  len += 2;
+#define ADD_U32(v)                                                             \
+  *(int32_t *)(to + len) = (v);                                                \
+  len += 4;
+#define ADD_U64(v)                                                             \
+  *(int64_t *)(to + len) = (v);                                                \
+  len += 8;
+
+#define SIB_BEGIN(_64, r, s, i, b, o)                                          \
+  do {                                                                         \
+    int64_t R = (r), S = (s), I = (i), B = (b), O = (o);                       \
+    switch (S) {                                                               \
+    default:                                                                   \
+      S = -1;                                                                  \
+      break;                                                                   \
+    case 1:                                                                    \
+      S = 0;                                                                   \
+      break;                                                                   \
+    case 2:                                                                    \
+      S = 1;                                                                   \
+      break;                                                                   \
+    case 4:                                                                    \
+      S = 2;                                                                   \
+      break;                                                                   \
+    case 8:                                                                    \
+      S = 3;                                                                   \
+    }                                                                          \
+    if (B == RIP) {                                                            \
+      if (_64 || (I & 0b1000) || (B & 0b1000) || (R & 0b1000))                 \
+        ADD_U8(ErectREX(_64, R, 0, 0));                                        \
+    } else if (I != -1 || B == R12) {                                          \
+      if (S == -1)                                                             \
+        I = RSP;                                                               \
+      if (_64 || (I & 0b1000) || (B & 0b1000) || (R & 0b1000))                 \
+        ADD_U8(ErectREX(_64, R, I, B));                                        \
+    } else {                                                                   \
+      if (_64 || (I & 0b1000) || (B & 0b1000) || (R & 0b1000))                 \
+        ADD_U8(ErectREX(_64, R, I, B));                                        \
+    }
+#define SIB_END()                                                              \
+  if (I == -1 && R12 != B && B != RIP && B != RSP) {                           \
+    if (!O && B != RBP)                                                        \
+      ADD_U8(((R & 0b111) << 3) | (B & 0b111))                                 \
+    else if (-0x7f <= O && O <= 0x7f) {                                        \
+      ADD_U8(0b01000000 | ((R & 0b111) << 3) | (B & 0b111));                   \
+      ADD_U8(O);                                                               \
+    } else {                                                                   \
+      ADD_U8(0b10000000 | ((R & 0b111) << 3) | (B & 0b111));                   \
+      ADD_U32(O);                                                              \
+    }                                                                          \
+    break;                                                                     \
+  }                                                                            \
+  if (B == RIP) {                                                              \
+    ADD_U8(((R & 0b111) << 3) | 0b101)                                         \
+    ADD_U32(O - (len + 4));                                                    \
+    break;                                                                     \
+  } else {                                                                     \
+    ADD_U8(MODRMSIB((R & 0b111)) |                                             \
+           (((-0x7f <= O && O <= 0x7f) ? 0b01 : 0b10) << 6))                   \
+  }                                                                            \
+  if (S == -1) {                                                               \
+    ADD_U8((RSP << 3) | (B & 0b111));                                          \
+  } else if (B == -1) {                                                        \
+    ADD_U8((S << 6) | ((I & 0b111) << 3) | RBP);                               \
+  } else {                                                                     \
+    ADD_U8((S << 6) | ((I & 0b111) << 3) | (B & 0b111));                       \
+  }                                                                            \
+  if ((-0x7f <= O && O <= 0x7f) && B != -1) {                                  \
+    ADD_U8(O);                                                                 \
+  } else {                                                                     \
+    ADD_U32(O);                                                                \
+  }                                                                            \
+  }                                                                            \
+  while (0)                                                                    \
+    ;
+
+static int64_t Is32Bit(int64_t num) {
+  if (num > -0x7fFFffFFll)
+    if (num < 0x7fFFffFFll)
+      return 1;
+  return 0;
+}
+static uint8_t MODRMRegReg(int64_t a, int64_t b) {
+  return (0b11 << 6) | ((a & 0b111) << 3) | (b & 0b111);
+}
+static uint8_t MODRMRip32(int64_t a) {
+  return (0b00 << 6) | ((a & 0b111) << 4) | 0b101;
+}
+
+static uint8_t MODRMSIB(int64_t a) {
+  return ((a & 0b111) << 3) | 0b100;
+}
+
+static int64_t X86CmpRegReg(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, a, 0, b));
+  ADD_U8(0x3b);
+  ADD_U8(MODRMRegReg(a, b));
+  return len;
+}
+
+static int64_t X86CmpSIB64Imm(char *to, int64_t imm, int64_t s, int64_t i,
+                              int64_t b, int64_t o) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, 7, s, i, b, o);
+  ADD_U8(0x81);
+  SIB_END();
+  ADD_U32(imm);
+  return len;
+}
+
+static int64_t X86CmpSIB32Imm(char *to, int64_t imm, int64_t s, int64_t i,
+                              int64_t b, int64_t o) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(0, 7, s, i, b, o);
+  ADD_U8(0x81);
+  SIB_END();
+  ADD_U32(imm);
+  return len;
+}
+
+static int64_t X86CmpSIB16Imm(char *to, int64_t imm, int64_t s, int64_t i,
+                              int64_t b, int64_t o) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0x66);
+  SIB_BEGIN(0, 7, s, i, b, o);
+  ADD_U8(0x81);
+  SIB_END();
+  ADD_U16(imm);
+  return len;
+}
+
+static int64_t X86CmpSIB8Imm(char *to, int64_t imm, int64_t s, int64_t i,
+                             int64_t b, int64_t o) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(0, 7, s, i, b, o);
+  ADD_U8(0x80);
+  SIB_END();
+  ADD_U8(imm);
+  return len;
+}
+
+static int64_t X86CmpRegImm(char *to, int64_t a, int64_t imm) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, 0, 0, a));
+  ADD_U8(0x81);
+  ADD_U8(MODRMRegReg(7, a));
+  ADD_U32(imm);
+  return len;
+}
+
+static int64_t X86MovRegReg(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, b, 0, a));
+  ADD_U8(0x89);
+  ADD_U8(MODRMRegReg(b, a));
+  return len;
+}
+
+static int64_t X86Leave(char *to, int64_t ul) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0xc9);
+  return len;
+}
+
+static int64_t X86Ret(char *to, int64_t ul) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  if (!ul) {
+    ADD_U8(0xc3);
+  } else {
+    ADD_U8(0xc2);
+    ADD_U16(ul);
+  }
+  return len;
+}
+
+int64_t X86MovImm(char *to, int64_t a, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  if (((1ll << 32) - 1) >= off && off >= 0) {
+    // Is unsigned 32bit
+    ADD_U8(ErectREX(0, a, 0, a));
+    ADD_U8(0xB8 + (a & 0x7));
+    ADD_U32(off);
+    return len;
+  }
+  if (((1ll << 32) - 1) / 2 >= off) {
+    if (-((1ll << 32) - 1) / 2 <= off) {
+      // Is Signed 32bit
+      ADD_U8(ErectREX(1, 0, 0, a));
+      ADD_U8(0xc7);
+      ADD_U8(MODRMRegReg(0, a));
+      ADD_U32(off);
+      return len;
+    }
+  }
+  ADD_U8(ErectREX(1, a, 0, a));
+  ADD_U8(0xB8 + (a & 0x7));
+  ADD_U64(off);
+  return len;
+}
+static int64_t X86MovF64RIP(char *to, int64_t a, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0xF2);
+  SIB_BEGIN(1, a, -1, -1, RIP, off);
+  ADD_U8(0x0F);
+  ADD_U8(0x10);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86AddImm32(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, 0, 0, a));
+  ADD_U8(0x81);
+  ADD_U8(MODRMRegReg(0, a));
+  ADD_U32(b);
+  return len;
+}
+
+static int64_t X86SubImm32(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, a, 0, a));
+  ADD_U8(0x81);
+  ADD_U8(MODRMRegReg(5, a));
+  ADD_U32(b);
+  return len;
+}
+
+static int64_t X86SubReg(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, a, 0, b));
+  ADD_U8(0x2b);
+  ADD_U8(MODRMRegReg(a, b));
+  return len;
+}
+
+static int64_t X86AddReg(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, a, 0, b));
+  ADD_U8(0x03);
+  ADD_U8(MODRMRegReg(a, b));
+  return len;
+}
+
+static int64_t X86AddSIB64(char *to, int64_t a, int64_t s, int64_t i, int64_t b,
+                           int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, a, s, i, b, off);
+  ADD_U8(0x03);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86SubSIB64(char *to, int64_t a, int64_t s, int64_t i, int64_t b,
+                           int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, a, s, i, b, off);
+  ADD_U8(0x2b);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86IncReg(char *to, int64_t a) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, 0, 0, a));
+  ADD_U8(0xff);
+  ADD_U8(MODRMRegReg(0, a));
+  return len;
+}
+
+static int64_t X86IncSIB64(char *to, int64_t s, int64_t i, int64_t b,
+                           int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, 0, s, i, b, off);
+  ADD_U8(0xff);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86DecReg(char *to, int64_t a) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, 0, 0, a));
+  ADD_U8(0xff);
+  ADD_U8(MODRMRegReg(1, a));
+  return len;
+}
+
+static int64_t X86DecSIB64(char *to, int64_t s, int64_t i, int64_t b,
+                           int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, 1, s, i, b, off);
+  ADD_U8(0xff);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86CVTTSD2SIRegSIB64(char *to, int64_t a, int64_t s, int64_t i,
+                                    int64_t b, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0xf2);
+  SIB_BEGIN(1, a, s, i, b, off);
+  ADD_U8(0x0f);
+  ADD_U8(0x2c);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86CVTTSD2SIRegReg(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0xf2);
+  ADD_U8(ErectREX(1, a, 0, b));
+  ADD_U8(0x0f);
+  ADD_U8(0x2c);
+  ADD_U8(MODRMRegReg(a, b));
+  return len;
+}
+
+static int64_t X86CVTTSI2SDRegReg(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0xf2);
+  ADD_U8(ErectREX(1, a, 0, b));
+  ADD_U8(0x0f);
+  ADD_U8(0x2a);
+  ADD_U8(MODRMRegReg(a, b));
+  return len;
+}
+
+static int64_t X86CVTTSI2SDRegSIB64(char *to, int64_t a, int64_t s, int64_t i,
+                                    int64_t b, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0xf2);
+  SIB_BEGIN(1, a, s, i, b, off);
+  ADD_U8(0x0f);
+  ADD_U8(0x2a);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86AndPDReg(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0x66);
+  if ((a & 0b1000) || (b & 0b1000))
+    ADD_U8(ErectREX(0, a, 0, b));
+  ADD_U8(0x0f);
+  ADD_U8(0x54);
+  ADD_U8(MODRMRegReg(a, b));
+  return len;
+}
+
+static int64_t X86AndPDSIB64(char *to, int64_t a, int64_t s, int64_t i,
+                             int64_t b, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0x66);
+  SIB_BEGIN(0, a, s, i, b, off);
+  ADD_U8(0x0f);
+  ADD_U8(0x54);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86OrPDReg(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0x66);
+  if ((a & 0b1000) || (b & 0b1000))
+    ADD_U8(ErectREX(0, a, 0, b));
+  ADD_U8(0x0f);
+  ADD_U8(0x56);
+  ADD_U8(MODRMRegReg(a, b));
+  return len;
+}
+
+static int64_t X86OrPDSIB64(char *to, int64_t a, int64_t s, int64_t i,
+                            int64_t b, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0x66);
+  SIB_BEGIN(0, a, s, i, b, off);
+  ADD_U8(0x0f);
+  ADD_U8(0x56);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86XorPDReg(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0x66);
+  if ((a & 0b1000) || (b & 0b1000))
+    ADD_U8(ErectREX(0, a, 0, b));
+  ADD_U8(0x0f);
+  ADD_U8(0x57);
+  ADD_U8(MODRMRegReg(a, b));
+  return len;
+}
+
+static int64_t X86XorPDSIB64(char *to, int64_t a, int64_t s, int64_t i,
+                             int64_t b, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0x66);
+  SIB_BEGIN(0, a, s, i, b, off);
+  ADD_U8(0x0f);
+  ADD_U8(0x57);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86COMISDRegReg(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0x66);
+  if ((a & 0b1000) || (b & 0b1000))
+    ADD_U8(ErectREX(0, a, 0, b));
+  ADD_U8(0x0f);
+  ADD_U8(0x2f);
+  ADD_U8(MODRMRegReg(a, b));
+  return len;
+}
+
+static int64_t X86Test(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, a, 0, b));
+  ADD_U8(0x85);
+  ADD_U8(MODRMRegReg(a, b));
+  return len;
+}
+
+static int64_t X86AddSDReg(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0xf2);
+  if ((a & 0b1000) || (b & 0b1000))
+    ADD_U8(ErectREX(0, a, 0, b));
+  ADD_U8(0x0f);
+  ADD_U8(0x58);
+  ADD_U8(MODRMRegReg(a, b));
+  return len;
+}
+
+static int64_t X86AddSDSIB64(char *to, int64_t a, int64_t s, int64_t i,
+                             int64_t b, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0xf2);
+  SIB_BEGIN(0, a, s, i, b, off);
+  ADD_U8(0x0f);
+  ADD_U8(0x58);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86SubSDReg(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0xf2);
+  if ((a & 0b1000) || (b & 0b1000))
+    ADD_U8(ErectREX(0, a, 0, b));
+  ADD_U8(0x0f);
+  ADD_U8(0x5c);
+  ADD_U8(MODRMRegReg(a, b));
+  return len;
+}
+
+static int64_t X86SubSDSIB64(char *to, int64_t a, int64_t s, int64_t i,
+                             int64_t b, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0xf2);
+  SIB_BEGIN(0, a, s, i, b, off);
+  ADD_U8(0x0f);
+  ADD_U8(0x5c);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86RoundSD(char *to, int64_t a, int64_t b, int64_t mode) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0x66);
+  ADD_U8(ErectREX(0, a, 0, b));
+  ADD_U8(0x0f);
+  ADD_U8(0x3a);
+  ADD_U8(0x0b);
+  ADD_U8(MODRMRegReg(a, b));
+  ADD_U8(mode);
+  return len;
+}
+
+static int64_t X86MulSDReg(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0xf2);
+  if ((a & 0b1000) || (b & 0b1000))
+    ADD_U8(ErectREX(0, a, 0, b));
+  ADD_U8(0x0f);
+  ADD_U8(0x59);
+  ADD_U8(MODRMRegReg(a, b));
+  return len;
+}
+
+static int64_t X86MulSDSIB64(char *to, int64_t a, int64_t s, int64_t i,
+                             int64_t b, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0xf2);
+  SIB_BEGIN(0, a, s, i, b, off);
+  ADD_U8(0x0f);
+  ADD_U8(0x59);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86DivSDReg(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0xf2);
+  if ((a & 0b1000) || (b & 0b1000))
+    ADD_U8(ErectREX(0, a, 0, b));
+  ADD_U8(0x0f);
+  ADD_U8(0x5E);
+  ADD_U8(MODRMRegReg(a, b));
+  return len;
+}
+
+static int64_t X86DivSDSIB64(char *to, int64_t a, int64_t s, int64_t i,
+                             int64_t b, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0xf2);
+  SIB_BEGIN(0, a, s, i, b, off);
+  ADD_U8(0x0f);
+  ADD_U8(0x5e);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86AndReg(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, a, 0, b));
+  ADD_U8(0x23);
+  ADD_U8(MODRMRegReg(a, b));
+  return len;
+}
+
+static int64_t X86AndImm(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, 0, 0, a));
+  ADD_U8(0x81);
+  ADD_U8(MODRMRegReg(4, a));
+  ADD_U32(b);
+  return len;
+}
+
+static int64_t X86AndSIB64(char *to, int64_t a, int64_t s, int64_t i, int64_t b,
+                           int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, a, s, i, b, off);
+  ADD_U8(0x23);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86OrReg(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, a, 0, b));
+  ADD_U8(0x0b);
+  ADD_U8(MODRMRegReg(a, b));
+  return len;
+}
+
+static int64_t X86OrSIB64(char *to, int64_t a, int64_t s, int64_t i, int64_t b,
+                          int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, a, s, i, b, off);
+  ADD_U8(0xb);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86OrImm(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, 0, 0, a));
+  ADD_U8(0x81);
+  ADD_U8(MODRMRegReg(1, a));
+  ADD_U32(b);
+  return len;
+}
+
+static int64_t X86XorReg(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, a, 0, b));
+  ADD_U8(0x33);
+  ADD_U8(MODRMRegReg(a, b));
+  return len;
+}
+
+static int64_t X86XorSIB64(char *to, int64_t a, int64_t s, int64_t i, int64_t b,
+                           int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, a, s, i, b, off);
+  ADD_U8(0x33);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86XorImm(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, 0, 0, a));
+  ADD_U8(0x81);
+  ADD_U8(MODRMRegReg(6, a));
+  ADD_U32(b);
+  return len;
+}
+
+static int64_t X86Cqo(char *to, int64_t unused) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, 0, 0, 0));
+  ADD_U8(0x99);
+  return len;
+}
+
+static int64_t X86DivReg(char *to, int64_t a) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, 6, 0, a));
+  ADD_U8(0xf7);
+  ADD_U8(MODRMRegReg(6, a));
+  return len;
+}
+
+static int64_t X86DivSIB64(char *to, int64_t s, int64_t i, int64_t b,
+                           int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, 6, s, i, b, off);
+  ADD_U8(0xf7);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86IDivReg(char *to, int64_t a) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, 0, 0, a));
+  ADD_U8(0xf7);
+  ADD_U8(MODRMRegReg(7, a));
+  return len;
+}
+
+static int64_t X86IDivSIB64(char *to, int64_t s, int64_t i, int64_t b,
+                            int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, 7, s, i, b, off);
+  ADD_U8(0xf7);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86SarRCX(char *to, int64_t a) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, 0, 0, a));
+  ADD_U8(0xd3);
+  ADD_U8(MODRMRegReg(7, a));
+  return len;
+}
+
+static int64_t X86SarRCXSIB64(char *to, int64_t s, int64_t i, int64_t b,
+                              int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, 7, s, i, b, off);
+  ADD_U8(0xd3);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86SarImm(char *to, int64_t a, int64_t imm) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, 0, 0, a));
+  ADD_U8(0xc1);
+  ADD_U8(MODRMRegReg(7, a));
+  ADD_U8(imm);
+  return len;
+}
+
+static int64_t X86SarImmSIB64(char *to, int64_t s, int64_t i, int64_t b,
+                              int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, 7, s, i, b, off);
+  ADD_U8(0xc1);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86ShrRCX(char *to, int64_t a) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, 0, 0, a));
+  ADD_U8(0xd3);
+  ADD_U8(MODRMRegReg(5, a));
+  return len;
+}
+
+static int64_t X86ShrImm(char *to, int64_t a, int64_t imm) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, 0, 0, a));
+  ADD_U8(0xc1);
+  ADD_U8(MODRMRegReg(5, a));
+  ADD_U8(imm);
+  return len;
+}
+
+static int64_t X86ShlRCX(char *to, int64_t a) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, 0, 0, a));
+  ADD_U8(0xd3);
+  ADD_U8(MODRMRegReg(4, a));
+  return len;
+}
+
+static int64_t X86ShlImm(char *to, int64_t a, int64_t imm) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, 0, 0, a));
+  ADD_U8(0xc1);
+  ADD_U8(MODRMRegReg(4, a));
+  ADD_U8(imm);
+  return len;
+}
+
+static int64_t X86MulReg(char *to, int64_t a) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, 0, 0, a));
+  ADD_U8(0xf7);
+  ADD_U8(MODRMRegReg(4, a));
+  return len;
+}
+
+static int64_t X86MulSIB64(char *to, int64_t s, int64_t i, int64_t b,
+                           int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, 4, s, i, b, off);
+  ADD_U8(0xf7);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86IMulReg(char *to, int64_t a) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, 0, 0, a));
+  ADD_U8(0xf7);
+  ADD_U8(MODRMRegReg(5, a));
+  return len;
+}
+static int64_t X86IMulSIB64(char *to, int64_t s, int64_t i, int64_t b,
+                            int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, 5, s, i, b, off);
+  ADD_U8(0xf7);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86IMul2Reg(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, a, 0, b));
+  ADD_U8(0x0f);
+  ADD_U8(0xaf);
+  ADD_U8(MODRMRegReg(a, b));
+  return len;
+}
+
+static int64_t X86IMul2SIB64(char *to, int64_t r, int64_t s, int64_t i,
+                             int64_t b, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, r, s, i, b, off);
+  ADD_U8(0x0f);
+  ADD_U8(0xaf);
+  SIB_END();
+  return len;
+}
+
+int64_t X86Call32(char *to, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0xe8);
+  ADD_U32(off - 5);
+  return len;
+}
+
+int64_t X86CallReg(char *to, int64_t reg) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, 2, 0, reg));
+  ADD_U8(0xff);
+  ADD_U8(MODRMRegReg(2, reg));
+  return len;
+}
+
+int64_t X86CallSIB64(char *to, int64_t s, int64_t i, int64_t b, int64_t o) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, 2, s, i, b, o);
+  ADD_U8(0xff);
+  SIB_END();
+  return len;
+}
+
+int64_t X86PushReg(char *to, int64_t reg) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, reg, 0, reg));
+  ADD_U8(0x50 + (reg & 0x7));
+  return len;
+}
+
+int64_t X86PushM16(char *to, int64_t s, int64_t i, int64_t b, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(0, 6, s, i, b, off);
+  ADD_U8(0x66);
+  ADD_U8(0xff);
+  SIB_END();
+  return len;
+}
+int64_t X86PushM32(char *to, int64_t s, int64_t i, int64_t b, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(0, 6, s, i, b, off);
+  ADD_U8(0xff);
+  SIB_END();
+  return len;
+}
+int64_t X86PushM64(char *to, int64_t s, int64_t i, int64_t b, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, 6, s, i, b, off);
+  ADD_U8(0xff);
+  SIB_END();
+  return len;
+}
+int64_t X86PushImm(char *to, int64_t imm) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0x68);
+  ADD_U32(imm);
+  return len;
+}
+
+int64_t X86PopReg(char *to, int64_t reg) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, reg, 0, reg));
+  ADD_U8(0x58 + (reg & 0x7));
+  return len;
+}
+
+static int64_t X86CmpRegSIB64(char *to, int64_t a, int64_t s, int64_t i,
+                              int64_t b, int64_t o) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, a, s, i, b, o);
+  ADD_U8(0x3b);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86CmpSIBReg64(char *to, int64_t a, int64_t s, int64_t i,
+                              int64_t b, int64_t o) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, a, s, i, b, o);
+  ADD_U8(0x39);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86MovQF64I64(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0x66);
+  ADD_U8(ErectREX(1, a, 0, b));
+  ADD_U8(0x0F)
+  ADD_U8(0x6e);
+  ADD_U8(MODRMRegReg(a, b));
+  return len;
+}
+
+static int64_t X86LeaSIB(char *to, int64_t a, int64_t s, int64_t i, int64_t b,
+                         int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, a, s, i, b, off);
+  ADD_U8(0x8D);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86MovQI64F64(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0x66);
+  ADD_U8(ErectREX(1, b, 0, a));
+  ADD_U8(0x0F)
+  ADD_U8(0x7e);
+  ADD_U8(MODRMRegReg(b, a));
+  return len;
+}
+
+static int64_t X86Jmp(char *to, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0xe9);
+  ADD_U32(off - 5);
+  return len;
+}
+
+static int64_t X86JmpSIB(char *to, int64_t scale, int64_t idx, int64_t base,
+                         int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(0, 4, scale, idx, base, off);
+  ADD_U8(0xff);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86JmpReg(char *to, int64_t r) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, 0, 0, r));
+  ADD_U8(0xff);
+  ADD_U8(MODRMRegReg(4, r));
+  return len;
+}
+
+static int64_t X86NegReg(char *to, int64_t r) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, 3, 0, r));
+  ADD_U8(0xf7);
+  ADD_U8(MODRMRegReg(3, r));
+  return len;
+}
+
+static int64_t X86NegSIB64(char *to, int64_t s, int64_t i, int64_t b,
+                           int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, 3, s, i, b, off);
+  ADD_U8(0xf7);
+  SIB_END();
+  return len;
+}
+
+static int64_t X86NotReg(char *to, int64_t r) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, 2, 0, r));
+  ADD_U8(0xf7);
+  ADD_U8(MODRMRegReg(2, r));
+  return len;
+}
+
+static int64_t X86NotSIB64(char *to, int64_t s, int64_t i, int64_t b,
+                           int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, 2, s, i, b, off);
+  ADD_U8(0xf7);
+  SIB_END();
+  return len;
 }
 
 // MOVSD
-static int64_t X86MovRegRegF64(char* to, int64_t a, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0xf2);
-	if ((a & 0b1000) || (b & 0b1000))
-		ADD_U8(ErectREX(0, a, 0, b));
-	ADD_U8(0x0F)
-	ADD_U8(0x10);
-	ADD_U8(MODRMRegReg(a, b));
-	return len;
+static int64_t X86MovRegRegF64(char *to, int64_t a, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0xf2);
+  if ((a & 0b1000) || (b & 0b1000))
+    ADD_U8(ErectREX(0, a, 0, b));
+  ADD_U8(0x0F)
+  ADD_U8(0x10);
+  ADD_U8(MODRMRegReg(a, b));
+  return len;
 }
 
-int64_t X86MovIndirRegF64(char* to, int64_t reg, int64_t scale, int64_t index, int64_t base, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0xf2);
-	SIB_BEGIN(1, reg, scale, index, base, off);
-	ADD_U8(0x0F);
-	ADD_U8(0x11);
-	SIB_END();
-	return len;
+int64_t X86MovIndirRegF64(char *to, int64_t reg, int64_t scale, int64_t index,
+                          int64_t base, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0xf2);
+  SIB_BEGIN(1, reg, scale, index, base, off);
+  ADD_U8(0x0F);
+  ADD_U8(0x11);
+  SIB_END();
+  return len;
 }
-int64_t X86MovRegIndirF64(char* to, int64_t reg, int64_t scale, int64_t index, int64_t base, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0xf2);
-	SIB_BEGIN(1, reg, scale, index, base, off);
-	ADD_U8(0x0F);
-	ADD_U8(0x10);
-	SIB_END();
-	return len;
-}
-
-int64_t X86MovRegIndirI64(char* to, int64_t reg, int64_t scale, int64_t index, int64_t base, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, reg, scale, index, base, off);
-	ADD_U8(0x8b);
-	SIB_END();
-	return len;
+int64_t X86MovRegIndirF64(char *to, int64_t reg, int64_t scale, int64_t index,
+                          int64_t base, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0xf2);
+  SIB_BEGIN(1, reg, scale, index, base, off);
+  ADD_U8(0x0F);
+  ADD_U8(0x10);
+  SIB_END();
+  return len;
 }
 
-int64_t X86MovIndirI8Imm(char *to,int64_t imm,int64_t scale, int64_t index, int64_t base, int64_t off) {
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(0, 0, scale, index, base, off);
-	ADD_U8(0xc6);
-	SIB_END();
-	ADD_U8(imm);
-	return len;
+int64_t X86MovRegIndirI64(char *to, int64_t reg, int64_t scale, int64_t index,
+                          int64_t base, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, reg, scale, index, base, off);
+  ADD_U8(0x8b);
+  SIB_END();
+  return len;
 }
 
-int64_t X86MovIndirI16Imm(char *to,int64_t imm,int64_t scale, int64_t index, int64_t base, int64_t off) {
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0x66);
-	SIB_BEGIN(0, 0, scale, index, base, off);
-	ADD_U8(0xc7);
-	SIB_END();
-	ADD_U16(imm);
-	return len;
+int64_t X86MovIndirI8Imm(char *to, int64_t imm, int64_t scale, int64_t index,
+                         int64_t base, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(0, 0, scale, index, base, off);
+  ADD_U8(0xc6);
+  SIB_END();
+  ADD_U8(imm);
+  return len;
 }
 
-int64_t X86MovIndirI32Imm(char *to,int64_t imm,int64_t scale, int64_t index, int64_t base, int64_t off) {
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(0, 0, scale, index, base, off);
-	ADD_U8(0xc7);
-	SIB_END();
-	ADD_U32(imm);
-	return len;
+int64_t X86MovIndirI16Imm(char *to, int64_t imm, int64_t scale, int64_t index,
+                          int64_t base, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0x66);
+  SIB_BEGIN(0, 0, scale, index, base, off);
+  ADD_U8(0xc7);
+  SIB_END();
+  ADD_U16(imm);
+  return len;
 }
 
-int64_t X86MovIndirI64Imm(char *to,int64_t imm,int64_t scale, int64_t index, int64_t base, int64_t off) {
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, 0, scale, index, base, off);
-	ADD_U8(0xc7);
-	SIB_END();
-	ADD_U32(imm);
-	return len;
+int64_t X86MovIndirI32Imm(char *to, int64_t imm, int64_t scale, int64_t index,
+                          int64_t base, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(0, 0, scale, index, base, off);
+  ADD_U8(0xc7);
+  SIB_END();
+  ADD_U32(imm);
+  return len;
 }
 
-
-int64_t X86MovIndirRegI64(char* to, int64_t reg, int64_t scale, int64_t index, int64_t base, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, reg, scale, index, base, off);
-	ADD_U8(0x89);
-	SIB_END();
-	return len;
+int64_t X86MovIndirI64Imm(char *to, int64_t imm, int64_t scale, int64_t index,
+                          int64_t base, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, 0, scale, index, base, off);
+  ADD_U8(0xc7);
+  SIB_END();
+  ADD_U32(imm);
+  return len;
 }
 
-int64_t X86MovRegIndirI32(char* to, int64_t reg, int64_t scale, int64_t index, int64_t base, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(0, reg, scale, index, base, off);
-	ADD_U8(0x8b);
-	SIB_END();
-	return len;
+int64_t X86MovIndirRegI64(char *to, int64_t reg, int64_t scale, int64_t index,
+                          int64_t base, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, reg, scale, index, base, off);
+  ADD_U8(0x89);
+  SIB_END();
+  return len;
 }
 
-int64_t X86MovIndirRegI32(char* to, int64_t reg, int64_t scale, int64_t index, int64_t base, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(0, reg, scale, index, base, off);
-	ADD_U8(0x89);
-	SIB_END();
-	return len;
+int64_t X86MovRegIndirI32(char *to, int64_t reg, int64_t scale, int64_t index,
+                          int64_t base, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(0, reg, scale, index, base, off);
+  ADD_U8(0x8b);
+  SIB_END();
+  return len;
 }
 
-int64_t X86MovRegIndirI16(char* to, int64_t reg, int64_t scale, int64_t index, int64_t base, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0x66);
-	SIB_BEGIN(0, reg, scale, index, base, off);
-	ADD_U8(0x8b);
-	SIB_END();
-	return len;
+int64_t X86MovIndirRegI32(char *to, int64_t reg, int64_t scale, int64_t index,
+                          int64_t base, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(0, reg, scale, index, base, off);
+  ADD_U8(0x89);
+  SIB_END();
+  return len;
 }
 
-static int64_t X86MovZXRegIndirI8(char* to, int64_t reg, int64_t scale, int64_t index, int64_t base, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, reg, scale, index, base, off);
-	ADD_U8(0x0f);
-	ADD_U8(0xb6);
-	SIB_END();
-	return len;
+int64_t X86MovRegIndirI16(char *to, int64_t reg, int64_t scale, int64_t index,
+                          int64_t base, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0x66);
+  SIB_BEGIN(0, reg, scale, index, base, off);
+  ADD_U8(0x8b);
+  SIB_END();
+  return len;
 }
 
-static int64_t X86MovZXRegRegI8(char* to, int64_t reg, int64_t reg2)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, reg, 0, reg2))
-	ADD_U8(0x0f);
-	ADD_U8(0xb6);
-	ADD_U8(MODRMRegReg(reg, reg2));
-	return len;
+static int64_t X86MovZXRegIndirI8(char *to, int64_t reg, int64_t scale,
+                                  int64_t index, int64_t base, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, reg, scale, index, base, off);
+  ADD_U8(0x0f);
+  ADD_U8(0xb6);
+  SIB_END();
+  return len;
 }
 
-static int64_t X86MovZXRegIndirI16(char* to, int64_t reg, int64_t scale, int64_t index, int64_t base, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, reg, scale, index, base, off);
-	ADD_U8(0x0f);
-	ADD_U8(0xb7);
-	SIB_END();
-	return len;
+static int64_t X86MovZXRegRegI8(char *to, int64_t reg, int64_t reg2) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, reg, 0, reg2))
+  ADD_U8(0x0f);
+  ADD_U8(0xb6);
+  ADD_U8(MODRMRegReg(reg, reg2));
+  return len;
 }
 
-static int64_t X86MovSXRegIndirI8(char* to, int64_t reg, int64_t scale, int64_t index, int64_t base, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, reg, scale, index, base, off);
-	ADD_U8(0x0f);
-	ADD_U8(0xbe);
-	SIB_END();
-	return len;
+static int64_t X86MovZXRegIndirI16(char *to, int64_t reg, int64_t scale,
+                                   int64_t index, int64_t base, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, reg, scale, index, base, off);
+  ADD_U8(0x0f);
+  ADD_U8(0xb7);
+  SIB_END();
+  return len;
 }
 
-static int64_t X86MovSXRegIndirI16(char* to, int64_t reg, int64_t scale, int64_t index, int64_t base, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, reg, scale, index, base, off);
-	ADD_U8(0x0f);
-	ADD_U8(0xbf);
-	SIB_END();
-	return len;
+static int64_t X86MovSXRegIndirI8(char *to, int64_t reg, int64_t scale,
+                                  int64_t index, int64_t base, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, reg, scale, index, base, off);
+  ADD_U8(0x0f);
+  ADD_U8(0xbe);
+  SIB_END();
+  return len;
 }
 
-static int64_t X86MovSXRegIndirI32(char* to, int64_t reg, int64_t scale, int64_t index, int64_t base, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, reg, scale, index, base, off);
-	ADD_U8(0x63);
-	SIB_END();
-	return len;
+static int64_t X86MovSXRegIndirI16(char *to, int64_t reg, int64_t scale,
+                                   int64_t index, int64_t base, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, reg, scale, index, base, off);
+  ADD_U8(0x0f);
+  ADD_U8(0xbf);
+  SIB_END();
+  return len;
 }
 
-int64_t X86MovIndirRegI16(char* to, int64_t reg, int64_t scale, int64_t index, int64_t base, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0x66);
-	SIB_BEGIN(0, reg, scale, index, base, off);
-	ADD_U8(0x89);
-	SIB_END();
-	return len;
+static int64_t X86MovSXRegIndirI32(char *to, int64_t reg, int64_t scale,
+                                   int64_t index, int64_t base, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, reg, scale, index, base, off);
+  ADD_U8(0x63);
+  SIB_END();
+  return len;
 }
 
-int64_t
-X86MovRegIndirI8(char* to, int64_t reg, int64_t scale, int64_t index, int64_t base, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(0, reg, scale, index, base, off);
-	ADD_U8(0x88);
-	SIB_END();
-	return len;
+int64_t X86MovIndirRegI16(char *to, int64_t reg, int64_t scale, int64_t index,
+                          int64_t base, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0x66);
+  SIB_BEGIN(0, reg, scale, index, base, off);
+  ADD_U8(0x89);
+  SIB_END();
+  return len;
 }
 
-int64_t X86MovIndirRegI8(char* to, int64_t reg, int64_t scale, int64_t index, int64_t base, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(0, reg, scale, index, base, off);
-	ADD_U8(0x88);
-	SIB_END();
-	return len;
+int64_t X86MovRegIndirI8(char *to, int64_t reg, int64_t scale, int64_t index,
+                         int64_t base, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(0, reg, scale, index, base, off);
+  ADD_U8(0x88);
+  SIB_END();
+  return len;
 }
 
-int64_t X86BtRegReg(char* to, int64_t r, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, b, 0, r));
-	ADD_U8(0x0f);
-	ADD_U8(0xa3);
-	ADD_U8(MODRMRegReg(b, r))
-	return len;
+int64_t X86MovIndirRegI8(char *to, int64_t reg, int64_t scale, int64_t index,
+                         int64_t base, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(0, reg, scale, index, base, off);
+  ADD_U8(0x88);
+  SIB_END();
+  return len;
 }
 
-int64_t X86BtSIBReg(char* to, int64_t r, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, r, s, i, b, off);
-	ADD_U8(0x0f);
-	ADD_U8(0xa3);
-	SIB_END();
-	return len;
+int64_t X86BtRegReg(char *to, int64_t r, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, b, 0, r));
+  ADD_U8(0x0f);
+  ADD_U8(0xa3);
+  ADD_U8(MODRMRegReg(b, r))
+  return len;
 }
 
-int64_t X86BtRegImm(char* to, int64_t r, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, 4, 0, b));
-	ADD_U8(0x0f);
-	ADD_U8(0xba);
-	ADD_U8(MODRMRegReg(4, b))
-	ADD_U8(b);
-	return len;
+int64_t X86BtSIBReg(char *to, int64_t r, int64_t s, int64_t i, int64_t b,
+                    int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, r, s, i, b, off);
+  ADD_U8(0x0f);
+  ADD_U8(0xa3);
+  SIB_END();
+  return len;
 }
 
-int64_t X86BtSIBImm(char* to, int64_t r, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, 4, s, i, b, off);
-	ADD_U8(0x0f);
-	ADD_U8(0xba);
-	SIB_END();
-	ADD_U8(r);
-	return len;
+int64_t X86BtRegImm(char *to, int64_t r, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, 4, 0, b));
+  ADD_U8(0x0f);
+  ADD_U8(0xba);
+  ADD_U8(MODRMRegReg(4, b))
+  ADD_U8(b);
+  return len;
 }
 
-int64_t X86BtcRegReg(char* to, int64_t r, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, b, 0, r));
-	ADD_U8(0x0f);
-	ADD_U8(0xbb);
-	ADD_U8(MODRMRegReg(b, r))
-	return len;
+int64_t X86BtSIBImm(char *to, int64_t r, int64_t s, int64_t i, int64_t b,
+                    int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, 4, s, i, b, off);
+  ADD_U8(0x0f);
+  ADD_U8(0xba);
+  SIB_END();
+  ADD_U8(r);
+  return len;
 }
 
-int64_t X86BtcSIBReg(char* to, int64_t r, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, r, s, i, b, off);
-	ADD_U8(0x0f);
-	ADD_U8(0xbb);
-	SIB_END();
-	return len;
+int64_t X86BtcRegReg(char *to, int64_t r, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, b, 0, r));
+  ADD_U8(0x0f);
+  ADD_U8(0xbb);
+  ADD_U8(MODRMRegReg(b, r))
+  return len;
 }
 
-static int64_t X86Lock(char* to, int64_t ul)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0xf0);
-	return len;
-}
-int64_t X86BtcRegImm(char* to, int64_t r, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, r, 0, 7));
-	ADD_U8(0x0f);
-	ADD_U8(0xba);
-	ADD_U8(MODRMRegReg(7, r))
-	ADD_U8(b);
-	return len;
+int64_t X86BtcSIBReg(char *to, int64_t r, int64_t s, int64_t i, int64_t b,
+                     int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, r, s, i, b, off);
+  ADD_U8(0x0f);
+  ADD_U8(0xbb);
+  SIB_END();
+  return len;
 }
 
-int64_t X86BtcSIBImm(char* to, int64_t r, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, 7, s, i, b, off);
-	ADD_U8(0x0f);
-	ADD_U8(0xba);
-	SIB_END();
-	ADD_U8(r);
-	return len;
+static int64_t X86Lock(char *to, int64_t ul) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0xf0);
+  return len;
+}
+int64_t X86BtcRegImm(char *to, int64_t r, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, r, 0, 7));
+  ADD_U8(0x0f);
+  ADD_U8(0xba);
+  ADD_U8(MODRMRegReg(7, r))
+  ADD_U8(b);
+  return len;
 }
 
-int64_t X86BtsRegReg(char* to, int64_t r, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, b, 0, r));
-	ADD_U8(0x0f);
-	ADD_U8(0xab);
-	ADD_U8(MODRMRegReg(b, r))
-	return len;
+int64_t X86BtcSIBImm(char *to, int64_t r, int64_t s, int64_t i, int64_t b,
+                     int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, 7, s, i, b, off);
+  ADD_U8(0x0f);
+  ADD_U8(0xba);
+  SIB_END();
+  ADD_U8(r);
+  return len;
 }
 
-int64_t X86BtsSIBReg(char* to, int64_t r, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, r, s, i, b, off);
-	ADD_U8(0x0f);
-	ADD_U8(0xab);
-	SIB_END();
-	return len;
+int64_t X86BtsRegReg(char *to, int64_t r, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, b, 0, r));
+  ADD_U8(0x0f);
+  ADD_U8(0xab);
+  ADD_U8(MODRMRegReg(b, r))
+  return len;
 }
 
-int64_t X86BtsRegImm(char* to, int64_t r, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, 5, 0, b));
-	ADD_U8(0x0f);
-	ADD_U8(0xba);
-	ADD_U8(MODRMRegReg(5, b))
-	ADD_U8(b);
-	return len;
+int64_t X86BtsSIBReg(char *to, int64_t r, int64_t s, int64_t i, int64_t b,
+                     int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, r, s, i, b, off);
+  ADD_U8(0x0f);
+  ADD_U8(0xab);
+  SIB_END();
+  return len;
 }
 
-int64_t X86BtsSIBImm(char* to, int64_t r, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, 5, s, i, b, off);
-	ADD_U8(0x0f);
-	ADD_U8(0xba);
-	SIB_END();
-	ADD_U8(r);
-	return len;
+int64_t X86BtsRegImm(char *to, int64_t r, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, 5, 0, b));
+  ADD_U8(0x0f);
+  ADD_U8(0xba);
+  ADD_U8(MODRMRegReg(5, b))
+  ADD_U8(b);
+  return len;
 }
 
-int64_t X86BtrRegReg(char* to, int64_t r, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, b, 0, r));
-	ADD_U8(0x0f);
-	ADD_U8(0xb3);
-	ADD_U8(MODRMRegReg(b, r))
-	return len;
+int64_t X86BtsSIBImm(char *to, int64_t r, int64_t s, int64_t i, int64_t b,
+                     int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, 5, s, i, b, off);
+  ADD_U8(0x0f);
+  ADD_U8(0xba);
+  SIB_END();
+  ADD_U8(r);
+  return len;
 }
 
-int64_t X86BtrSIBReg(char* to, int64_t r, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, r, s, i, b, off);
-	ADD_U8(0x0f);
-	ADD_U8(0xb3);
-	SIB_END();
-	return len;
+int64_t X86BtrRegReg(char *to, int64_t r, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, b, 0, r));
+  ADD_U8(0x0f);
+  ADD_U8(0xb3);
+  ADD_U8(MODRMRegReg(b, r))
+  return len;
 }
 
-int64_t X86BtrRegImm(char* to, int64_t r, int64_t b)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(ErectREX(1, 6, 0, b));
-	ADD_U8(0x0f);
-	ADD_U8(0xba);
-	ADD_U8(MODRMRegReg(6, b))
-	ADD_U8(b);
-	return len;
+int64_t X86BtrSIBReg(char *to, int64_t r, int64_t s, int64_t i, int64_t b,
+                     int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, r, s, i, b, off);
+  ADD_U8(0x0f);
+  ADD_U8(0xb3);
+  SIB_END();
+  return len;
 }
 
-int64_t X86BtrSIBImm(char* to, int64_t r, int64_t s, int64_t i, int64_t b, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	SIB_BEGIN(1, 6, s, i, b, off);
-	ADD_U8(0x0f);
-	ADD_U8(0xba);
-	SIB_END();
-	ADD_U8(r);
-	return len;
+int64_t X86BtrRegImm(char *to, int64_t r, int64_t b) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(ErectREX(1, 6, 0, b));
+  ADD_U8(0x0f);
+  ADD_U8(0xba);
+  ADD_U8(MODRMRegReg(6, b))
+  ADD_U8(b);
+  return len;
+}
+
+int64_t X86BtrSIBImm(char *to, int64_t r, int64_t s, int64_t i, int64_t b,
+                     int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  SIB_BEGIN(1, 6, s, i, b, off);
+  ADD_U8(0x0f);
+  ADD_U8(0xba);
+  SIB_END();
+  ADD_U8(r);
+  return len;
 }
 
 //
 // Codegen section
 //
 
-static int64_t IsTerminalInst(CRPN* r)
-{
-	switch (r->type) {
-		break;
-	case IC_RET:
-	case IC_GOTO:
-		return 1;
-	}
-	return 0;
+static int64_t IsTerminalInst(CRPN *r) {
+  switch (r->type) {
+    break;
+  case IC_RET:
+  case IC_GOTO:
+    return 1;
+  }
+  return 0;
 }
 
-static int64_t IsConst(CRPN* rpn)
-{
-	switch (rpn->type) {
-	case IC_CHR:
-	case IC_F64:
-	case IC_I64:
-		return 1;
-	}
-	return 0;
+static int64_t IsConst(CRPN *rpn) {
+  switch (rpn->type) {
+  case IC_CHR:
+  case IC_F64:
+  case IC_I64:
+    return 1;
+  }
+  return 0;
 }
 
-static int64_t ConstVal(CRPN* rpn)
-{
-	switch (rpn->type) {
-	case IC_CHR:
-	case IC_I64:
-		return rpn->integer;
-	case IC_F64:
-		return rpn->flt;
-	}
-	return 0;
+static int64_t ConstVal(CRPN *rpn) {
+  switch (rpn->type) {
+  case IC_CHR:
+  case IC_I64:
+    return rpn->integer;
+  case IC_F64:
+    return rpn->flt;
+  }
+  return 0;
 }
 
 //
 // If we call a function the tmp regs go to poo poo land
 //
-static int64_t SpillsTmpRegs(CRPN* rpn)
-{
-	int64_t idx;
-	switch (rpn->type) {
-		break;
-	case __IC_CALL:
-	case IC_CALL:
-		return 1;
-		break;
-	case __IC_VARGS:
-		for (idx = 0; idx != rpn->length; idx++)
-			if (SpillsTmpRegs(ICArgN(rpn, idx)))
-				return 1;
-		return 0;
-	case IC_TO_F64:
-	case IC_TO_I64:
-	case IC_NEG:
-	unop:
-		return SpillsTmpRegs(rpn->base.next);
-		break;
-	case IC_POS:
-		goto unop;
-		break;
-	case IC_POW:
-		return 1; // calls pow
-	binop:
-		if (SpillsTmpRegs(rpn->base.next))
-			return 1;
-		if (SpillsTmpRegs(ICFwd(rpn->base.next)))
-			return 1;
-		break;
-	case IC_ADD:
-		goto binop;
-		break;
-	case IC_EQ:
-		goto binop;
-		break;
-	case IC_SUB:
-		goto binop;
-		break;
-	case IC_DIV:
-		goto binop;
-		break;
-	case IC_MUL:
-		goto binop;
-		break;
-	case IC_DEREF:
-		goto unop;
-		break;
-	case IC_AND:
-		goto binop;
-		break;
-	case IC_ADDR_OF:
-		goto unop;
-		break;
-	case IC_XOR:
-		goto binop;
-		break;
-	case IC_MOD:
-		goto binop;
-		break;
-	case IC_OR:
-		goto binop;
-		break;
-	case IC_LT:
-		goto binop;
-		break;
-	case IC_GT:
-		goto binop;
-		break;
-	case IC_LNOT:
-		goto unop;
-		break;
-	case IC_BNOT:
-		goto unop;
-		break;
-	case IC_POST_INC:
-		goto binop;
-		break;
-	case IC_POST_DEC:
-		goto binop;
-		break;
-	case IC_PRE_INC:
-		goto binop;
-		break;
-	case IC_PRE_DEC:
-		goto binop;
-		break;
-	case IC_AND_AND:
-		goto binop;
-	case IC_OR_OR:
-		goto binop;
-		break;
-	case IC_XOR_XOR:
-		goto binop;
-		break;
-	case IC_EQ_EQ:
-		goto binop;
-		break;
-	case IC_NE:
-		goto binop;
-		break;
-	case IC_LE:
-		goto binop;
-		break;
-	case IC_GE:
-		goto binop;
-		break;
-	case IC_LSH:
-		goto binop;
-		break;
-	case IC_RSH:
-		goto binop;
-		break;
-	case IC_ADD_EQ:
-		goto binop;
-		break;
-	case IC_SUB_EQ:
-		goto binop;
-		break;
-	case IC_MUL_EQ:
-		goto binop;
-		break;
-	case IC_DIV_EQ:
-		goto binop;
-		break;
-	case IC_LSH_EQ:
-		goto binop;
-		break;
-	case IC_RSH_EQ:
-		goto binop;
-		break;
-	case IC_AND_EQ:
-		goto binop;
-		break;
-	case IC_OR_EQ:
-		goto binop;
-		break;
-	case IC_XOR_EQ:
-		goto binop;
-		break;
-	case IC_MOD_EQ:
-		goto binop;
-		break;
-	case IC_BT:
-	case IC_BTS:
-	case IC_BTR:
-	case IC_BTC:
-	case IC_LBTS:
-	case IC_LBTR:
-	case IC_LBTC:
-	case IC_STORE:
-		goto binop;
-	case IC_TYPECAST:
-		goto unop;
-	}
-	return 0;
+static int64_t SpillsTmpRegs(CRPN *rpn) {
+  int64_t idx;
+  switch (rpn->type) {
+    break;
+  case __IC_CALL:
+  case IC_CALL:
+    return 1;
+    break;
+  case __IC_VARGS:
+    for (idx = 0; idx != rpn->length; idx++)
+      if (SpillsTmpRegs(ICArgN(rpn, idx)))
+        return 1;
+    return 0;
+  case IC_TO_F64:
+  case IC_TO_I64:
+  case IC_NEG:
+  unop:
+    return SpillsTmpRegs(rpn->base.next);
+    break;
+  case IC_POS:
+    goto unop;
+    break;
+  case IC_POW:
+    return 1; // calls pow
+  binop:
+    if (SpillsTmpRegs(rpn->base.next))
+      return 1;
+    if (SpillsTmpRegs(ICFwd(rpn->base.next)))
+      return 1;
+    break;
+  case IC_ADD:
+    goto binop;
+    break;
+  case IC_EQ:
+    goto binop;
+    break;
+  case IC_SUB:
+    goto binop;
+    break;
+  case IC_DIV:
+    goto binop;
+    break;
+  case IC_MUL:
+    goto binop;
+    break;
+  case IC_DEREF:
+    goto unop;
+    break;
+  case IC_AND:
+    goto binop;
+    break;
+  case IC_ADDR_OF:
+    goto unop;
+    break;
+  case IC_XOR:
+    goto binop;
+    break;
+  case IC_MOD:
+    goto binop;
+    break;
+  case IC_OR:
+    goto binop;
+    break;
+  case IC_LT:
+    goto binop;
+    break;
+  case IC_GT:
+    goto binop;
+    break;
+  case IC_LNOT:
+    goto unop;
+    break;
+  case IC_BNOT:
+    goto unop;
+    break;
+  case IC_POST_INC:
+    goto binop;
+    break;
+  case IC_POST_DEC:
+    goto binop;
+    break;
+  case IC_PRE_INC:
+    goto binop;
+    break;
+  case IC_PRE_DEC:
+    goto binop;
+    break;
+  case IC_AND_AND:
+    goto binop;
+  case IC_OR_OR:
+    goto binop;
+    break;
+  case IC_XOR_XOR:
+    goto binop;
+    break;
+  case IC_EQ_EQ:
+    goto binop;
+    break;
+  case IC_NE:
+    goto binop;
+    break;
+  case IC_LE:
+    goto binop;
+    break;
+  case IC_GE:
+    goto binop;
+    break;
+  case IC_LSH:
+    goto binop;
+    break;
+  case IC_RSH:
+    goto binop;
+    break;
+  case IC_ADD_EQ:
+    goto binop;
+    break;
+  case IC_SUB_EQ:
+    goto binop;
+    break;
+  case IC_MUL_EQ:
+    goto binop;
+    break;
+  case IC_DIV_EQ:
+    goto binop;
+    break;
+  case IC_LSH_EQ:
+    goto binop;
+    break;
+  case IC_RSH_EQ:
+    goto binop;
+    break;
+  case IC_AND_EQ:
+    goto binop;
+    break;
+  case IC_OR_EQ:
+    goto binop;
+    break;
+  case IC_XOR_EQ:
+    goto binop;
+    break;
+  case IC_MOD_EQ:
+    goto binop;
+    break;
+  case IC_BT:
+  case IC_BTS:
+  case IC_BTR:
+  case IC_BTC:
+  case IC_LBTS:
+  case IC_LBTR:
+  case IC_LBTC:
+  case IC_STORE:
+    goto binop;
+  case IC_TYPECAST:
+    goto unop;
+  }
+  return 0;
 t:
-	return 1;
+  return 1;
 }
 
 //
 // Will overwrite the arg's value,but it's ok as we are about to use it's
 // value(and discard it)
 //
-static int64_t PutICArgIntoReg(CCmpCtrl* cctrl, CICArg* arg, int64_t raw_type,
-	int64_t fallback, char* bin, int64_t code_off)
-{
-	CICArg tmp = { 0 };
-	if (arg->mode == MD_REG) {
-		if ((raw_type == RT_F64) ^ (arg->raw_type == RT_F64)) {
-			// They differ so continue as usaul
-		} else // They are the same
-			return code_off;
-	}
-	tmp.raw_type = raw_type;
-	tmp.reg = fallback;
-	tmp.mode = MD_REG;
-	code_off = ICMov(cctrl, &tmp, arg, bin, code_off);
-	memcpy(arg, &tmp, sizeof(CICArg));
-	return code_off;
+static int64_t PutICArgIntoReg(CCmpCtrl *cctrl, CICArg *arg, int64_t raw_type,
+                               int64_t fallback, char *bin, int64_t code_off) {
+  CICArg tmp = {0};
+  if (arg->mode == MD_REG) {
+    if ((raw_type == RT_F64) ^ (arg->raw_type == RT_F64)) {
+      // They differ so continue as usaul
+    } else // They are the same
+      return code_off;
+  }
+  tmp.raw_type = raw_type;
+  tmp.reg = fallback;
+  tmp.mode = MD_REG;
+  code_off = ICMov(cctrl, &tmp, arg, bin, code_off);
+  memcpy(arg, &tmp, sizeof(CICArg));
+  return code_off;
 }
 
-static int64_t PushToStack(CCmpCtrl* cctrl, CICArg* arg, char* bin,
-	int64_t code_off)
-{
-	CICArg tmp = *arg;
-	if(tmp.mode==MD_I64&&tmp.raw_type!=RT_F64&&Is32Bit(tmp.integer)) {
-		AIWNIOS_ADD_CODE(X86PushImm,tmp.integer);
-		return code_off;
-	}
-	switch(tmp.mode) {
-		case __MD_X86_64_SIB:
-		switch(tmp.raw_type) {
-			case RT_I64i:
-			case RT_U64i:
-			case RT_F64:
-			AIWNIOS_ADD_CODE(X86PushM64,tmp.__SIB_scale,tmp.reg2,tmp.reg,tmp.off);
-			break;
-			default: goto defacto;
-		}
-		return code_off;
-		case MD_INDIR_REG:
-		switch(tmp.raw_type) {
-			case RT_I64i:
-			case RT_U64i:
-			case RT_F64:
-			AIWNIOS_ADD_CODE(X86PushM64,-1,-1,tmp.reg,tmp.off);
-			break;
-			default: goto defacto;
-		}
-		return code_off;
-	}
+static int64_t PushToStack(CCmpCtrl *cctrl, CICArg *arg, char *bin,
+                           int64_t code_off) {
+  CICArg tmp = *arg;
+  if (tmp.mode == MD_I64 && tmp.raw_type != RT_F64 && Is32Bit(tmp.integer)) {
+    AIWNIOS_ADD_CODE(X86PushImm, tmp.integer);
+    return code_off;
+  }
+  switch (tmp.mode) {
+  case __MD_X86_64_SIB:
+    switch (tmp.raw_type) {
+    case RT_I64i:
+    case RT_U64i:
+    case RT_F64:
+      AIWNIOS_ADD_CODE(X86PushM64, tmp.__SIB_scale, tmp.reg2, tmp.reg, tmp.off);
+      break;
+    default:
+      goto defacto;
+    }
+    return code_off;
+  case MD_INDIR_REG:
+    switch (tmp.raw_type) {
+    case RT_I64i:
+    case RT_U64i:
+    case RT_F64:
+      AIWNIOS_ADD_CODE(X86PushM64, -1, -1, tmp.reg, tmp.off);
+      break;
+    default:
+      goto defacto;
+    }
+    return code_off;
+  }
 defacto:
-	code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, 0, bin, code_off);
-	if (tmp.raw_type != RT_F64) {
-		AIWNIOS_ADD_CODE(X86PushReg, tmp.reg);
-	} else {
-		AIWNIOS_ADD_CODE(X86PushReg, RAX);
-		AIWNIOS_ADD_CODE(X86MovIndirRegF64, tmp.reg, -1, -1, RSP, 0);
-	}
-	return code_off;
+  code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, 0, bin, code_off);
+  if (tmp.raw_type != RT_F64) {
+    AIWNIOS_ADD_CODE(X86PushReg, tmp.reg);
+  } else {
+    AIWNIOS_ADD_CODE(X86PushReg, RAX);
+    AIWNIOS_ADD_CODE(X86MovIndirRegF64, tmp.reg, -1, -1, RSP, 0);
+  }
+  return code_off;
 }
-static int64_t PopFromStack(CCmpCtrl* cctrl, CICArg* arg, char* bin,
-	int64_t code_off)
-{
-	CICArg tmp = *arg;
-	if (arg->mode == MD_REG) {
-		// All is good
-	} else {
-		tmp.mode = MD_REG;
-		tmp.reg = 0;
-	}
-	if (tmp.raw_type != RT_F64) {
-		AIWNIOS_ADD_CODE(X86PopReg, tmp.reg);
-	} else {
-		AIWNIOS_ADD_CODE(X86MovRegIndirF64, tmp.reg, -1, -1, RSP, 0);
-		AIWNIOS_ADD_CODE(X86PopReg, RAX);
-	}
-	if (arg->mode != MD_REG)
-		code_off = ICMov(cctrl, arg, &tmp, bin, code_off);
-	return code_off;
-}
-
-static int64_t __ICMoveI64(CCmpCtrl* cctrl, int64_t reg, uint64_t imm, char* bin,
-	int64_t code_off)
-{
-	int64_t code;
-	if (bin && !(cctrl->flags & CCF_AOT_COMPILE)) {
-		if (Is32Bit(imm - (int64_t)(bin + code_off))) {
-			AIWNIOS_ADD_CODE(X86LeaSIB, reg, -1, -1, RIP, imm - (int64_t)(bin + code_off));
-			return code_off;
-		}
-	}
-	AIWNIOS_ADD_CODE(X86MovImm, reg, imm);
-	return code_off;
+static int64_t PopFromStack(CCmpCtrl *cctrl, CICArg *arg, char *bin,
+                            int64_t code_off) {
+  CICArg tmp = *arg;
+  if (arg->mode == MD_REG) {
+    // All is good
+  } else {
+    tmp.mode = MD_REG;
+    tmp.reg = 0;
+  }
+  if (tmp.raw_type != RT_F64) {
+    AIWNIOS_ADD_CODE(X86PopReg, tmp.reg);
+  } else {
+    AIWNIOS_ADD_CODE(X86MovRegIndirF64, tmp.reg, -1, -1, RSP, 0);
+    AIWNIOS_ADD_CODE(X86PopReg, RAX);
+  }
+  if (arg->mode != MD_REG)
+    code_off = ICMov(cctrl, arg, &tmp, bin, code_off);
+  return code_off;
 }
 
-static int64_t __ICMoveF64(CCmpCtrl* cctrl, int64_t reg, double imm, char* bin,
-	int64_t code_off)
-{
-	CCodeMisc* misc = cctrl->code_ctrl->code_misc->next;
-	char* dptr;
-	for (misc; misc != cctrl->code_ctrl->code_misc; misc = misc->base.next) {
-		if (misc->type == CMT_FLOAT_CONST)
-			if (misc->integer == *(int64_t*)&imm) {
-				goto found;
-			}
-	}
-	misc = A_CALLOC(sizeof(CCodeMisc), cctrl->hc);
-	misc->type = CMT_FLOAT_CONST;
-	misc->integer = *(int64_t*)&imm;
-	QueIns(misc, cctrl->code_ctrl->code_misc->last);
+static int64_t __ICMoveI64(CCmpCtrl *cctrl, int64_t reg, uint64_t imm,
+                           char *bin, int64_t code_off) {
+  int64_t code;
+  if (bin && !(cctrl->flags & CCF_AOT_COMPILE)) {
+    if (Is32Bit(imm - (int64_t)(bin + code_off))) {
+      AIWNIOS_ADD_CODE(X86LeaSIB, reg, -1, -1, RIP,
+                       imm - (int64_t)(bin + code_off));
+      return code_off;
+    }
+  }
+  AIWNIOS_ADD_CODE(X86MovImm, reg, imm);
+  return code_off;
+}
+
+static int64_t __ICMoveF64(CCmpCtrl *cctrl, int64_t reg, double imm, char *bin,
+                           int64_t code_off) {
+  CCodeMisc *misc = cctrl->code_ctrl->code_misc->next;
+  char *dptr;
+  for (misc; misc != cctrl->code_ctrl->code_misc; misc = misc->base.next) {
+    if (misc->type == CMT_FLOAT_CONST)
+      if (misc->integer == *(int64_t *)&imm) {
+        goto found;
+      }
+  }
+  misc = A_CALLOC(sizeof(CCodeMisc), cctrl->hc);
+  misc->type = CMT_FLOAT_CONST;
+  misc->integer = *(int64_t *)&imm;
+  QueIns(misc, cctrl->code_ctrl->code_misc->last);
 found:
-	if (bin && misc->addr && cctrl->code_ctrl->final_pass) {
-		AIWNIOS_ADD_CODE(X86MovF64RIP, reg, 0);
-		CodeMiscAddRef(misc, bin + code_off - 4);
-	} else
-		AIWNIOS_ADD_CODE(X86MovF64RIP, reg, 0);
-	return code_off;
+  if (bin && misc->addr && cctrl->code_ctrl->final_pass) {
+    AIWNIOS_ADD_CODE(X86MovF64RIP, reg, 0);
+    CodeMiscAddRef(misc, bin + code_off - 4);
+  } else
+    AIWNIOS_ADD_CODE(X86MovF64RIP, reg, 0);
+  return code_off;
 }
 
-static void PushSpilledTmp(CCmpCtrl* cctrl, CRPN* rpn)
-{
-	int64_t raw_type = rpn->raw_type;
-	CICArg* res = &rpn->res;
-	if (rpn->flags & ICF_PRECOMPUTED)
-		return;
-	// These have no need to be put into a temporay
-	switch (rpn->type) {
-		break;
-	case IC_I64:
-		res->mode = MD_I64;
-		res->integer = rpn->integer;
-		res->raw_type = RT_I64i;
-		return;
-		break;
-	case IC_F64:
-		res->mode = MD_F64;
-		res->flt = rpn->flt;
-		res->raw_type = RT_F64;
-		return;
-		break;
-	case IC_IREG:
-	case IC_FREG:
-		res->mode = MD_REG;
-		res->raw_type = raw_type;
-		res->reg = rpn->integer;
-		return;
-		break;
-	case IC_BASE_PTR:
-		res->mode = MD_FRAME;
-		res->raw_type = raw_type;
-		res->off = rpn->integer;
-		return;
-	case IC_STATIC:
-		res->mode = MD_PTR;
-		res->raw_type = raw_type;
-		res->off = rpn->integer;
-		return;
-	case __IC_STATIC_REF:
-		res->mode = MD_STATIC;
-		res->raw_type = raw_type;
-		res->off = rpn->integer;
-		return;
-	}
-	rpn->flags |= ICF_SPILLED;
-	if (raw_type != RT_F64) {
-		res->mode = MD_FRAME;
-		res->raw_type = raw_type;
-		if (cctrl->backend_user_data0 < (res->off = cctrl->backend_user_data1 += 8)) { // Will set ref->off before the top
-			cctrl->backend_user_data0 = res->off;
-		}
-	} else {
-		res->mode = MD_FRAME;
-		res->raw_type = raw_type;
-		if (cctrl->backend_user_data0 < (res->off = cctrl->backend_user_data1 += 8)) { // Will set ref->off before the top
-			cctrl->backend_user_data0 = res->off;
-		}
-	}
-	// See two above notes
-	res->off -= 8;
-	// In functions,wiggle room comes after the function locals.
-	if (cctrl->cur_fun && res->mode == MD_FRAME)
-		res->off += cctrl->cur_fun->base.sz + 16; //+16 for LR/FP
-	else if (res->mode == MD_FRAME) {
-		if (cctrl->backend_user_data4) {
-			res->off += cctrl->backend_user_data4; // wiggle room start(if set)
-		} else
-			// Anonymus potatoes like to assume LR/FP pair too.
-			res->off += 16;
-	}
+static void PushSpilledTmp(CCmpCtrl *cctrl, CRPN *rpn) {
+  int64_t raw_type = rpn->raw_type;
+  CICArg *res = &rpn->res;
+  if (rpn->flags & ICF_PRECOMPUTED)
+    return;
+  // These have no need to be put into a temporay
+  switch (rpn->type) {
+    break;
+  case IC_I64:
+    res->mode = MD_I64;
+    res->integer = rpn->integer;
+    res->raw_type = RT_I64i;
+    return;
+    break;
+  case IC_F64:
+    res->mode = MD_F64;
+    res->flt = rpn->flt;
+    res->raw_type = RT_F64;
+    return;
+    break;
+  case IC_IREG:
+  case IC_FREG:
+    res->mode = MD_REG;
+    res->raw_type = raw_type;
+    res->reg = rpn->integer;
+    return;
+    break;
+  case IC_BASE_PTR:
+    res->mode = MD_FRAME;
+    res->raw_type = raw_type;
+    res->off = rpn->integer;
+    return;
+  case IC_STATIC:
+    res->mode = MD_PTR;
+    res->raw_type = raw_type;
+    res->off = rpn->integer;
+    return;
+  case __IC_STATIC_REF:
+    res->mode = MD_STATIC;
+    res->raw_type = raw_type;
+    res->off = rpn->integer;
+    return;
+  }
+  rpn->flags |= ICF_SPILLED;
+  if (raw_type != RT_F64) {
+    res->mode = MD_FRAME;
+    res->raw_type = raw_type;
+    if (cctrl->backend_user_data0 < (res->off = cctrl->backend_user_data1 +=
+                                     8)) { // Will set ref->off before the top
+      cctrl->backend_user_data0 = res->off;
+    }
+  } else {
+    res->mode = MD_FRAME;
+    res->raw_type = raw_type;
+    if (cctrl->backend_user_data0 < (res->off = cctrl->backend_user_data1 +=
+                                     8)) { // Will set ref->off before the top
+      cctrl->backend_user_data0 = res->off;
+    }
+  }
+  // See two above notes
+  res->off -= 8;
+  // In functions,wiggle room comes after the function locals.
+  if (cctrl->cur_fun && res->mode == MD_FRAME)
+    res->off += cctrl->cur_fun->base.sz + 16; //+16 for LR/FP
+  else if (res->mode == MD_FRAME) {
+    if (cctrl->backend_user_data4) {
+      res->off += cctrl->backend_user_data4; // wiggle room start(if set)
+    } else
+      // Anonymus potatoes like to assume LR/FP pair too.
+      res->off += 16;
+  }
 }
-int64_t TmpRegToReg(int64_t r)
-{
-	switch (r) {
-		break;
-	case 0:
-		return R9;
-	case 1:
-		return RBX;
-	default:
-		abort();
-	}
+int64_t TmpRegToReg(int64_t r) {
+  switch (r) {
+    break;
+  case 0:
+    return R9;
+  case 1:
+    return RBX;
+  default:
+    abort();
+  }
 }
 
 //
@@ -2121,1671 +2176,1757 @@ int64_t TmpRegToReg(int64_t r)
 //  ~ dst=1
 //   ! dst=2
 
-static void PushTmp(CCmpCtrl* cctrl, CRPN* rpn, CICArg* inher_from)
-{
-	int64_t raw_type = rpn->raw_type;
-	CICArg* res = &rpn->res;
-	if (rpn->flags & ICF_PRECOMPUTED)
-		return;
-	// These have no need to be put into a temporay
-	switch (rpn->type) {
-		break;
-	case __IC_STATIC_REF:
-		res->mode = MD_STATIC;
-		res->raw_type = raw_type;
-		res->off = rpn->integer;
-		return;
-	case IC_STATIC:
-		res->mode = MD_PTR;
-		res->raw_type = raw_type;
-		res->off = rpn->integer;
-		return;
-		// These dudes will compile down to a MD_I64/MD_F64
-	case IC_I64:
-		res->mode = MD_I64;
-		res->integer = rpn->integer;
-		res->raw_type = RT_I64i;
-		return;
-		break;
-	case IC_F64:
-		res->mode = MD_F64;
-		res->flt = rpn->flt;
-		res->raw_type = RT_F64;
-		return;
-	case IC_IREG:
-	case IC_FREG:
-		res->mode = MD_REG;
-		res->raw_type = raw_type;
-		res->reg = rpn->integer;
-		return;
-		break;
-	case IC_BASE_PTR:
-		res->mode = MD_FRAME;
-		res->raw_type = raw_type;
-		res->off = rpn->integer;
-		return;
-		return;
-	}
-	if (inher_from) {
-		if (rpn->raw_type == RT_F64 && inher_from->raw_type == RT_F64 && inher_from->mode != MD_NULL) {
-			rpn->res = *inher_from;
-			rpn->flags |= ICF_TMP_NO_UNDO;
-			return;
-		} else if (rpn->raw_type != RT_F64 && inher_from->raw_type != RT_F64 && inher_from->mode != MD_NULL) {
-			rpn->res = *inher_from;
-			rpn->flags |= ICF_TMP_NO_UNDO;
-			return;
-		}
-	}
+static void PushTmp(CCmpCtrl *cctrl, CRPN *rpn, CICArg *inher_from) {
+  int64_t raw_type = rpn->raw_type;
+  CICArg *res = &rpn->res;
+  if (rpn->flags & ICF_PRECOMPUTED)
+    return;
+  // These have no need to be put into a temporay
+  switch (rpn->type) {
+    break;
+  case __IC_STATIC_REF:
+    res->mode = MD_STATIC;
+    res->raw_type = raw_type;
+    res->off = rpn->integer;
+    return;
+  case IC_STATIC:
+    res->mode = MD_PTR;
+    res->raw_type = raw_type;
+    res->off = rpn->integer;
+    return;
+    // These dudes will compile down to a MD_I64/MD_F64
+  case IC_I64:
+    res->mode = MD_I64;
+    res->integer = rpn->integer;
+    res->raw_type = RT_I64i;
+    return;
+    break;
+  case IC_F64:
+    res->mode = MD_F64;
+    res->flt = rpn->flt;
+    res->raw_type = RT_F64;
+    return;
+  case IC_IREG:
+  case IC_FREG:
+    res->mode = MD_REG;
+    res->raw_type = raw_type;
+    res->reg = rpn->integer;
+    return;
+    break;
+  case IC_BASE_PTR:
+    res->mode = MD_FRAME;
+    res->raw_type = raw_type;
+    res->off = rpn->integer;
+    return;
+    return;
+  }
+  if (inher_from) {
+    if (rpn->raw_type == RT_F64 && inher_from->raw_type == RT_F64 &&
+        inher_from->mode != MD_NULL) {
+      rpn->res = *inher_from;
+      rpn->flags |= ICF_TMP_NO_UNDO;
+      return;
+    } else if (rpn->raw_type != RT_F64 && inher_from->raw_type != RT_F64 &&
+               inher_from->mode != MD_NULL) {
+      rpn->res = *inher_from;
+      rpn->flags |= ICF_TMP_NO_UNDO;
+      return;
+    }
+  }
 use_defacto:
-	if (raw_type != RT_F64) {
-		if (cctrl->backend_user_data2 < AIWNIOS_TMP_IREG_CNT) {
-			res->mode = MD_REG;
-			res->raw_type = raw_type;
-			res->off = 0;
-			res->reg = TmpRegToReg(cctrl->backend_user_data2++);
-		} else {
-			PushSpilledTmp(cctrl, rpn);
-		}
-	} else {
-		if (cctrl->backend_user_data3 < AIWNIOS_TMP_FREG_CNT) {
-			res->mode = MD_REG;
-			res->raw_type = raw_type;
-			res->off = 0;
-			res->reg = AIWNIOS_TMP_FREG_START + cctrl->backend_user_data3++;
-		} else {
-			PushSpilledTmp(cctrl, rpn);
-		}
-	}
+  if (raw_type != RT_F64) {
+    if (cctrl->backend_user_data2 < AIWNIOS_TMP_IREG_CNT) {
+      res->mode = MD_REG;
+      res->raw_type = raw_type;
+      res->off = 0;
+      res->reg = TmpRegToReg(cctrl->backend_user_data2++);
+    } else {
+      PushSpilledTmp(cctrl, rpn);
+    }
+  } else {
+    if (cctrl->backend_user_data3 < AIWNIOS_TMP_FREG_CNT) {
+      res->mode = MD_REG;
+      res->raw_type = raw_type;
+      res->off = 0;
+      res->reg = AIWNIOS_TMP_FREG_START + cctrl->backend_user_data3++;
+    } else {
+      PushSpilledTmp(cctrl, rpn);
+    }
+  }
 }
 
-static void PopTmp(CCmpCtrl* cctrl, CRPN* rpn)
-{
-	int64_t raw_type = rpn->raw_type;
-	// We didnt modift the res with PushTmp,so dont modify the results here
-	if (rpn->flags & ICF_PRECOMPUTED)
-		return;
-	if (rpn->flags & ICF_TMP_NO_UNDO)
-		return;
-	// These have no need to be put into a temporay
-	switch (rpn->type) {
-		break;
-	case IC_I64:
-	case IC_F64:
-	case IC_IREG:
-	case IC_FREG:
-	case IC_BASE_PTR:
-	case IC_STATIC:
-	case __IC_STATIC_REF:
-		return;
-	}
-	if (rpn->flags & ICF_SPILLED) {
-		cctrl->backend_user_data1 -= 8;
-	} else {
-		if (raw_type != RT_F64) {
-		indir:
-			if (rpn->flags & (ICF_SIB | ICF_INDIR_REG)) {
-				assert((cctrl->backend_user_data2 -= rpn->res.pop_n_tmp_regs) >= 0);
-			} else {
-				assert(--cctrl->backend_user_data2 >= 0);
-			}
-		} else {
-			if (rpn->flags & (ICF_SIB | ICF_INDIR_REG))
-				goto indir;
-			assert(--cctrl->backend_user_data3 >= 0);
-		}
-	}
-	assert(cctrl->backend_user_data1 >= 0);
+static void PopTmp(CCmpCtrl *cctrl, CRPN *rpn) {
+  int64_t raw_type = rpn->raw_type;
+  // We didnt modift the res with PushTmp,so dont modify the results here
+  if (rpn->flags & ICF_PRECOMPUTED)
+    return;
+  if (rpn->flags & ICF_TMP_NO_UNDO)
+    return;
+  // These have no need to be put into a temporay
+  switch (rpn->type) {
+    break;
+  case IC_I64:
+  case IC_F64:
+  case IC_IREG:
+  case IC_FREG:
+  case IC_BASE_PTR:
+  case IC_STATIC:
+  case __IC_STATIC_REF:
+    return;
+  }
+  if (rpn->flags & ICF_SPILLED) {
+    cctrl->backend_user_data1 -= 8;
+  } else {
+    if (raw_type != RT_F64) {
+    indir:
+      if (rpn->flags & (ICF_SIB | ICF_INDIR_REG)) {
+        assert((cctrl->backend_user_data2 -= rpn->res.pop_n_tmp_regs) >= 0);
+      } else {
+        assert(--cctrl->backend_user_data2 >= 0);
+      }
+    } else {
+      if (rpn->flags & (ICF_SIB | ICF_INDIR_REG))
+        goto indir;
+      assert(--cctrl->backend_user_data3 >= 0);
+    }
+  }
+  assert(cctrl->backend_user_data1 >= 0);
 }
 
-static CRPN* __AddScale(CRPN* r, int64_t* const_val)
-{
-	if (r->type != IC_MUL)
-		return NULL;
-	CRPN *n0 = ICArgN(r, 0), *n1 = ICArgN(r, 1);
-	if (IsConst(n0) && Is32Bit(ConstVal(n0))) {
-		switch (ConstVal(n0)) {
-		case 1:
-		case 2:
-		case 4:
-		case 8:
-			if (const_val)
-				*const_val = ConstVal(n0);
-			return n1;
-		}
-	}
-	if (IsConst(n1) && Is32Bit(ConstVal(n1))) {
-		switch (ConstVal(n1)) {
-		case 1:
-		case 2:
-		case 4:
-		case 8:
-			if (const_val)
-				*const_val = ConstVal(n1);
-			return n0;
-		}
-	}
-	if (const_val)
-		*const_val = 1;
-	return NULL;
+static CRPN *__AddScale(CRPN *r, int64_t *const_val) {
+  if (r->type != IC_MUL)
+    return NULL;
+  CRPN *n0 = ICArgN(r, 0), *n1 = ICArgN(r, 1);
+  if (IsConst(n0) && Is32Bit(ConstVal(n0))) {
+    switch (ConstVal(n0)) {
+    case 1:
+    case 2:
+    case 4:
+    case 8:
+      if (const_val)
+        *const_val = ConstVal(n0);
+      return n1;
+    }
+  }
+  if (IsConst(n1) && Is32Bit(ConstVal(n1))) {
+    switch (ConstVal(n1)) {
+    case 1:
+    case 2:
+    case 4:
+    case 8:
+      if (const_val)
+        *const_val = ConstVal(n1);
+      return n0;
+    }
+  }
+  if (const_val)
+    *const_val = 1;
+  return NULL;
 }
 
 // Returns the non-constant side of a +Const
 
-static CRPN* __AddOffset(CRPN* r, int64_t* const_val)
-{
-	if (r->type != IC_ADD && r->type != IC_SUB)
-		return NULL;
-	int64_t mul = (r->type == IC_ADD) ? 1 : -1;
-	CRPN *n0 = ICArgN(r, 0), *n1 = ICArgN(r, 1);
-	if (IsConst(n0) && Is32Bit(ConstVal(n0))) {
-		if (const_val)
-			*const_val = mul * ConstVal(n0);
-		return n1;
-	}
-	if (IsConst(n1) && Is32Bit(ConstVal(n1))) {
-		if (const_val)
-			*const_val = mul * ConstVal(n1);
-		return n0;
-	}
-	return NULL;
+static CRPN *__AddOffset(CRPN *r, int64_t *const_val) {
+  if (r->type != IC_ADD && r->type != IC_SUB)
+    return NULL;
+  int64_t mul = (r->type == IC_ADD) ? 1 : -1;
+  CRPN *n0 = ICArgN(r, 0), *n1 = ICArgN(r, 1);
+  if (IsConst(n0) && Is32Bit(ConstVal(n0))) {
+    if (const_val)
+      *const_val = mul * ConstVal(n0);
+    return n1;
+  }
+  if (IsConst(n1) && Is32Bit(ConstVal(n1))) {
+    if (const_val)
+      *const_val = mul * ConstVal(n1);
+    return n0;
+  }
+  return NULL;
 }
 static int64_t IsCompare(int64_t c) {
-	switch(c) {
-		case IC_GT:
-		case IC_LT:
-		case IC_GE:
-		case IC_LE:
-		return 1;
-	}
-	return 0;
+  switch (c) {
+  case IC_GT:
+  case IC_LT:
+  case IC_GE:
+  case IC_LE:
+    return 1;
+  }
+  return 0;
 }
 
 // Returns 1 if we hit the bottom
-static int64_t PushTmpDepthFirst(CCmpCtrl* cctrl, CRPN* r, int64_t spilled)
-{
-	switch (r->type) {
-	case __IC_STATIC_REF:
-	case IC_STATIC:
-	case IC_GLOBAL:
-	case IC_I64:
-	case IC_F64:
-	case IC_IREG:
-	case IC_FREG:
-	case IC_BASE_PTR:
-	case IC_STR:
-	case IC_CHR:
-		if (!spilled)
-			PushTmp(cctrl, r, NULL);
-		else
-			PushSpilledTmp(cctrl, r);
-		return 1;
-	}
-	int64_t a, argc, old_icnt = cctrl->backend_user_data2, old_fcnt = cctrl->backend_user_data3, i, i2, tmp, old_scnt = cctrl->backend_user_data1;
-	CRPN *arg, *arg2, *d, *b, *idx, *orig,**array;
-	switch (r->type) {
-		break;
-	case IC_SHORT_ADDR:
-		goto fin;
-	case IC_CALL:
-	case __IC_CALL:
-		for (i = 0; i < r->length + 1; i++) {
-			PushTmpDepthFirst(cctrl, ICArgN(r, i), 0);
-			PopTmp(cctrl, ICArgN(r, i));
-		}
-		goto fin;
-		break;
-	case IC_TO_I64:
-	unop:
-		PushTmpDepthFirst(cctrl, r->base.next, 0);
-		PopTmp(cctrl, r->base.next);
-		goto fin;
-		break;
-	case IC_TO_F64:
-		goto unop;
-		break;
-	case IC_PAREN:
-		goto unop;
-		break;
-	case IC_NEG:
-		goto unop;
-		break;
-	case IC_POS:
-		goto unop;
-		break;
-	case IC_LT:
-	case IC_GT:
-	case IC_GE:
-	case IC_LE:
-	cmp_binop:
-		arg = ICArgN(r, 1);
-		arg2 = ICArgN(r, 0);	
-		if (!IsCompoundCompare(r)) {
-			PushTmpDepthFirst(cctrl, arg, SpillsTmpRegs(arg2));
-			PushTmpDepthFirst(cctrl, arg2, 1);
-			PopTmp(cctrl, arg2);
-			PopTmp(cctrl, arg);
-			goto fin;
-		}
-		//There are 2 compares here,but 3 args
-		//a<b<c
-		argc=1;
-		d=r;
-		while(IsCompare(d->type)) {
-			d=ICFwd(d->base.next);
-			argc++;
-		}
-		array=A_MALLOC(sizeof(CRPN*)*argc,NULL);
-		argc=0;
-		d=r;
-		while(IsCompare(d->type)) {
-			array[argc++]=d->base.next;
-			PushTmpDepthFirst(cctrl,d->base.next,1);
-			d=ICFwd(d->base.next);
-		}
-		//See above note(d here is the 3)
-		array[argc++]=d;
-		PushTmpDepthFirst(cctrl,d,1);
-		//
-		while(argc--)
-			PopTmp(cctrl,array[argc]);
-		A_FREE(array);
-		goto fin;
-		break;
-	case IC_BT:
-	case IC_BTC:
-	case IC_BTR:
-	case IC_BTS:
-	case IC_LBTC:
-	case IC_LBTR:
-	case IC_LBTS:
-	case IC_POW:
-	binop:
-		arg = ICArgN(r, 1);
-		arg2 = ICArgN(r, 0);
-		PushTmpDepthFirst(cctrl, arg, SpillsTmpRegs(arg2));
-		PushTmpDepthFirst(cctrl, arg2, 0);
-		PopTmp(cctrl, arg2);
-		PopTmp(cctrl, arg);
-		goto fin;
-		break;
-	case IC_ADD:
-		orig = r;
-		orig->res.pop_n_tmp_regs = 0;
-		if (!spilled && r->raw_type != RT_F64) {
-			arg2 = r->base.last;
-			arg = r;
-			i = 0;
-			while (__AddOffset(arg, &tmp)) {
-				arg = __AddOffset(arg, &tmp);
-				i += tmp;
-			}
-			if (arg->type == IC_ADD && Is32Bit(i) && AIWNIOS_TMP_IREG_CNT - cctrl->backend_user_data2 >= 2) {
-				if (idx = __AddScale(ICArgN(arg, 0), &i2))
-					b = ICArgN(arg, 1);
-				else if (idx = __AddScale(ICArgN(arg, 1), &i2))
-					b = ICArgN(arg, 0);
-				else {
-					b = ICArgN(arg, 0), idx = ICArgN(arg, 1), i2 = 1;
-				}
-				if (SpillsTmpRegs(idx))
-					goto binop;
-				while (__AddOffset(idx, &tmp) && i2 == 1) {
-					idx = __AddOffset(idx, &tmp);
-					i += tmp;
-				}
-				while (__AddOffset(b, &tmp)) {
-					b = __AddOffset(b, &tmp);
-					i += tmp;
-				}
-				if (!Is32Bit(i))
-					goto binop;
-				PushTmpDepthFirst(cctrl, b, 0);
-				if (b->type == IC_IREG) { // Currently __OptPassFinal will dump the result to rpn->res.reg
-					// No need to store in a tmp register
-				} else {
-					cctrl->backend_user_data2++;
-				}
-				PushTmpDepthFirst(cctrl, idx, 0);
-				if (idx->type == IC_IREG) {
-					// No need to store in a tmp register
-				} else {
-					cctrl->backend_user_data2++;
-				}
-				PopTmp(cctrl, idx);
-				PopTmp(cctrl, b);
-				if (b->type != IC_IREG) {
-					// Store in a tmp reg
-					b->stuff_in_reg = TmpRegToReg(old_icnt);
-					b->flags |= ICF_STUFF_IN_REG;
-					orig->res.pop_n_tmp_regs++;
-				} else
-					b->stuff_in_reg = b->res.reg;
-				if (idx->type != IC_IREG) {
-					// Store in a tmp reg
-					idx->stuff_in_reg = TmpRegToReg(old_icnt + orig->res.pop_n_tmp_regs);
-					idx->flags |= ICF_STUFF_IN_REG;
-					orig->res.pop_n_tmp_regs++;
-				} else
-					idx->stuff_in_reg = idx->res.reg;
-				orig->res.mode = __MD_X86_64_LEA_SIB;
-				orig->res.off = i;
-				orig->res.__SIB_scale = i2;
-				orig->res.__sib_base_rpn = b;
-				orig->res.__sib_idx_rpn = idx;
-				orig->res.reg = b->stuff_in_reg;
-				orig->res.reg2 = idx->stuff_in_reg;
-				// HERE IS USE fallback_reg becuase we need a register to use after we compute SIB
-				while (orig->res.pop_n_tmp_regs--)
-					cctrl->backend_user_data2--;
-				orig->res.pop_n_tmp_regs = 1;
-				cctrl->backend_user_data2 += 1;
-				orig->res.fallback_reg = TmpRegToReg(old_icnt);
-				orig->res.raw_type = r->raw_type;
-				orig->flags |= ICF_SIB;
-				return 1;
-			} else if (Is32Bit(i) && AIWNIOS_TMP_IREG_CNT - cctrl->backend_user_data2 >= 1 && arg != r) {
-				PushTmpDepthFirst(cctrl, arg, 0);
-				PopTmp(cctrl, arg);
-				orig->flags |= ICF_INDIR_REG;
-				orig->res.mode = __MD_X86_64_LEA_SIB;
-				orig->res.__SIB_scale = -1;
-				orig->res.off = i;
-				orig->res.reg2 = -1;
-				orig->res.raw_type = r->raw_type;
-				orig->res.__sib_base_rpn = arg;
-				if (arg->type == IC_IREG) {
-					arg->stuff_in_reg = arg->res.reg;
-				} else {
-					arg->stuff_in_reg = TmpRegToReg(old_icnt);
-					arg->flags |= ICF_STUFF_IN_REG;
-				}
-				orig->res.pop_n_tmp_regs = 1;
-				cctrl->backend_user_data2++;
-				orig->res.reg = arg->stuff_in_reg;
-				orig->res.fallback_reg = TmpRegToReg(old_icnt);
-				return 1;
-			}
-		}
-		goto binop;
-		break;
-	case IC_EQ:
-		PushTmpDepthFirst(cctrl, ICArgN(r, 0), SpillsTmpRegs(ICArgN(r, 1)));
-		PushTmpDepthFirst(cctrl, ICArgN(r, 1), 0);
-		PopTmp(cctrl, ICArgN(r, 1));
-		PopTmp(cctrl, ICArgN(r, 0));
-		goto fin;
-		break;
-	case IC_SUB:
-		goto binop;
-		break;
-	case IC_DIV:
-		goto binop;
-		break;
-	case IC_MUL:
-		goto binop;
-		break;
-	case IC_DEREF:
-		orig = r;
-		//
-		// We can directly use the code ref(ICF_PRECOMPUTED to avoid recomputing)
-		//
-		if ((b = ICArgN(r, 0))->type == IC_SHORT_ADDR) {
-			r->flags |= ICF_TMP_NO_UNDO;
-			r->res.mode = MD_CODE_MISC_PTR;
-			r->res.raw_type = r->raw_type;
-			r->res.code_misc = b->code_misc;
-			// PUSH in case someone tries to bybass IC_DEREF
-			PushTmpDepthFirst(cctrl, b, 0);
-			PopTmp(cctrl, b);
-			r->flags |= ICF_PRECOMPUTED;
-			return 1;
-		}
-		//
-		// When we are looking for SIBs,the IC_DEREF is uselss so inhiere from the secret suace
-		//
-		orig->res.pop_n_tmp_regs = 0;
-		if (!spilled && r->raw_type != RT_FUNC) {
-			orig = r;
-			d = orig->base.next;
-			i = i2 = 0;
-			while (__AddOffset(d, &tmp)) {
-				i += tmp;
-				d = __AddOffset(d, &tmp);
-			}
-			if (d->type == IC_ADD) {
-				if (idx = __AddScale(ICArgN(d, 0), &i2))
-					b = ICArgN(d, 1);
-				else if (idx = __AddScale(ICArgN(d, 1), &i2))
-					b = ICArgN(d, 0);
-				else {
-					b = ICArgN(d, 0), idx = ICArgN(d, 1), i2 = 1;
-				}
-				if (AIWNIOS_TMP_IREG_CNT - cctrl->backend_user_data2 >= 2 && !SpillsTmpRegs(idx)) {
-					while (__AddOffset(idx, &tmp) && i2 == 1) {
-						idx = __AddOffset(idx, &tmp);
-						i += tmp;
-					}
-					while (__AddOffset(b, &tmp)) {
-						b = __AddOffset(b, &tmp);
-						i += tmp;
-					}
-					if (Is32Bit(i)) {
-						PushTmpDepthFirst(cctrl, b, 0);
-						if (b->type == IC_IREG) {
-							// No need to store in a tmp register
-						} else {
-							cctrl->backend_user_data2++;
-						}
-						PushTmpDepthFirst(cctrl, idx, 0);
-						if (idx->type == IC_IREG) {
-							// No need to store in a tmp register
-						} else {
-							cctrl->backend_user_data2++;
-						}
-						PopTmp(cctrl, idx);
-						PopTmp(cctrl, b);
-						if (b->type != IC_IREG) {
-							// Store in a tmp reg
-							b->stuff_in_reg = TmpRegToReg(old_icnt);
-							b->flags |= ICF_STUFF_IN_REG;
-							orig->res.pop_n_tmp_regs++;
-						} else
-							b->stuff_in_reg = b->res.reg;
-						if (idx->type != IC_IREG) {
-							// Store in a tmp reg
-							idx->stuff_in_reg = TmpRegToReg(old_icnt + orig->res.pop_n_tmp_regs);
-							idx->flags |= ICF_STUFF_IN_REG;
-							orig->res.pop_n_tmp_regs++;
-						} else
-							idx->stuff_in_reg = idx->res.reg;
-						orig->res.mode = __MD_X86_64_SIB;
-						orig->res.off = i;
-						orig->res.__SIB_scale = i2;
-						orig->res.__sib_base_rpn = b;
-						orig->res.__sib_idx_rpn = idx;
-						orig->res.reg = b->stuff_in_reg;
-						orig->res.reg2 = idx->stuff_in_reg;
-						orig->res.raw_type = r->raw_type;
-						orig->flags |= ICF_SIB;
-						return 1;
-					}
-				}
-			}
-			if (AIWNIOS_TMP_IREG_CNT - cctrl->backend_user_data2 >= 1) {
-				b = d;
-				while (__AddOffset(b, &tmp)) {
-					b = __AddOffset(b, &tmp);
-					i += tmp;
-				}
-				if (!Is32Bit(i)) {
-					PushTmpDepthFirst(cctrl, r->base.next, 0);
-					PopTmp(cctrl, r->base.next);
-					goto fin;
-				}
-				PushTmpDepthFirst(cctrl, b, 0);
-				PopTmp(cctrl, b);
-				orig->flags |= ICF_INDIR_REG;
-				orig->res.mode = __MD_X86_64_SIB;
-				orig->res.__SIB_scale = -1;
-				arg = b;
-				orig->res.off = i;
-				orig->res.reg2 = -1;
-				orig->res.raw_type = r->raw_type;
-				orig->res.__sib_base_rpn = arg;
-				if (b->type == IC_IREG) {
-					// No need to store in a tmp register
-					orig->res.pop_n_tmp_regs = 0;
-					arg->stuff_in_reg = b->res.reg;
-				} else {
-					arg->stuff_in_reg = TmpRegToReg(old_icnt);
-					arg->flags |= ICF_STUFF_IN_REG;
-					orig->res.pop_n_tmp_regs = 1;
-					cctrl->backend_user_data2++;
-				}
-				orig->res.reg = arg->stuff_in_reg;
-				return 1;
-			}
-		}
-		PushTmpDepthFirst(cctrl, r->base.next, 0);
-		PopTmp(cctrl, r->base.next);
-		goto fin;
-		break;
-	case IC_AND:
-		goto binop;
-		break;
-	case IC_ADDR_OF:
-		goto unop;
-		break;
-	case IC_XOR:
-		goto binop;
-		break;
-	case IC_MOD:
-		goto binop;
-		break;
-	case IC_OR:
-		goto binop;
-		break;
-	case IC_LNOT:
-		goto unop;
-		break;
-	case IC_BNOT:
-		goto unop;
-		break;
-	case IC_POST_INC:
-	post_op:
-		// This is the hack i was refering to mother-foofer
-		//
-		//  Doing R9=(*R9)++ is a bad idea as we need to keep R9's pointer for storing the result
-		//
-		//  MOV R9,[R9]
-		//  INC R9
-		//  MOV [R9], R9
-		//
-		//  I will Keep 2 differnet tmps ,no sharing result reigster with the source reigster
-		arg = ICArgN(r, 0);
-		if (!spilled)
-			PushTmp(cctrl, r, NULL);
-		else
-			PushSpilledTmp(cctrl, r);
-		PushTmpDepthFirst(cctrl, arg, 0);
-		PopTmp(cctrl, arg);
-		return 1;
-		break;
-	case IC_POST_DEC:
-		goto post_op;
-		break;
-	case IC_PRE_INC:
-		goto post_op;
-		break;
-	case IC_PRE_DEC:
-		goto post_op;
-		break;
-	case IC_AND_AND:
-	logical_binop:
-		arg = ICArgN(r, 1);
-		arg2 = ICArgN(r, 0);
-		PushTmpDepthFirst(cctrl, arg, SpillsTmpRegs(arg2));
-		PushTmpDepthFirst(cctrl, arg2, 0);
-		PopTmp(cctrl, arg2);
-		PopTmp(cctrl, arg);
-		goto fin;
-		break;
-	case IC_OR_OR:
-		goto logical_binop;
-		break;
-	case IC_XOR_XOR:
-		goto logical_binop;
-		break;
-	case IC_EQ_EQ:
-		goto binop;
-		break;
-	case IC_NE:
-		goto binop;
-		break;
-	case IC_LSH:
-		goto binop;
-		break;
-	case IC_RSH:
-		goto binop;
-	assign_xop:
-		arg = ICArgN(r, 1);
-		arg2 = ICArgN(r, 0);
-		// Equals (when used with IC_DEREF) are weird,they will preserve the IC_DEREF->next
-		//  and the DEREF
-		//  *(arg->next)+=arg2
-		//  IS TRAETED THE SAME AS
-		//  tmp=arg->next;
-		//  *tmp=*tmp=arg2;
-		//
-		//  arg is same as *(arg->next)
-		// WE WILL NEED TO KEEP arg->next loaded in a register and such
-		if (arg->type == IC_DEREF) {
-			if (SpillsTmpRegs(arg2))
-				PushSpilledTmp(cctrl, arg);
-			else
-				PushTmp(cctrl, arg, NULL);
-			PushTmpDepthFirst(cctrl, arg->base.next, SpillsTmpRegs(arg2));
-		} else
-			PushTmpDepthFirst(cctrl, arg, SpillsTmpRegs(arg2));
-		PushTmpDepthFirst(cctrl, arg2, 0);
-		PopTmp(cctrl, arg2);
-		if (arg->type == IC_DEREF)
-			PopTmp(cctrl, arg->base.next);
-		PopTmp(cctrl, arg);
-		goto fin;
-		break;
-	case IC_ADD_EQ:
-		goto assign_xop;
-		break;
-	case IC_SUB_EQ:
-		goto assign_xop;
-		break;
-	case IC_MUL_EQ:
-		goto assign_xop;
-		break;
-	case IC_DIV_EQ:
-		goto assign_xop;
-		break;
-	case IC_LSH_EQ:
-		goto assign_xop;
-		break;
-	case IC_RSH_EQ:
-		goto assign_xop;
-		break;
-	case IC_AND_EQ:
-		goto assign_xop;
-		break;
-	case IC_OR_EQ:
-		goto assign_xop;
-		break;
-	case IC_XOR_EQ:
-		goto assign_xop;
-		break;
-	case IC_MOD_EQ:
-		goto assign_xop;
-		break;
-	case IC_COMMA:
-		PushTmpDepthFirst(cctrl, ICArgN(r, 1), 0);
-		PopTmp(cctrl, ICArgN(r, 1));
-		ICArgN(r, 1)->res.mode = MD_NULL;
-		PushTmpDepthFirst(cctrl, ICArgN(r, 0), 0);
-		PopTmp(cctrl, ICArgN(r, 0));
-		goto fin;
-		break;
-	case IC_TYPECAST:
-		goto unop;
-		break;
-	case __IC_VARGS:
-		if (!spilled)
-			PushTmp(cctrl, r, NULL);
-		else
-			PushSpilledTmp(cctrl, r);
-		for (a = 0; a != r->length; a++) {
-			PushTmpDepthFirst(cctrl, ICArgN(r, a), 1); // TODO check if next vargs spill
-		}
-		while (a--)
-			PopTmp(cctrl, ICArgN(r, a));
-		break;
-	case IC_RELOC:
-		goto fin;
-		break;
-	default:
-		return 0;
-	fin:
-		if (!spilled)
-			PushTmp(cctrl, r, NULL);
-		else
-			PushSpilledTmp(cctrl, r);
-	}
-	return 1;
+static int64_t PushTmpDepthFirst(CCmpCtrl *cctrl, CRPN *r, int64_t spilled) {
+  switch (r->type) {
+  case __IC_STATIC_REF:
+  case IC_STATIC:
+  case IC_GLOBAL:
+  case IC_I64:
+  case IC_F64:
+  case IC_IREG:
+  case IC_FREG:
+  case IC_BASE_PTR:
+  case IC_STR:
+  case IC_CHR:
+    if (!spilled)
+      PushTmp(cctrl, r, NULL);
+    else
+      PushSpilledTmp(cctrl, r);
+    return 1;
+  }
+  int64_t a, argc, old_icnt = cctrl->backend_user_data2,
+                   old_fcnt = cctrl->backend_user_data3, i, i2, tmp,
+                   old_scnt = cctrl->backend_user_data1;
+  CRPN *arg, *arg2, *d, *b, *idx, *orig, **array;
+  switch (r->type) {
+    break;
+  case IC_SHORT_ADDR:
+    goto fin;
+  case IC_CALL:
+  case __IC_CALL:
+    for (i = 0; i < r->length + 1; i++) {
+      PushTmpDepthFirst(cctrl, ICArgN(r, i), 0);
+      PopTmp(cctrl, ICArgN(r, i));
+    }
+    goto fin;
+    break;
+  case IC_TO_I64:
+  unop:
+    PushTmpDepthFirst(cctrl, r->base.next, 0);
+    PopTmp(cctrl, r->base.next);
+    goto fin;
+    break;
+  case IC_TO_F64:
+    goto unop;
+    break;
+  case IC_PAREN:
+    goto unop;
+    break;
+  case IC_NEG:
+    goto unop;
+    break;
+  case IC_POS:
+    goto unop;
+    break;
+  case IC_LT:
+  case IC_GT:
+  case IC_GE:
+  case IC_LE:
+  cmp_binop:
+    arg = ICArgN(r, 1);
+    arg2 = ICArgN(r, 0);
+    if (!IsCompoundCompare(r)) {
+      PushTmpDepthFirst(cctrl, arg, SpillsTmpRegs(arg2));
+      PushTmpDepthFirst(cctrl, arg2, 1);
+      PopTmp(cctrl, arg2);
+      PopTmp(cctrl, arg);
+      goto fin;
+    }
+    // There are 2 compares here,but 3 args
+    // a<b<c
+    argc = 1;
+    d = r;
+    while (IsCompare(d->type)) {
+      d = ICFwd(d->base.next);
+      argc++;
+    }
+    array = A_MALLOC(sizeof(CRPN *) * argc, NULL);
+    argc = 0;
+    d = r;
+    while (IsCompare(d->type)) {
+      array[argc++] = d->base.next;
+      PushTmpDepthFirst(cctrl, d->base.next, 1);
+      d = ICFwd(d->base.next);
+    }
+    // See above note(d here is the 3)
+    array[argc++] = d;
+    PushTmpDepthFirst(cctrl, d, 1);
+    //
+    while (argc--)
+      PopTmp(cctrl, array[argc]);
+    A_FREE(array);
+    goto fin;
+    break;
+  case IC_BT:
+  case IC_BTC:
+  case IC_BTR:
+  case IC_BTS:
+  case IC_LBTC:
+  case IC_LBTR:
+  case IC_LBTS:
+  case IC_POW:
+  binop:
+    arg = ICArgN(r, 1);
+    arg2 = ICArgN(r, 0);
+    PushTmpDepthFirst(cctrl, arg, SpillsTmpRegs(arg2));
+    PushTmpDepthFirst(cctrl, arg2, 0);
+    PopTmp(cctrl, arg2);
+    PopTmp(cctrl, arg);
+    goto fin;
+    break;
+  case IC_ADD:
+    orig = r;
+    orig->res.pop_n_tmp_regs = 0;
+    if (!spilled && r->raw_type != RT_F64) {
+      arg2 = r->base.last;
+      arg = r;
+      i = 0;
+      while (__AddOffset(arg, &tmp)) {
+        arg = __AddOffset(arg, &tmp);
+        i += tmp;
+      }
+      if (arg->type == IC_ADD && Is32Bit(i) &&
+          AIWNIOS_TMP_IREG_CNT - cctrl->backend_user_data2 >= 2) {
+        if (idx = __AddScale(ICArgN(arg, 0), &i2))
+          b = ICArgN(arg, 1);
+        else if (idx = __AddScale(ICArgN(arg, 1), &i2))
+          b = ICArgN(arg, 0);
+        else {
+          b = ICArgN(arg, 0), idx = ICArgN(arg, 1), i2 = 1;
+        }
+        if (SpillsTmpRegs(idx))
+          goto binop;
+        while (__AddOffset(idx, &tmp) && i2 == 1) {
+          idx = __AddOffset(idx, &tmp);
+          i += tmp;
+        }
+        while (__AddOffset(b, &tmp)) {
+          b = __AddOffset(b, &tmp);
+          i += tmp;
+        }
+        if (!Is32Bit(i))
+          goto binop;
+        PushTmpDepthFirst(cctrl, b, 0);
+        if (b->type == IC_IREG) { // Currently __OptPassFinal will dump the
+                                  // result to rpn->res.reg
+                                  // No need to store in a tmp register
+        } else {
+          cctrl->backend_user_data2++;
+        }
+        PushTmpDepthFirst(cctrl, idx, 0);
+        if (idx->type == IC_IREG) {
+          // No need to store in a tmp register
+        } else {
+          cctrl->backend_user_data2++;
+        }
+        PopTmp(cctrl, idx);
+        PopTmp(cctrl, b);
+        if (b->type != IC_IREG) {
+          // Store in a tmp reg
+          b->stuff_in_reg = TmpRegToReg(old_icnt);
+          b->flags |= ICF_STUFF_IN_REG;
+          orig->res.pop_n_tmp_regs++;
+        } else
+          b->stuff_in_reg = b->res.reg;
+        if (idx->type != IC_IREG) {
+          // Store in a tmp reg
+          idx->stuff_in_reg = TmpRegToReg(old_icnt + orig->res.pop_n_tmp_regs);
+          idx->flags |= ICF_STUFF_IN_REG;
+          orig->res.pop_n_tmp_regs++;
+        } else
+          idx->stuff_in_reg = idx->res.reg;
+        orig->res.mode = __MD_X86_64_LEA_SIB;
+        orig->res.off = i;
+        orig->res.__SIB_scale = i2;
+        orig->res.__sib_base_rpn = b;
+        orig->res.__sib_idx_rpn = idx;
+        orig->res.reg = b->stuff_in_reg;
+        orig->res.reg2 = idx->stuff_in_reg;
+        // HERE IS USE fallback_reg becuase we need a register to use after we
+        // compute SIB
+        while (orig->res.pop_n_tmp_regs--)
+          cctrl->backend_user_data2--;
+        orig->res.pop_n_tmp_regs = 1;
+        cctrl->backend_user_data2 += 1;
+        orig->res.fallback_reg = TmpRegToReg(old_icnt);
+        orig->res.raw_type = r->raw_type;
+        orig->flags |= ICF_SIB;
+        return 1;
+      } else if (Is32Bit(i) &&
+                 AIWNIOS_TMP_IREG_CNT - cctrl->backend_user_data2 >= 1 &&
+                 arg != r) {
+        PushTmpDepthFirst(cctrl, arg, 0);
+        PopTmp(cctrl, arg);
+        orig->flags |= ICF_INDIR_REG;
+        orig->res.mode = __MD_X86_64_LEA_SIB;
+        orig->res.__SIB_scale = -1;
+        orig->res.off = i;
+        orig->res.reg2 = -1;
+        orig->res.raw_type = r->raw_type;
+        orig->res.__sib_base_rpn = arg;
+        if (arg->type == IC_IREG) {
+          arg->stuff_in_reg = arg->res.reg;
+        } else {
+          arg->stuff_in_reg = TmpRegToReg(old_icnt);
+          arg->flags |= ICF_STUFF_IN_REG;
+        }
+        orig->res.pop_n_tmp_regs = 1;
+        cctrl->backend_user_data2++;
+        orig->res.reg = arg->stuff_in_reg;
+        orig->res.fallback_reg = TmpRegToReg(old_icnt);
+        return 1;
+      }
+    }
+    goto binop;
+    break;
+  case IC_EQ:
+    PushTmpDepthFirst(cctrl, ICArgN(r, 0), SpillsTmpRegs(ICArgN(r, 1)));
+    PushTmpDepthFirst(cctrl, ICArgN(r, 1), 0);
+    PopTmp(cctrl, ICArgN(r, 1));
+    PopTmp(cctrl, ICArgN(r, 0));
+    goto fin;
+    break;
+  case IC_SUB:
+    goto binop;
+    break;
+  case IC_DIV:
+    goto binop;
+    break;
+  case IC_MUL:
+    goto binop;
+    break;
+  case IC_DEREF:
+    orig = r;
+    //
+    // We can directly use the code ref(ICF_PRECOMPUTED to avoid recomputing)
+    //
+    if ((b = ICArgN(r, 0))->type == IC_SHORT_ADDR) {
+      r->flags |= ICF_TMP_NO_UNDO;
+      r->res.mode = MD_CODE_MISC_PTR;
+      r->res.raw_type = r->raw_type;
+      r->res.code_misc = b->code_misc;
+      // PUSH in case someone tries to bybass IC_DEREF
+      PushTmpDepthFirst(cctrl, b, 0);
+      PopTmp(cctrl, b);
+      r->flags |= ICF_PRECOMPUTED;
+      return 1;
+    }
+    //
+    // When we are looking for SIBs,the IC_DEREF is uselss so inhiere from the
+    // secret suace
+    //
+    orig->res.pop_n_tmp_regs = 0;
+    if (!spilled && r->raw_type != RT_FUNC) {
+      orig = r;
+      d = orig->base.next;
+      i = i2 = 0;
+      while (__AddOffset(d, &tmp)) {
+        i += tmp;
+        d = __AddOffset(d, &tmp);
+      }
+      if (d->type == IC_ADD) {
+        if (idx = __AddScale(ICArgN(d, 0), &i2))
+          b = ICArgN(d, 1);
+        else if (idx = __AddScale(ICArgN(d, 1), &i2))
+          b = ICArgN(d, 0);
+        else {
+          b = ICArgN(d, 0), idx = ICArgN(d, 1), i2 = 1;
+        }
+        if (AIWNIOS_TMP_IREG_CNT - cctrl->backend_user_data2 >= 2 &&
+            !SpillsTmpRegs(idx)) {
+          while (__AddOffset(idx, &tmp) && i2 == 1) {
+            idx = __AddOffset(idx, &tmp);
+            i += tmp;
+          }
+          while (__AddOffset(b, &tmp)) {
+            b = __AddOffset(b, &tmp);
+            i += tmp;
+          }
+          if (Is32Bit(i)) {
+            PushTmpDepthFirst(cctrl, b, 0);
+            if (b->type == IC_IREG) {
+              // No need to store in a tmp register
+            } else {
+              cctrl->backend_user_data2++;
+            }
+            PushTmpDepthFirst(cctrl, idx, 0);
+            if (idx->type == IC_IREG) {
+              // No need to store in a tmp register
+            } else {
+              cctrl->backend_user_data2++;
+            }
+            PopTmp(cctrl, idx);
+            PopTmp(cctrl, b);
+            if (b->type != IC_IREG) {
+              // Store in a tmp reg
+              b->stuff_in_reg = TmpRegToReg(old_icnt);
+              b->flags |= ICF_STUFF_IN_REG;
+              orig->res.pop_n_tmp_regs++;
+            } else
+              b->stuff_in_reg = b->res.reg;
+            if (idx->type != IC_IREG) {
+              // Store in a tmp reg
+              idx->stuff_in_reg =
+                  TmpRegToReg(old_icnt + orig->res.pop_n_tmp_regs);
+              idx->flags |= ICF_STUFF_IN_REG;
+              orig->res.pop_n_tmp_regs++;
+            } else
+              idx->stuff_in_reg = idx->res.reg;
+            orig->res.mode = __MD_X86_64_SIB;
+            orig->res.off = i;
+            orig->res.__SIB_scale = i2;
+            orig->res.__sib_base_rpn = b;
+            orig->res.__sib_idx_rpn = idx;
+            orig->res.reg = b->stuff_in_reg;
+            orig->res.reg2 = idx->stuff_in_reg;
+            orig->res.raw_type = r->raw_type;
+            orig->flags |= ICF_SIB;
+            return 1;
+          }
+        }
+      }
+      if (AIWNIOS_TMP_IREG_CNT - cctrl->backend_user_data2 >= 1) {
+        b = d;
+        while (__AddOffset(b, &tmp)) {
+          b = __AddOffset(b, &tmp);
+          i += tmp;
+        }
+        if (!Is32Bit(i)) {
+          PushTmpDepthFirst(cctrl, r->base.next, 0);
+          PopTmp(cctrl, r->base.next);
+          goto fin;
+        }
+        PushTmpDepthFirst(cctrl, b, 0);
+        PopTmp(cctrl, b);
+        orig->flags |= ICF_INDIR_REG;
+        orig->res.mode = __MD_X86_64_SIB;
+        orig->res.__SIB_scale = -1;
+        arg = b;
+        orig->res.off = i;
+        orig->res.reg2 = -1;
+        orig->res.raw_type = r->raw_type;
+        orig->res.__sib_base_rpn = arg;
+        if (b->type == IC_IREG) {
+          // No need to store in a tmp register
+          orig->res.pop_n_tmp_regs = 0;
+          arg->stuff_in_reg = b->res.reg;
+        } else {
+          arg->stuff_in_reg = TmpRegToReg(old_icnt);
+          arg->flags |= ICF_STUFF_IN_REG;
+          orig->res.pop_n_tmp_regs = 1;
+          cctrl->backend_user_data2++;
+        }
+        orig->res.reg = arg->stuff_in_reg;
+        return 1;
+      }
+    }
+    PushTmpDepthFirst(cctrl, r->base.next, 0);
+    PopTmp(cctrl, r->base.next);
+    goto fin;
+    break;
+  case IC_AND:
+    goto binop;
+    break;
+  case IC_ADDR_OF:
+    goto unop;
+    break;
+  case IC_XOR:
+    goto binop;
+    break;
+  case IC_MOD:
+    goto binop;
+    break;
+  case IC_OR:
+    goto binop;
+    break;
+  case IC_LNOT:
+    goto unop;
+    break;
+  case IC_BNOT:
+    goto unop;
+    break;
+  case IC_POST_INC:
+  post_op:
+    // This is the hack i was refering to mother-foofer
+    //
+    //  Doing R9=(*R9)++ is a bad idea as we need to keep R9's pointer for
+    //  storing the result
+    //
+    //  MOV R9,[R9]
+    //  INC R9
+    //  MOV [R9], R9
+    //
+    //  I will Keep 2 differnet tmps ,no sharing result reigster with the source
+    //  reigster
+    arg = ICArgN(r, 0);
+    if (!spilled)
+      PushTmp(cctrl, r, NULL);
+    else
+      PushSpilledTmp(cctrl, r);
+    PushTmpDepthFirst(cctrl, arg, 0);
+    PopTmp(cctrl, arg);
+    return 1;
+    break;
+  case IC_POST_DEC:
+    goto post_op;
+    break;
+  case IC_PRE_INC:
+    goto post_op;
+    break;
+  case IC_PRE_DEC:
+    goto post_op;
+    break;
+  case IC_AND_AND:
+  logical_binop:
+    arg = ICArgN(r, 1);
+    arg2 = ICArgN(r, 0);
+    PushTmpDepthFirst(cctrl, arg, SpillsTmpRegs(arg2));
+    PushTmpDepthFirst(cctrl, arg2, 0);
+    PopTmp(cctrl, arg2);
+    PopTmp(cctrl, arg);
+    goto fin;
+    break;
+  case IC_OR_OR:
+    goto logical_binop;
+    break;
+  case IC_XOR_XOR:
+    goto logical_binop;
+    break;
+  case IC_EQ_EQ:
+    goto binop;
+    break;
+  case IC_NE:
+    goto binop;
+    break;
+  case IC_LSH:
+    goto binop;
+    break;
+  case IC_RSH:
+    goto binop;
+  assign_xop:
+    arg = ICArgN(r, 1);
+    arg2 = ICArgN(r, 0);
+    // Equals (when used with IC_DEREF) are weird,they will preserve the
+    // IC_DEREF->next
+    //  and the DEREF
+    //  *(arg->next)+=arg2
+    //  IS TRAETED THE SAME AS
+    //  tmp=arg->next;
+    //  *tmp=*tmp=arg2;
+    //
+    //  arg is same as *(arg->next)
+    // WE WILL NEED TO KEEP arg->next loaded in a register and such
+    if (arg->type == IC_DEREF) {
+      if (SpillsTmpRegs(arg2))
+        PushSpilledTmp(cctrl, arg);
+      else
+        PushTmp(cctrl, arg, NULL);
+      PushTmpDepthFirst(cctrl, arg->base.next, SpillsTmpRegs(arg2));
+    } else
+      PushTmpDepthFirst(cctrl, arg, SpillsTmpRegs(arg2));
+    PushTmpDepthFirst(cctrl, arg2, 0);
+    PopTmp(cctrl, arg2);
+    if (arg->type == IC_DEREF)
+      PopTmp(cctrl, arg->base.next);
+    PopTmp(cctrl, arg);
+    goto fin;
+    break;
+  case IC_ADD_EQ:
+    goto assign_xop;
+    break;
+  case IC_SUB_EQ:
+    goto assign_xop;
+    break;
+  case IC_MUL_EQ:
+    goto assign_xop;
+    break;
+  case IC_DIV_EQ:
+    goto assign_xop;
+    break;
+  case IC_LSH_EQ:
+    goto assign_xop;
+    break;
+  case IC_RSH_EQ:
+    goto assign_xop;
+    break;
+  case IC_AND_EQ:
+    goto assign_xop;
+    break;
+  case IC_OR_EQ:
+    goto assign_xop;
+    break;
+  case IC_XOR_EQ:
+    goto assign_xop;
+    break;
+  case IC_MOD_EQ:
+    goto assign_xop;
+    break;
+  case IC_COMMA:
+    PushTmpDepthFirst(cctrl, ICArgN(r, 1), 0);
+    PopTmp(cctrl, ICArgN(r, 1));
+    ICArgN(r, 1)->res.mode = MD_NULL;
+    PushTmpDepthFirst(cctrl, ICArgN(r, 0), 0);
+    PopTmp(cctrl, ICArgN(r, 0));
+    goto fin;
+    break;
+  case IC_TYPECAST:
+    goto unop;
+    break;
+  case __IC_VARGS:
+    if (!spilled)
+      PushTmp(cctrl, r, NULL);
+    else
+      PushSpilledTmp(cctrl, r);
+    for (a = 0; a != r->length; a++) {
+      PushTmpDepthFirst(cctrl, ICArgN(r, a),
+                        1); // TODO check if next vargs spill
+    }
+    while (a--)
+      PopTmp(cctrl, ICArgN(r, a));
+    break;
+  case IC_RELOC:
+    goto fin;
+    break;
+  default:
+    return 0;
+  fin:
+    if (!spilled)
+      PushTmp(cctrl, r, NULL);
+    else
+      PushSpilledTmp(cctrl, r);
+  }
+  return 1;
 }
 
-static int64_t DstRegAffectsMode(CICArg* d, CICArg* arg)
-{
-	if (d->mode != MD_REG)
-		return 0;
-	int64_t r = d->reg;
-	switch (arg->mode) {
-		break;
-	case MD_REG:
-		return r == arg->reg;
-		break;
-	case MD_INDIR_REG:
-		return r == arg->reg;
-		break;
-	case __MD_X86_64_SIB:
-		return r == arg->reg || r == arg->reg2;
-	}
-	return 0;
+static int64_t DstRegAffectsMode(CICArg *d, CICArg *arg) {
+  if (d->mode != MD_REG)
+    return 0;
+  int64_t r = d->reg;
+  switch (arg->mode) {
+    break;
+  case MD_REG:
+    return r == arg->reg;
+    break;
+  case MD_INDIR_REG:
+    return r == arg->reg;
+    break;
+  case __MD_X86_64_SIB:
+    return r == arg->reg || r == arg->reg2;
+  }
+  return 0;
 }
-static int64_t __ICFCallTOS(CCmpCtrl* cctrl, CRPN* rpn, char* bin,
-	int64_t code_off)
-{
-	int64_t i,has_vargs=0;
-	CICArg tmp;
-	CRPN* rpn2;
-	int64_t to_pop = rpn->length * 8;
-	void* fptr;
-	for (i = 0; i < rpn->length; i++) {
-		rpn2 = ICArgN(rpn, i);
-		if (rpn2->type == __IC_VARGS) {
-			to_pop-=8; //We dont count argv
-			to_pop += rpn2->length * 8;
-			has_vargs=1;
-			code_off = __OptPassFinal(cctrl, rpn2, bin, code_off);
-		} else {
-			code_off = __OptPassFinal(cctrl, rpn2, bin, code_off);
-			code_off = PushToStack(cctrl, &rpn2->res, bin, code_off);
-		}
-	}
-	rpn2 = ICArgN(rpn, rpn->length);
-	if (rpn2->type == IC_SHORT_ADDR) {
-		AIWNIOS_ADD_CODE(X86Call32, 0)
-		if (bin)
-			CodeMiscAddRef(rpn2->code_misc, bin + code_off - 4);
-		goto after_call;
-	}
-	if (rpn2->type == IC_GLOBAL) {
-		if (rpn2->global_var->base.type & HTT_FUN) {
-			fptr = ((CHashFun*)rpn2->global_var)->fun_ptr;
-		use_fptr:
-			if (!((CHashFun*)rpn2->global_var)->fun_ptr)
-				goto defacto;
-			if (!Is32Bit((int64_t)fptr - (int64_t)(bin + code_off)))
-				goto defacto;
-			if (cctrl->code_ctrl->final_pass) {
-				AIWNIOS_ADD_CODE(X86Call32, (int64_t)fptr - (int64_t)(bin + code_off));
-			} else
-				goto defacto;
-		} else
-			goto defacto;
-	} else {
-	defacto:
-		rpn2->res.raw_type = RT_PTR; // Not set for some reason
-		if (rpn2->type == IC_RELOC) {
-			AIWNIOS_ADD_CODE(X86CallSIB64, -1, -1, RIP, 0);
-			if (bin)
-				CodeMiscAddRef(rpn2->code_misc, bin + code_off - 4);
-		} else if (rpn2->type == IC_I64 && Is32Bit(rpn2->integer - (int64_t)(bin + code_off))) {
-			AIWNIOS_ADD_CODE(X86Call32, rpn2->integer - (int64_t)(bin + code_off));
-		} else {
-			code_off = __OptPassFinal(cctrl, rpn2, bin, code_off);
-			code_off = PutICArgIntoReg(cctrl, &rpn2->res, RT_PTR, AIWNIOS_TMP_IREG_POOP, bin, code_off);
-			AIWNIOS_ADD_CODE(X86CallReg, rpn2->res.reg);
-		}
-	}
+static int64_t __ICFCallTOS(CCmpCtrl *cctrl, CRPN *rpn, char *bin,
+                            int64_t code_off) {
+  int64_t i, has_vargs = 0;
+  CICArg tmp;
+  CRPN *rpn2;
+  int64_t to_pop = rpn->length * 8;
+  void *fptr;
+  for (i = 0; i < rpn->length; i++) {
+    rpn2 = ICArgN(rpn, i);
+    if (rpn2->type == __IC_VARGS) {
+      to_pop -= 8; // We dont count argv
+      to_pop += rpn2->length * 8;
+      has_vargs = 1;
+      code_off = __OptPassFinal(cctrl, rpn2, bin, code_off);
+    } else {
+      code_off = __OptPassFinal(cctrl, rpn2, bin, code_off);
+      code_off = PushToStack(cctrl, &rpn2->res, bin, code_off);
+    }
+  }
+  rpn2 = ICArgN(rpn, rpn->length);
+  if (rpn2->type == IC_SHORT_ADDR) {
+    AIWNIOS_ADD_CODE(X86Call32, 0)
+    if (bin)
+      CodeMiscAddRef(rpn2->code_misc, bin + code_off - 4);
+    goto after_call;
+  }
+  if (rpn2->type == IC_GLOBAL) {
+    if (rpn2->global_var->base.type & HTT_FUN) {
+      fptr = ((CHashFun *)rpn2->global_var)->fun_ptr;
+    use_fptr:
+      if (!((CHashFun *)rpn2->global_var)->fun_ptr)
+        goto defacto;
+      if (!Is32Bit((int64_t)fptr - (int64_t)(bin + code_off)))
+        goto defacto;
+      if (cctrl->code_ctrl->final_pass) {
+        AIWNIOS_ADD_CODE(X86Call32, (int64_t)fptr - (int64_t)(bin + code_off));
+      } else
+        goto defacto;
+    } else
+      goto defacto;
+  } else {
+  defacto:
+    rpn2->res.raw_type = RT_PTR; // Not set for some reason
+    if (rpn2->type == IC_RELOC) {
+      AIWNIOS_ADD_CODE(X86CallSIB64, -1, -1, RIP, 0);
+      if (bin)
+        CodeMiscAddRef(rpn2->code_misc, bin + code_off - 4);
+    } else if (rpn2->type == IC_I64 &&
+               Is32Bit(rpn2->integer - (int64_t)(bin + code_off))) {
+      AIWNIOS_ADD_CODE(X86Call32, rpn2->integer - (int64_t)(bin + code_off));
+    } else {
+      code_off = __OptPassFinal(cctrl, rpn2, bin, code_off);
+      code_off = PutICArgIntoReg(cctrl, &rpn2->res, RT_PTR,
+                                 AIWNIOS_TMP_IREG_POOP, bin, code_off);
+      AIWNIOS_ADD_CODE(X86CallReg, rpn2->res.reg);
+    }
+  }
 after_call:
-	if (has_vargs)
-		AIWNIOS_ADD_CODE(X86AddImm32, RSP, to_pop);
-	if (rpn->raw_type != RT_U0 && rpn->res.mode != MD_NULL) {
-		tmp.reg = 0;
-		tmp.mode = MD_REG;
-		tmp.raw_type = rpn->raw_type == RT_F64 ? RT_F64 : RT_I64i; // Promote to 64bits
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-	}
-	return code_off;
+  if (has_vargs)
+    AIWNIOS_ADD_CODE(X86AddImm32, RSP, to_pop);
+  if (rpn->raw_type != RT_U0 && rpn->res.mode != MD_NULL) {
+    tmp.reg = 0;
+    tmp.mode = MD_REG;
+    tmp.raw_type =
+        rpn->raw_type == RT_F64 ? RT_F64 : RT_I64i; // Promote to 64bits
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+  }
+  return code_off;
 }
-int64_t ICMov(CCmpCtrl* cctrl, CICArg* dst, CICArg* src, char* bin,
-	int64_t code_off)
-{
-	int64_t use_reg, use_reg2, restore_from_tmp = 0, indir_off = 0,
-							   indir_off2 = 0, opc;
-	CICArg tmp = { 0 }, tmp2 = { 0 };
-	assert(src->mode > 0 || src->mode == -1);
-	assert(dst->mode > 0 || dst->mode == -1);
-	if (dst->mode == MD_NULL)
-		return code_off;
-	if ((dst->raw_type == RT_F64) == (src->raw_type == RT_F64))
-		if (dst->mode == src->mode) {
-			switch (dst->mode) {
-				break;
-			case __MD_X86_64_SIB:
-				if (dst->off == src->off && dst->__SIB_scale == src->__SIB_scale
-					&& dst->reg == src->reg && dst->reg2 == src->reg2) {
-					return code_off;
-				}
-				break;
-			case MD_STATIC:
-				if (dst->off == src->off)
-					return code_off;
-				break;
-			case MD_PTR:
-				if (dst->off == src->off)
-					return code_off;
-				break;
-			case MD_REG:
-				if (dst->reg == src->reg)
-					return code_off;
-				break;
-			case MD_FRAME:
-				if (dst->off == src->off)
-					return code_off;
-				break;
-			case MD_INDIR_REG:
-				if (dst->off == src->off && dst->reg == src->reg)
-					return code_off;
-			}
-		}
-	switch (dst->mode) {
-		break;
-	case MD_CODE_MISC_PTR:
-		if (src->mode == MD_REG && ((src->raw_type == RT_F64) == (dst->raw_type == RT_F64))) {
-			switch (dst->raw_type) {
-				break;
-			case RT_U8i:
-			case RT_I8i:
-				AIWNIOS_ADD_CODE(X86MovIndirRegI8, src->reg, -1, -1, RIP, 0);
-				break;
-			case RT_U16i:
-			case RT_I16i:
-				AIWNIOS_ADD_CODE(X86MovIndirRegI16, src->reg, -1, -1, RIP, 0);
-				break;
-			case RT_U32i:
-			case RT_I32i:
-				AIWNIOS_ADD_CODE(X86MovIndirRegI32, src->reg, -1, -1, RIP, 0);
-				break;
-			case RT_PTR:
-			case RT_U64i:
-			case RT_I64i:
-			case RT_FUNC:
-				AIWNIOS_ADD_CODE(X86MovIndirRegI64, src->reg, -1, -1, RIP, 0);
-				break;
-			case RT_F64:
-				AIWNIOS_ADD_CODE(X86MovIndirRegF64, src->reg, -1, -1, RIP, 0);
-				break;
-			default:
-				abort();
-			}
-			if (bin)
-				CodeMiscAddRef(dst->code_misc, bin + code_off - 4);
-			return code_off;
-		}
-		goto dft;
-	case __MD_X86_64_SIB:
-		if (src->mode == MD_I64 && Is32Bit(src->integer) && ((src->raw_type == RT_F64) == (dst->raw_type == RT_F64))) {
-			switch (dst->raw_type) {
-				break;
-			case RT_U8i:
-			case RT_I8i:
-				AIWNIOS_ADD_CODE(X86MovIndirI8Imm, src->integer, dst->__SIB_scale, dst->reg2, dst->reg, dst->off);
-				break;
-			case RT_U16i:
-			case RT_I16i:
-				AIWNIOS_ADD_CODE(X86MovIndirI16Imm, src->integer, dst->__SIB_scale, dst->reg2, dst->reg, dst->off);
-				break;
-			case RT_U32i:
-			case RT_I32i:
-				AIWNIOS_ADD_CODE(X86MovIndirI32Imm, src->integer, dst->__SIB_scale, dst->reg2, dst->reg, dst->off);
-				break;
-			case RT_PTR:
-			case RT_U64i:
-			case RT_I64i:
-			case RT_FUNC:
-				AIWNIOS_ADD_CODE(X86MovIndirI64Imm, src->integer, dst->__SIB_scale, dst->reg2, dst->reg, dst->off);
-				break;
-			default:
-				abort();
-			}
-			return code_off;
-		} else if(src->mode == MD_REG && ((src->raw_type == RT_F64) == (dst->raw_type == RT_F64))) {
-			switch (dst->raw_type) {
-				break;
-			case RT_U8i:
-			case RT_I8i:
-				AIWNIOS_ADD_CODE(X86MovIndirRegI8, src->reg, dst->__SIB_scale, dst->reg2, dst->reg, dst->off);
-				break;
-			case RT_U16i:
-			case RT_I16i:
-				AIWNIOS_ADD_CODE(X86MovIndirRegI16, src->reg, dst->__SIB_scale, dst->reg2, dst->reg, dst->off);
-				break;
-			case RT_U32i:
-			case RT_I32i:
-				AIWNIOS_ADD_CODE(X86MovIndirRegI32, src->reg, dst->__SIB_scale, dst->reg2, dst->reg, dst->off);
-				break;
-			case RT_PTR:
-			case RT_U64i:
-			case RT_I64i:
-			case RT_FUNC:
-				AIWNIOS_ADD_CODE(X86MovIndirRegI64, src->reg, dst->__SIB_scale, dst->reg2, dst->reg, dst->off);
-				break;
-			case RT_F64:
-				AIWNIOS_ADD_CODE(X86MovIndirRegF64, src->reg, dst->__SIB_scale, dst->reg2, dst->reg, dst->off);
-				break;
-			default:
-				abort();
-			}
-			return code_off;
-		}
-		goto dft;
-		break;
-	case MD_STATIC:
-		if (src->mode == MD_I64 && Is32Bit(src->integer) && ((src->raw_type == RT_F64) == (dst->raw_type == RT_F64))) {
-			switch (dst->raw_type) {
-				break;
-			case RT_U8i:
-			case RT_I8i:
-				AIWNIOS_ADD_CODE(X86MovIndirI8Imm, src->integer, -1, -1, RIP, 1000);
-				indir_off2=1;
-				break;
-			case RT_U16i:
-			case RT_I16i:
-				AIWNIOS_ADD_CODE(X86MovIndirI16Imm, src->integer, -1, -1, RIP, 1000);
-				indir_off2=2;
-				break;
-			case RT_U32i:
-			case RT_I32i:
-				AIWNIOS_ADD_CODE(X86MovIndirI32Imm, src->integer, -1, -1, RIP, 1000);
-				indir_off2=4;
-				break;
-			case RT_PTR:
-			case RT_U64i:
-			case RT_I64i:
-			case RT_FUNC:
-			case RT_F64:
-				indir_off2=8;
-				AIWNIOS_ADD_CODE(X86MovIndirI64Imm, src->integer, -1, -1, RIP, 1000);
-				break;
-			default:
-				abort();
-			}
-			if(bin) {
-				//Heres the deal
-				//These are encoded as CX05[offset][immediate]
-				//When we do the relocation,be sure to modify the offset and not the immeidate
-				//Also add indir_off2 to point to the end of the instriction as the relocation only points to the offset
-				CodeMiscAddRef(cctrl->statics_label, bin + code_off - 4-indir_off2)->offset = dst->off-indir_off2;
-			}
-			return code_off;
-		} else if (src->mode == MD_REG && (dst->raw_type == RT_F64) == (src->raw_type == RT_F64)) {
-			switch (dst->raw_type) {
-				break;
-			case RT_U8i:
-			case RT_I8i:
-				AIWNIOS_ADD_CODE(X86MovIndirRegI8, src->reg, -1, -1, RIP, 1000);
-				break;
-			case RT_U16i:
-			case RT_I16i:
-				AIWNIOS_ADD_CODE(X86MovIndirRegI16, src->reg, -1, -1, RIP, 1000);
-				break;
-			case RT_U32i:
-			case RT_I32i:
-				AIWNIOS_ADD_CODE(X86MovIndirRegI32, src->reg, -1, -1, RIP, 1000);
-				break;
-			case RT_PTR:
-			case RT_U64i:
-			case RT_I64i:
-			case RT_FUNC:
-				AIWNIOS_ADD_CODE(X86MovIndirRegI64, src->reg, -1, -1, RIP, 1000);
-				break;
-			case RT_F64:
-				AIWNIOS_ADD_CODE(X86MovIndirRegF64, src->reg, -1, -1, RIP, 1000);
-				break;
-			default:
-				abort();
-			}
-			if (bin)
-				CodeMiscAddRef(cctrl->statics_label, bin + code_off - 4)->offset = dst->off;
-			return code_off;
-		}
-		goto dft;
-		break;
-	case MD_INDIR_REG:
-		use_reg2 = dst->reg;
-		indir_off = dst->off;
-	indir_r2:
-		if (src->raw_type == dst->raw_type && src->raw_type == RT_F64 && src->mode == MD_REG) {
-			use_reg = src->reg;
-		} else if ((src->raw_type == RT_F64) ^ (RT_F64 == dst->raw_type)) { // Do they differ
-			goto dft;
-		} else if (src->mode == MD_FRAME || src->mode == MD_PTR || src->mode == MD_INDIR_REG) {
-			goto dft;
-		} else if (src->mode == MD_REG)
-			use_reg = src->reg;
-		else if (src->mode == MD_I64 && Is32Bit(src->integer) && ((src->raw_type == RT_F64) == (dst->raw_type == RT_F64))) {
-			switch (dst->raw_type) {
-				break;
-			case RT_U8i:
-			case RT_I8i:
-				AIWNIOS_ADD_CODE(X86MovIndirI8Imm, src->integer, -1, -1, use_reg2, indir_off);
-				break;
-			case RT_U16i:
-			case RT_I16i:
-				AIWNIOS_ADD_CODE(X86MovIndirI16Imm, src->integer, -1, -1, use_reg2, indir_off);
-				break;
-			case RT_U32i:
-			case RT_I32i:
-				AIWNIOS_ADD_CODE(X86MovIndirI32Imm, src->integer, -1, -1, use_reg2, indir_off);
-				break;
-			case RT_PTR:
-			case RT_U64i:
-			case RT_I64i:
-			case RT_FUNC:
-				AIWNIOS_ADD_CODE(X86MovIndirI64Imm, src->integer, -1, -1, use_reg2, indir_off);
-				break;
-			default:
-				abort();
-			}
-			return code_off;
-		} else {
-		dft:
-			tmp.raw_type = src->raw_type;
-			if (dst->raw_type != RT_F64)
-				use_reg = tmp.reg = AIWNIOS_TMP_IREG_POOP;
-			else
-				use_reg = tmp.reg = 0;
-			if (dst->mode == MD_REG)
-				use_reg = tmp.reg = dst->reg;
-			tmp.mode = MD_REG;
-			if (dst->raw_type == RT_F64 && src->raw_type != dst->raw_type) {
-				tmp.raw_type = RT_F64;
-				if (src->mode == MD_REG) {
-					AIWNIOS_ADD_CODE(X86CVTTSI2SDRegReg, use_reg, src->reg);
-				} else if (src->mode == MD_INDIR_REG&&RawTypeIs64(src->raw_type)) {
-					AIWNIOS_ADD_CODE(X86CVTTSI2SDRegSIB64, use_reg, -1, -1, src->reg, src->off);
-				} else if (src->mode == MD_FRAME&&RawTypeIs64(src->raw_type)) {
-					AIWNIOS_ADD_CODE(X86CVTTSI2SDRegSIB64, use_reg, -1, -1, RBP, -src->off);
-				} /*else if(src->mode==__MD_X86_64_SIB) {
-					AIWNIOS_ADD_CODE(X86CVTTSI2SDRegSIB64, use_reg, src->__SIB_scale, src->reg2, src->reg, src->off);
-				} */
-				else {
-					tmp2 = tmp;
-					tmp2.mode = MD_REG;
-					tmp2.reg = 0;
-					tmp2.raw_type = src->raw_type;
-					code_off = ICMov(cctrl, &tmp2, src, bin, code_off);
-					code_off = ICMov(cctrl, &tmp, &tmp2, bin, code_off);
-				}
-			} else if (src->raw_type == RT_F64 && src->raw_type != dst->raw_type) {
-				tmp.raw_type = RT_I64i;
-				if (src->mode == MD_REG) {
-					AIWNIOS_ADD_CODE(X86CVTTSD2SIRegReg, use_reg, src->reg);
-				} else if (src->mode == MD_INDIR_REG&&RawTypeIs64(src->raw_type)) {
-					AIWNIOS_ADD_CODE(X86CVTTSD2SIRegSIB64, use_reg, -1, -1, src->reg, src->off);
-				} else if (src->mode == MD_FRAME&&RawTypeIs64(src->raw_type)) {
-					AIWNIOS_ADD_CODE(X86CVTTSD2SIRegSIB64, use_reg, -1, -1, RBP, -src->off);
-				} /*else if(src->mode==__MD_X86_64_SIB) {
-					AIWNIOS_ADD_CODE(X86CVTTSD2SIRegSIB64, use_reg, src->__SIB_scale, src->reg2, src->reg, src->off);
-				} */
-				else {
-					tmp2 = tmp;
-					tmp2.mode = MD_REG;
-					tmp2.reg = 0;
-					tmp2.raw_type = src->raw_type;
-					code_off = ICMov(cctrl, &tmp2, src, bin, code_off);
-					code_off = ICMov(cctrl, &tmp, &tmp2, bin, code_off);
-				}
-			} else
-				code_off = ICMov(cctrl, &tmp, src, bin, code_off);
-			code_off = ICMov(cctrl, dst, &tmp, bin, code_off);
-			return code_off;
-		}
-		goto store_r2;
-		break;
-	case MD_PTR:
-		if (src->mode != MD_REG || ((src->raw_type == RT_F64) != (dst->raw_type == RT_F64)))
-			goto dft;
-		use_reg = src->reg;
-		if (Is32Bit((char*)dst->off - (bin + code_off))) {
-			indir_off = (char*)dst->off - (bin + code_off);
-			use_reg2 = RIP;
-			goto store_r2;
-		}
-		use_reg2 = (cctrl->flags & CCF_ICMOV_NO_USE_RAX) ? AIWNIOS_TMP_IREG_POOP2 : RAX;
-		code_off = __ICMoveI64(cctrl, use_reg2, dst->off, bin, code_off);
-		indir_off = 0;
-		goto store_r2;
-	store_r2:
-		switch (dst->raw_type) {
-		case RT_U0:
-			break;
-		case RT_F64:
-			AIWNIOS_ADD_CODE(X86MovIndirRegF64, use_reg, -1, -1, use_reg2, indir_off);
-			break;
-		case RT_U8i:
-		case RT_I8i:
-			AIWNIOS_ADD_CODE(X86MovIndirRegI8, use_reg, -1, -1, use_reg2, indir_off);
-			break;
-		case RT_U16i:
-		case RT_I16i:
-			AIWNIOS_ADD_CODE(X86MovIndirRegI16, use_reg, -1, -1, use_reg2, indir_off);
-			break;
-		case RT_U32i:
-		case RT_I32i:
-			AIWNIOS_ADD_CODE(X86MovIndirRegI32, use_reg, -1, -1, use_reg2, indir_off);
-			break;
-		case RT_U64i:
-		case RT_I64i:
-		case RT_FUNC: // func ptr
-		case RT_PTR:
-			AIWNIOS_ADD_CODE(X86MovIndirRegI64, use_reg, -1, -1, use_reg2, indir_off);
-			break;
-		default:
-			abort();
-		}
-		break;
-	case MD_FRAME:
-		use_reg2 = X86_64_BASE_REG;
-		indir_off = -dst->off;
-		goto indir_r2;
-		break;
-	case MD_REG:
-		use_reg = dst->reg;
-		if (src->mode == MD_FRAME) {
-			if (src->raw_type == RT_F64 && src->raw_type == dst->raw_type) {
-				use_reg2 = X86_64_BASE_REG;
-				indir_off = -src->off;
-				goto load_r2;
-			} else if ((src->raw_type == RT_F64) ^ (RT_F64 == dst->raw_type)) {
-				goto dft;
-			}
-			use_reg2 = X86_64_BASE_REG;
-			indir_off = -src->off;
-			goto load_r2;
-		} else if (src->mode == __MD_X86_64_SIB) {
-			if ((src->raw_type == RT_F64) != (dst->raw_type == RT_F64))
-				goto dft;
-			switch (src->raw_type) {
-			case RT_U0:
-				break;
-			case RT_U8i:
-				AIWNIOS_ADD_CODE(X86MovZXRegIndirI8, dst->reg, src->__SIB_scale, src->reg2, src->reg, src->off);
-				break;
-			case RT_I8i:
-				AIWNIOS_ADD_CODE(X86MovSXRegIndirI8, dst->reg, src->__SIB_scale, src->reg2, src->reg, src->off);
-				break;
-			case RT_U16i:
-				AIWNIOS_ADD_CODE(X86MovZXRegIndirI16, dst->reg, src->__SIB_scale, src->reg2, src->reg, src->off);
-				break;
-			case RT_I16i:
-				AIWNIOS_ADD_CODE(X86MovSXRegIndirI16, dst->reg, src->__SIB_scale, src->reg2, src->reg, src->off);
-				break;
-			case RT_U32i:
-				AIWNIOS_ADD_CODE(X86MovRegIndirI32, dst->reg, src->__SIB_scale, src->reg2, src->reg, src->off);
-				break;
-			case RT_I32i:
-				AIWNIOS_ADD_CODE(X86MovSXRegIndirI32, dst->reg, src->__SIB_scale, src->reg2, src->reg, src->off);
-				break;
-			case RT_U64i:
-			case RT_PTR:
-			case RT_FUNC:
-			case RT_I64i:
-				AIWNIOS_ADD_CODE(X86MovRegIndirI64, dst->reg, src->__SIB_scale, src->reg2, src->reg, src->off);
-				break;
-			case RT_F64:
-				AIWNIOS_ADD_CODE(X86MovRegIndirF64, dst->reg, src->__SIB_scale, src->reg2, src->reg, src->off);
-			}
-			return code_off;
-		} else if (src->mode == MD_CODE_MISC_PTR) {
-			if ((src->raw_type == RT_F64) != (dst->raw_type == RT_F64))
-				goto dft;
-			switch (src->raw_type) {
-			case RT_U0:
-				break;
-			case RT_U8i:
-				AIWNIOS_ADD_CODE(X86MovZXRegIndirI8, dst->reg, -1, -1, RIP, 0);
-				break;
-			case RT_I8i:
-				AIWNIOS_ADD_CODE(X86MovSXRegIndirI8, dst->reg, -1, -1, RIP, 0);
-				break;
-			case RT_U16i:
-				AIWNIOS_ADD_CODE(X86MovZXRegIndirI16, dst->reg, -1, -1, RIP, 0);
-				break;
-			case RT_I16i:
-				AIWNIOS_ADD_CODE(X86MovSXRegIndirI16, dst->reg, -1, -1, RIP, 0);
-				break;
-			case RT_U32i:
-				AIWNIOS_ADD_CODE(X86MovRegIndirI32, dst->reg, -1, -1, RIP, 0);
-				break;
-			case RT_I32i:
-				AIWNIOS_ADD_CODE(X86MovSXRegIndirI32, dst->reg, -1, -1, RIP, 0);
-				break;
-			case RT_U64i:
-			case RT_PTR:
-			case RT_FUNC:
-			case RT_I64i:
-				AIWNIOS_ADD_CODE(X86MovRegIndirI64, dst->reg, -1, -1, RIP, 0);
-				break;
-			case RT_F64:
-				AIWNIOS_ADD_CODE(X86MovRegIndirF64, dst->reg, -1, -1, RIP, 0);
-			}
-			if (bin)
-				CodeMiscAddRef(src->code_misc, bin + code_off - 4);
-			return code_off;
-		} else if (src->mode == MD_REG) {
-			if (src->raw_type == RT_F64 && src->raw_type == dst->raw_type) {
-				AIWNIOS_ADD_CODE(X86MovRegRegF64, dst->reg, src->reg);
-			} else if (src->raw_type != RT_F64 && dst->raw_type != RT_F64) {
-				AIWNIOS_ADD_CODE(X86MovRegReg, dst->reg, src->reg);
-			} else if (src->raw_type == RT_F64 && dst->raw_type != RT_F64) {
-				goto dft;
-			} else if (src->raw_type != RT_F64 && dst->raw_type == RT_F64) {
-				goto dft;
-			}
-		} else if (src->mode == MD_PTR) {
-			if (src->raw_type == RT_F64 && src->raw_type == dst->raw_type) {
-				use_reg2 = (cctrl->flags & CCF_ICMOV_NO_USE_RAX) ? AIWNIOS_TMP_IREG_POOP2 : RAX;
-				code_off = __ICMoveI64(cctrl, use_reg2, src->off, bin, code_off);
-				goto load_r2;
-			} else if ((src->raw_type == RT_F64) ^ (RT_F64 == dst->raw_type)) {
-				goto dft;
-			}
-			if (Is32Bit((char*)src->integer - (bin + code_off))) {
-				switch (src->raw_type) {
-				case RT_U0:
-					break;
-				case RT_U8i:
-					AIWNIOS_ADD_CODE(X86MovZXRegIndirI8, dst->reg, -1, -1, RIP, (char*)src->integer - (bin + code_off));
-					break;
-				case RT_I8i:
-					AIWNIOS_ADD_CODE(X86MovSXRegIndirI8, dst->reg, -1, -1, RIP, (char*)src->integer - (bin + code_off));
-					break;
-				case RT_U16i:
-					AIWNIOS_ADD_CODE(X86MovZXRegIndirI16, dst->reg, -1, -1, RIP, (char*)src->integer - (bin + code_off));
-					break;
-				case RT_I16i:
-					AIWNIOS_ADD_CODE(X86MovSXRegIndirI16, dst->reg, -1, -1, RIP, (char*)src->integer - (bin + code_off));
-					break;
-				case RT_U32i:
-					AIWNIOS_ADD_CODE(X86MovRegIndirI32, dst->reg, -1, -1, RIP, (char*)src->integer - (bin + code_off));
-					break;
-				case RT_I32i:
-					AIWNIOS_ADD_CODE(X86MovSXRegIndirI32, dst->reg, -1, -1, RIP, (char*)src->integer - (bin + code_off));
-					break;
-				case RT_U64i:
-				case RT_PTR:
-				case RT_FUNC:
-				case RT_I64i:
-					AIWNIOS_ADD_CODE(X86MovRegIndirI64, dst->reg, -1, -1, RIP, (char*)src->integer - (bin + code_off));
-					break;
-				case RT_F64:
-					AIWNIOS_ADD_CODE(X86MovRegIndirF64, dst->reg, -1, -1, RIP, (char*)src->integer - (bin + code_off));
-				}
-			} else {
-				use_reg2 = (cctrl->flags & CCF_ICMOV_NO_USE_RAX) ? AIWNIOS_TMP_IREG_POOP2 : RAX;
-				code_off = __ICMoveI64(cctrl, use_reg2, src->off, bin, code_off);
-				goto load_r2;
-			}
-			return code_off;
-		load_r2:
-			switch (src->raw_type) {
-			case RT_U0:
-				break;
-			case RT_U8i:
-				AIWNIOS_ADD_CODE(X86MovZXRegIndirI8, dst->reg, -1, -1, use_reg2, indir_off);
-				break;
-			case RT_I8i:
-				AIWNIOS_ADD_CODE(X86MovSXRegIndirI8, dst->reg, -1, -1, use_reg2, indir_off);
-				break;
-			case RT_U16i:
-				AIWNIOS_ADD_CODE(X86MovZXRegIndirI16, dst->reg, -1, -1, use_reg2, indir_off);
-				break;
-			case RT_I16i:
-				AIWNIOS_ADD_CODE(X86MovSXRegIndirI16, dst->reg, -1, -1, use_reg2, indir_off);
-				break;
-			case RT_U32i:
-				AIWNIOS_ADD_CODE(X86MovRegIndirI32, dst->reg, -1, -1, use_reg2, indir_off);
-				break;
-			case RT_I32i:
-				AIWNIOS_ADD_CODE(X86MovSXRegIndirI32, dst->reg, -1, -1, use_reg2, indir_off);
-				break;
-			case RT_U64i:
-			case RT_PTR:
-			case RT_FUNC:
-			case RT_I64i:
-				AIWNIOS_ADD_CODE(X86MovRegIndirI64, dst->reg, -1, -1, use_reg2, indir_off);
-				break;
-			case RT_F64:
-				AIWNIOS_ADD_CODE(X86MovRegIndirF64, dst->reg, -1, -1, use_reg2, indir_off);
-				break;
-			default:
-				abort();
-			}
-		} else if (src->mode == MD_INDIR_REG) {
-			use_reg2 = src->reg;
-			indir_off = src->off;
-			if (src->raw_type == RT_F64 && src->raw_type == dst->raw_type) {
-				use_reg2 = src->reg;
-			} else if ((src->raw_type == RT_F64) ^ (RT_F64 == dst->raw_type)) {
-				goto dft;
-			}
-			goto load_r2;
-		} else if (src->mode == MD_I64 && dst->raw_type != RT_F64) {
-			code_off = __ICMoveI64(cctrl, dst->reg, src->integer, bin, code_off);
-		} else if (src->mode == MD_F64 && dst->raw_type == RT_F64) {
-			code_off = __ICMoveF64(cctrl, dst->reg, src->flt, bin, code_off);
-		} else if (src->mode == MD_I64 && dst->raw_type == RT_F64) {
-			code_off = __ICMoveF64(cctrl, dst->reg, src->integer, bin, code_off);
-		} else if (src->mode == MD_F64 && dst->raw_type != RT_F64) {
-			code_off = __ICMoveI64(cctrl, dst->reg, src->flt, bin, code_off);
-		} else if (src->mode == MD_STATIC) {
-			if (dst->mode == MD_REG && (dst->raw_type == RT_F64) == (src->raw_type == RT_F64)) {
-				switch (src->raw_type) {
-				case RT_U0:
-					break;
-				case RT_U8i:
-					AIWNIOS_ADD_CODE(X86MovZXRegIndirI8, dst->reg, -1, -1, RIP, 1000);
-					break;
-				case RT_I8i:
-					AIWNIOS_ADD_CODE(X86MovSXRegIndirI8, dst->reg, -1, -1, RIP, 1000);
-					break;
-				case RT_U16i:
-					AIWNIOS_ADD_CODE(X86MovZXRegIndirI16, dst->reg, -1, -1, RIP, 1000);
-					break;
-				case RT_I16i:
-					AIWNIOS_ADD_CODE(X86MovSXRegIndirI16, dst->reg, -1, -1, RIP, 1000);
-					break;
-				case RT_U32i:
-					AIWNIOS_ADD_CODE(X86MovRegIndirI32, dst->reg, -1, -1, RIP, 1000);
-					break;
-				case RT_I32i:
-					AIWNIOS_ADD_CODE(X86MovSXRegIndirI32, dst->reg, -1, -1, RIP, 1000);
-					break;
-				case RT_U64i:
-				case RT_PTR:
-				case RT_FUNC:
-				case RT_I64i:
-					AIWNIOS_ADD_CODE(X86MovRegIndirI64, dst->reg, -1, -1, RIP, 0);
-					break;
-				case RT_F64:
-					AIWNIOS_ADD_CODE(X86MovRegIndirF64, dst->reg, -1, -1, RIP, 0);
-				}
-				if (bin)
-					CodeMiscAddRef(cctrl->statics_label, bin + code_off - 4)->offset = dst->off;
-			}
-			return code_off;
-		} else
-			goto dft;
-		break;
-	case MD_I64:
-	case MD_F64:
-		break;
-	default:
-		abort();
-	}
-	return code_off;
-}
-
-static int64_t DerefToICArg(CCmpCtrl* cctrl, CICArg* res, CRPN* rpn,
-	int64_t base_reg_fallback, char* bin,
-	int64_t code_off)
-{
-	if (rpn->res.mode == __MD_X86_64_SIB) {
-		if (rpn->res.__sib_base_rpn)
-			code_off = __OptPassFinal(cctrl, rpn->res.__sib_base_rpn, bin, code_off);
-		if (rpn->res.__sib_idx_rpn)
-			code_off = __OptPassFinal(cctrl, rpn->res.__sib_idx_rpn, bin, code_off);
-		*res = rpn->res;
-		return code_off;
-	}
-	if (rpn->type != IC_DEREF) {
-		code_off = __OptPassFinal(cctrl, rpn, bin, code_off);
-		if (rpn->res.mode == MD_FRAME) {
-			res->raw_type = rpn->raw_type;
-			res->mode = __MD_X86_64_SIB;
-			res->reg = RBP;
-			res->reg2 = -1;
-			res->off = -rpn->res.off;
-			res->__SIB_scale = -1;
-			return code_off;
-		}
-		*res = rpn->res;
-		return code_off;
-	}
-	int64_t r = rpn->raw_type, rsz, off, mul, lea = 0, reg;
-	CRPN *next = rpn->base.next, *next2, *next3, *next4, *tmp;
-	switch (r) {
-		break;
-	case RT_I8i:
-		rsz = 1;
-		break;
-	case RT_U8i:
-		rsz = 1;
-		break;
-	case RT_I16i:
-		rsz = 2;
-		break;
-	case RT_U16i:
-		rsz = 2;
-		break;
-	case RT_I32i:
-		rsz = 4;
-		break;
-	case RT_U32i:
-		rsz = 4;
-		break;
-	default:
-		rsz = 8;
-	}
-	code_off = __OptPassFinal(cctrl, next, bin, code_off);
-	code_off = PutICArgIntoReg(cctrl, &next->res, RT_PTR, base_reg_fallback, bin,
-		code_off);
-	res->mode = __MD_X86_64_SIB;
-	res->reg = next->res.reg;
-	res->reg2 = -1;
-	res->off = 0;
-	res->__SIB_scale = -1;
-	res->raw_type = r;
-	return code_off;
-}
-
-#define TYPECAST_ASSIGN_BEGIN(DST, SRC)                                                    \
-	{                                                                                      \
-		int64_t pop = 0, pop2 = 0;                                                         \
-		CICArg _orig = { 0 };                                                              \
-		CRPN* _tc = DST;                                                                   \
-		CRPN* SRC2 = SRC;                                                                  \
-		DST = DST->base.next;                                                              \
-		if (DST->type == IC_DEREF) {                                                       \
-			code_off = DerefToICArg(cctrl, &_orig, DST, 1, bin, code_off);                 \
-			DST->res = _orig;                                                              \
-			DST->raw_type = _tc->raw_type;                                                 \
-		} else if ((DST->raw_type == RT_F64) ^ (SRC2->raw_type == RT_F64)) {               \
-			pop2 = pop = 1;                                                                \
-			_orig = DST->res;                                                              \
-			code_off = PutICArgIntoReg(cctrl, &DST->res, DST->raw_type, 0, bin, code_off); \
-			code_off = PushToStack(cctrl, &DST->res, bin, code_off);                       \
-			DST->res.mode = MD_INDIR_REG;                                                  \
-			DST->res.off = 0;                                                              \
-			DST->res.reg = X86_64_STACK_REG;                                               \
-			DST->res.raw_type = _tc->raw_type;                                             \
-			DST->raw_type = _tc->raw_type;                                                 \
-		} else {                                                                           \
-			pop2 = 1;                                                                      \
-			DST->res.raw_type = _tc->raw_type;                                             \
-			DST->raw_type = _tc->raw_type;                                                 \
-		}
-#define TYPECAST_ASSIGN_END(DST)                               \
-	if (pop)                                                   \
-		code_off = PopFromStack(cctrl, &_orig, bin, code_off); \
-	}
-
-static int64_t __SexyPreOp(CCmpCtrl* cctrl, CRPN* rpn, int64_t (*i_imm)(char*, int64_t, int64_t),
-	int64_t (*ireg)(char*, int64_t, int64_t),
-	int64_t (*freg)(char*, int64_t, int64_t),
-	int64_t (*incr)(char*, int64_t),
-	int64_t (*incr_sib)(char*, int64_t, int64_t, int64_t, int64_t),
-	char* bin, int64_t code_off)
-{
-	int64_t code;
-	CRPN *next = rpn->base.next, *tc;
-	CICArg derefed = { 0 }, tmp = { 0 }, tmp2 = { 0 };
-	if (next->type == IC_TYPECAST) {
-		TYPECAST_ASSIGN_BEGIN(next, next);
-		if (next->raw_type == RT_F64) {
-			code_off = DerefToICArg(cctrl, &derefed, next, AIWNIOS_TMP_IREG_POOP2, bin, code_off);
-			tmp = derefed; //==RT_F64
-			code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, 1, bin, code_off);
-			code_off = __ICMoveF64(cctrl, 0, rpn->integer, bin, code_off);
-			AIWNIOS_ADD_CODE(freg, tmp.reg, 0);
-			code_off = ICMov(cctrl, &derefed, &tmp, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		} else if (rpn->integer != 1) {
-			code_off = DerefToICArg(cctrl, &derefed, next, 3, bin, code_off);
-			tmp = derefed;
-			code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, 2, bin, code_off);
-			AIWNIOS_ADD_CODE(i_imm, tmp.reg, rpn->integer);
-			code_off = ICMov(cctrl, &derefed, &tmp, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		} else if (ModeIsDerefToSIB(next) && RawTypeIs64(next->raw_type)) {
-			code_off = DerefToICArg(cctrl, &derefed, next, AIWNIOS_TMP_IREG_POOP2, bin, code_off);
-			AIWNIOS_ADD_CODE(incr_sib, derefed.__SIB_scale, derefed.reg2, derefed.reg, derefed.off);
-			code_off = ICMov(cctrl, &rpn->res, &derefed, bin, code_off);
-		} else {
-			CICArg orig;
-			code_off = DerefToICArg(cctrl, &next->res, next, AIWNIOS_TMP_IREG_POOP2, bin, code_off);
-			orig = next->res;
-			tmp = next->res;
-			code_off = PutICArgIntoReg(cctrl, &tmp, RT_I64i, RAX, bin, code_off);
-			AIWNIOS_ADD_CODE(incr, tmp.reg);
-			code_off = ICMov(cctrl, &orig, &tmp, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		}
-		TYPECAST_ASSIGN_END(next);
-	} else {
-		if (next->raw_type == RT_F64) {
-			code_off = DerefToICArg(cctrl, &derefed, next, AIWNIOS_TMP_IREG_POOP2, bin, code_off);
-			tmp = derefed; //==RT_F64
-			code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, 1, bin, code_off);
-			code_off = __ICMoveF64(cctrl, 0, rpn->integer, bin, code_off);
-			AIWNIOS_ADD_CODE(freg, tmp.reg, 0);
-			code_off = ICMov(cctrl, &derefed, &tmp, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		} else if (rpn->integer != 1) {
-			code_off = DerefToICArg(cctrl, &derefed, next, 3, bin, code_off);
-			tmp = derefed;
-			code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, 2, bin, code_off);
-			AIWNIOS_ADD_CODE(i_imm, tmp.reg, rpn->integer);
-			code_off = ICMov(cctrl, &derefed, &tmp, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		} else if (ModeIsDerefToSIB(next) && RawTypeIs64(next->raw_type)) {
-			code_off = DerefToICArg(cctrl, &derefed, next, AIWNIOS_TMP_IREG_POOP2, bin, code_off);
-			AIWNIOS_ADD_CODE(incr_sib, derefed.__SIB_scale, derefed.reg2, derefed.reg, derefed.off);
-			code_off = ICMov(cctrl, &rpn->res, &derefed, bin, code_off);
-		} else {
-			CICArg orig;
-			code_off = DerefToICArg(cctrl, &next->res, next, AIWNIOS_TMP_IREG_POOP2, bin, code_off);
-			orig = next->res;
-			tmp = next->res;
-			code_off = PutICArgIntoReg(cctrl, &tmp, RT_I64i, RAX, bin, code_off);
-			AIWNIOS_ADD_CODE(incr, tmp.reg);
-			code_off = ICMov(cctrl, &orig, &tmp, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		}
-	}
-	return code_off;
+int64_t ICMov(CCmpCtrl *cctrl, CICArg *dst, CICArg *src, char *bin,
+              int64_t code_off) {
+  int64_t use_reg, use_reg2, restore_from_tmp = 0, indir_off = 0,
+                             indir_off2 = 0, opc;
+  CICArg tmp = {0}, tmp2 = {0};
+  assert(src->mode > 0 || src->mode == -1);
+  assert(dst->mode > 0 || dst->mode == -1);
+  if (dst->mode == MD_NULL)
+    return code_off;
+  if ((dst->raw_type == RT_F64) == (src->raw_type == RT_F64))
+    if (dst->mode == src->mode) {
+      switch (dst->mode) {
+        break;
+      case __MD_X86_64_SIB:
+        if (dst->off == src->off && dst->__SIB_scale == src->__SIB_scale &&
+            dst->reg == src->reg && dst->reg2 == src->reg2) {
+          return code_off;
+        }
+        break;
+      case MD_STATIC:
+        if (dst->off == src->off)
+          return code_off;
+        break;
+      case MD_PTR:
+        if (dst->off == src->off)
+          return code_off;
+        break;
+      case MD_REG:
+        if (dst->reg == src->reg)
+          return code_off;
+        break;
+      case MD_FRAME:
+        if (dst->off == src->off)
+          return code_off;
+        break;
+      case MD_INDIR_REG:
+        if (dst->off == src->off && dst->reg == src->reg)
+          return code_off;
+      }
+    }
+  switch (dst->mode) {
+    break;
+  case MD_CODE_MISC_PTR:
+    if (src->mode == MD_REG &&
+        ((src->raw_type == RT_F64) == (dst->raw_type == RT_F64))) {
+      switch (dst->raw_type) {
+        break;
+      case RT_U8i:
+      case RT_I8i:
+        AIWNIOS_ADD_CODE(X86MovIndirRegI8, src->reg, -1, -1, RIP, 0);
+        break;
+      case RT_U16i:
+      case RT_I16i:
+        AIWNIOS_ADD_CODE(X86MovIndirRegI16, src->reg, -1, -1, RIP, 0);
+        break;
+      case RT_U32i:
+      case RT_I32i:
+        AIWNIOS_ADD_CODE(X86MovIndirRegI32, src->reg, -1, -1, RIP, 0);
+        break;
+      case RT_PTR:
+      case RT_U64i:
+      case RT_I64i:
+      case RT_FUNC:
+        AIWNIOS_ADD_CODE(X86MovIndirRegI64, src->reg, -1, -1, RIP, 0);
+        break;
+      case RT_F64:
+        AIWNIOS_ADD_CODE(X86MovIndirRegF64, src->reg, -1, -1, RIP, 0);
+        break;
+      default:
+        abort();
+      }
+      if (bin)
+        CodeMiscAddRef(dst->code_misc, bin + code_off - 4);
+      return code_off;
+    }
+    goto dft;
+  case __MD_X86_64_SIB:
+    if (src->mode == MD_I64 && Is32Bit(src->integer) &&
+        ((src->raw_type == RT_F64) == (dst->raw_type == RT_F64))) {
+      switch (dst->raw_type) {
+        break;
+      case RT_U8i:
+      case RT_I8i:
+        AIWNIOS_ADD_CODE(X86MovIndirI8Imm, src->integer, dst->__SIB_scale,
+                         dst->reg2, dst->reg, dst->off);
+        break;
+      case RT_U16i:
+      case RT_I16i:
+        AIWNIOS_ADD_CODE(X86MovIndirI16Imm, src->integer, dst->__SIB_scale,
+                         dst->reg2, dst->reg, dst->off);
+        break;
+      case RT_U32i:
+      case RT_I32i:
+        AIWNIOS_ADD_CODE(X86MovIndirI32Imm, src->integer, dst->__SIB_scale,
+                         dst->reg2, dst->reg, dst->off);
+        break;
+      case RT_PTR:
+      case RT_U64i:
+      case RT_I64i:
+      case RT_FUNC:
+        AIWNIOS_ADD_CODE(X86MovIndirI64Imm, src->integer, dst->__SIB_scale,
+                         dst->reg2, dst->reg, dst->off);
+        break;
+      default:
+        abort();
+      }
+      return code_off;
+    } else if (src->mode == MD_REG &&
+               ((src->raw_type == RT_F64) == (dst->raw_type == RT_F64))) {
+      switch (dst->raw_type) {
+        break;
+      case RT_U8i:
+      case RT_I8i:
+        AIWNIOS_ADD_CODE(X86MovIndirRegI8, src->reg, dst->__SIB_scale,
+                         dst->reg2, dst->reg, dst->off);
+        break;
+      case RT_U16i:
+      case RT_I16i:
+        AIWNIOS_ADD_CODE(X86MovIndirRegI16, src->reg, dst->__SIB_scale,
+                         dst->reg2, dst->reg, dst->off);
+        break;
+      case RT_U32i:
+      case RT_I32i:
+        AIWNIOS_ADD_CODE(X86MovIndirRegI32, src->reg, dst->__SIB_scale,
+                         dst->reg2, dst->reg, dst->off);
+        break;
+      case RT_PTR:
+      case RT_U64i:
+      case RT_I64i:
+      case RT_FUNC:
+        AIWNIOS_ADD_CODE(X86MovIndirRegI64, src->reg, dst->__SIB_scale,
+                         dst->reg2, dst->reg, dst->off);
+        break;
+      case RT_F64:
+        AIWNIOS_ADD_CODE(X86MovIndirRegF64, src->reg, dst->__SIB_scale,
+                         dst->reg2, dst->reg, dst->off);
+        break;
+      default:
+        abort();
+      }
+      return code_off;
+    }
+    goto dft;
+    break;
+  case MD_STATIC:
+    if (src->mode == MD_I64 && Is32Bit(src->integer) &&
+        ((src->raw_type == RT_F64) == (dst->raw_type == RT_F64))) {
+      switch (dst->raw_type) {
+        break;
+      case RT_U8i:
+      case RT_I8i:
+        AIWNIOS_ADD_CODE(X86MovIndirI8Imm, src->integer, -1, -1, RIP, 1000);
+        indir_off2 = 1;
+        break;
+      case RT_U16i:
+      case RT_I16i:
+        AIWNIOS_ADD_CODE(X86MovIndirI16Imm, src->integer, -1, -1, RIP, 1000);
+        indir_off2 = 2;
+        break;
+      case RT_U32i:
+      case RT_I32i:
+        AIWNIOS_ADD_CODE(X86MovIndirI32Imm, src->integer, -1, -1, RIP, 1000);
+        indir_off2 = 4;
+        break;
+      case RT_PTR:
+      case RT_U64i:
+      case RT_I64i:
+      case RT_FUNC:
+      case RT_F64:
+        indir_off2 = 8;
+        AIWNIOS_ADD_CODE(X86MovIndirI64Imm, src->integer, -1, -1, RIP, 1000);
+        break;
+      default:
+        abort();
+      }
+      if (bin) {
+        // Heres the deal
+        // These are encoded as CX05[offset][immediate]
+        // When we do the relocation,be sure to modify the offset and not the
+        // immeidate Also add indir_off2 to point to the end of the instriction
+        // as the relocation only points to the offset
+        CodeMiscAddRef(cctrl->statics_label, bin + code_off - 4 - indir_off2)
+            ->offset = dst->off - indir_off2;
+      }
+      return code_off;
+    } else if (src->mode == MD_REG &&
+               (dst->raw_type == RT_F64) == (src->raw_type == RT_F64)) {
+      switch (dst->raw_type) {
+        break;
+      case RT_U8i:
+      case RT_I8i:
+        AIWNIOS_ADD_CODE(X86MovIndirRegI8, src->reg, -1, -1, RIP, 1000);
+        break;
+      case RT_U16i:
+      case RT_I16i:
+        AIWNIOS_ADD_CODE(X86MovIndirRegI16, src->reg, -1, -1, RIP, 1000);
+        break;
+      case RT_U32i:
+      case RT_I32i:
+        AIWNIOS_ADD_CODE(X86MovIndirRegI32, src->reg, -1, -1, RIP, 1000);
+        break;
+      case RT_PTR:
+      case RT_U64i:
+      case RT_I64i:
+      case RT_FUNC:
+        AIWNIOS_ADD_CODE(X86MovIndirRegI64, src->reg, -1, -1, RIP, 1000);
+        break;
+      case RT_F64:
+        AIWNIOS_ADD_CODE(X86MovIndirRegF64, src->reg, -1, -1, RIP, 1000);
+        break;
+      default:
+        abort();
+      }
+      if (bin)
+        CodeMiscAddRef(cctrl->statics_label, bin + code_off - 4)->offset =
+            dst->off;
+      return code_off;
+    }
+    goto dft;
+    break;
+  case MD_INDIR_REG:
+    use_reg2 = dst->reg;
+    indir_off = dst->off;
+  indir_r2:
+    if (src->raw_type == dst->raw_type && src->raw_type == RT_F64 &&
+        src->mode == MD_REG) {
+      use_reg = src->reg;
+    } else if ((src->raw_type == RT_F64) ^
+               (RT_F64 == dst->raw_type)) { // Do they differ
+      goto dft;
+    } else if (src->mode == MD_FRAME || src->mode == MD_PTR ||
+               src->mode == MD_INDIR_REG) {
+      goto dft;
+    } else if (src->mode == MD_REG)
+      use_reg = src->reg;
+    else if (src->mode == MD_I64 && Is32Bit(src->integer) &&
+             ((src->raw_type == RT_F64) == (dst->raw_type == RT_F64))) {
+      switch (dst->raw_type) {
+        break;
+      case RT_U8i:
+      case RT_I8i:
+        AIWNIOS_ADD_CODE(X86MovIndirI8Imm, src->integer, -1, -1, use_reg2,
+                         indir_off);
+        break;
+      case RT_U16i:
+      case RT_I16i:
+        AIWNIOS_ADD_CODE(X86MovIndirI16Imm, src->integer, -1, -1, use_reg2,
+                         indir_off);
+        break;
+      case RT_U32i:
+      case RT_I32i:
+        AIWNIOS_ADD_CODE(X86MovIndirI32Imm, src->integer, -1, -1, use_reg2,
+                         indir_off);
+        break;
+      case RT_PTR:
+      case RT_U64i:
+      case RT_I64i:
+      case RT_FUNC:
+        AIWNIOS_ADD_CODE(X86MovIndirI64Imm, src->integer, -1, -1, use_reg2,
+                         indir_off);
+        break;
+      default:
+        abort();
+      }
+      return code_off;
+    } else {
+    dft:
+      tmp.raw_type = src->raw_type;
+      if (dst->raw_type != RT_F64)
+        use_reg = tmp.reg = AIWNIOS_TMP_IREG_POOP;
+      else
+        use_reg = tmp.reg = 0;
+      if (dst->mode == MD_REG)
+        use_reg = tmp.reg = dst->reg;
+      tmp.mode = MD_REG;
+      if (dst->raw_type == RT_F64 && src->raw_type != dst->raw_type) {
+        tmp.raw_type = RT_F64;
+        if (src->mode == MD_REG) {
+          AIWNIOS_ADD_CODE(X86CVTTSI2SDRegReg, use_reg, src->reg);
+        } else if (src->mode == MD_INDIR_REG && RawTypeIs64(src->raw_type)) {
+          AIWNIOS_ADD_CODE(X86CVTTSI2SDRegSIB64, use_reg, -1, -1, src->reg,
+                           src->off);
+        } else if (src->mode == MD_FRAME && RawTypeIs64(src->raw_type)) {
+          AIWNIOS_ADD_CODE(X86CVTTSI2SDRegSIB64, use_reg, -1, -1, RBP,
+                           -src->off);
+        } /*else if(src->mode==__MD_X86_64_SIB) {
+          AIWNIOS_ADD_CODE(X86CVTTSI2SDRegSIB64, use_reg, src->__SIB_scale,
+        src->reg2, src->reg, src->off);
+        } */
+        else {
+          tmp2 = tmp;
+          tmp2.mode = MD_REG;
+          tmp2.reg = 0;
+          tmp2.raw_type = src->raw_type;
+          code_off = ICMov(cctrl, &tmp2, src, bin, code_off);
+          code_off = ICMov(cctrl, &tmp, &tmp2, bin, code_off);
+        }
+      } else if (src->raw_type == RT_F64 && src->raw_type != dst->raw_type) {
+        tmp.raw_type = RT_I64i;
+        if (src->mode == MD_REG) {
+          AIWNIOS_ADD_CODE(X86CVTTSD2SIRegReg, use_reg, src->reg);
+        } else if (src->mode == MD_INDIR_REG && RawTypeIs64(src->raw_type)) {
+          AIWNIOS_ADD_CODE(X86CVTTSD2SIRegSIB64, use_reg, -1, -1, src->reg,
+                           src->off);
+        } else if (src->mode == MD_FRAME && RawTypeIs64(src->raw_type)) {
+          AIWNIOS_ADD_CODE(X86CVTTSD2SIRegSIB64, use_reg, -1, -1, RBP,
+                           -src->off);
+        } /*else if(src->mode==__MD_X86_64_SIB) {
+          AIWNIOS_ADD_CODE(X86CVTTSD2SIRegSIB64, use_reg, src->__SIB_scale,
+        src->reg2, src->reg, src->off);
+        } */
+        else {
+          tmp2 = tmp;
+          tmp2.mode = MD_REG;
+          tmp2.reg = 0;
+          tmp2.raw_type = src->raw_type;
+          code_off = ICMov(cctrl, &tmp2, src, bin, code_off);
+          code_off = ICMov(cctrl, &tmp, &tmp2, bin, code_off);
+        }
+      } else
+        code_off = ICMov(cctrl, &tmp, src, bin, code_off);
+      code_off = ICMov(cctrl, dst, &tmp, bin, code_off);
+      return code_off;
+    }
+    goto store_r2;
+    break;
+  case MD_PTR:
+    if (src->mode != MD_REG ||
+        ((src->raw_type == RT_F64) != (dst->raw_type == RT_F64)))
+      goto dft;
+    use_reg = src->reg;
+    if (Is32Bit((char *)dst->off - (bin + code_off))) {
+      indir_off = (char *)dst->off - (bin + code_off);
+      use_reg2 = RIP;
+      goto store_r2;
+    }
+    use_reg2 =
+        (cctrl->flags & CCF_ICMOV_NO_USE_RAX) ? AIWNIOS_TMP_IREG_POOP2 : RAX;
+    code_off = __ICMoveI64(cctrl, use_reg2, dst->off, bin, code_off);
+    indir_off = 0;
+    goto store_r2;
+  store_r2:
+    switch (dst->raw_type) {
+    case RT_U0:
+      break;
+    case RT_F64:
+      AIWNIOS_ADD_CODE(X86MovIndirRegF64, use_reg, -1, -1, use_reg2, indir_off);
+      break;
+    case RT_U8i:
+    case RT_I8i:
+      AIWNIOS_ADD_CODE(X86MovIndirRegI8, use_reg, -1, -1, use_reg2, indir_off);
+      break;
+    case RT_U16i:
+    case RT_I16i:
+      AIWNIOS_ADD_CODE(X86MovIndirRegI16, use_reg, -1, -1, use_reg2, indir_off);
+      break;
+    case RT_U32i:
+    case RT_I32i:
+      AIWNIOS_ADD_CODE(X86MovIndirRegI32, use_reg, -1, -1, use_reg2, indir_off);
+      break;
+    case RT_U64i:
+    case RT_I64i:
+    case RT_FUNC: // func ptr
+    case RT_PTR:
+      AIWNIOS_ADD_CODE(X86MovIndirRegI64, use_reg, -1, -1, use_reg2, indir_off);
+      break;
+    default:
+      abort();
+    }
+    break;
+  case MD_FRAME:
+    use_reg2 = X86_64_BASE_REG;
+    indir_off = -dst->off;
+    goto indir_r2;
+    break;
+  case MD_REG:
+    use_reg = dst->reg;
+    if (src->mode == MD_FRAME) {
+      if (src->raw_type == RT_F64 && src->raw_type == dst->raw_type) {
+        use_reg2 = X86_64_BASE_REG;
+        indir_off = -src->off;
+        goto load_r2;
+      } else if ((src->raw_type == RT_F64) ^ (RT_F64 == dst->raw_type)) {
+        goto dft;
+      }
+      use_reg2 = X86_64_BASE_REG;
+      indir_off = -src->off;
+      goto load_r2;
+    } else if (src->mode == __MD_X86_64_SIB) {
+      if ((src->raw_type == RT_F64) != (dst->raw_type == RT_F64))
+        goto dft;
+      switch (src->raw_type) {
+      case RT_U0:
+        break;
+      case RT_U8i:
+        AIWNIOS_ADD_CODE(X86MovZXRegIndirI8, dst->reg, src->__SIB_scale,
+                         src->reg2, src->reg, src->off);
+        break;
+      case RT_I8i:
+        AIWNIOS_ADD_CODE(X86MovSXRegIndirI8, dst->reg, src->__SIB_scale,
+                         src->reg2, src->reg, src->off);
+        break;
+      case RT_U16i:
+        AIWNIOS_ADD_CODE(X86MovZXRegIndirI16, dst->reg, src->__SIB_scale,
+                         src->reg2, src->reg, src->off);
+        break;
+      case RT_I16i:
+        AIWNIOS_ADD_CODE(X86MovSXRegIndirI16, dst->reg, src->__SIB_scale,
+                         src->reg2, src->reg, src->off);
+        break;
+      case RT_U32i:
+        AIWNIOS_ADD_CODE(X86MovRegIndirI32, dst->reg, src->__SIB_scale,
+                         src->reg2, src->reg, src->off);
+        break;
+      case RT_I32i:
+        AIWNIOS_ADD_CODE(X86MovSXRegIndirI32, dst->reg, src->__SIB_scale,
+                         src->reg2, src->reg, src->off);
+        break;
+      case RT_U64i:
+      case RT_PTR:
+      case RT_FUNC:
+      case RT_I64i:
+        AIWNIOS_ADD_CODE(X86MovRegIndirI64, dst->reg, src->__SIB_scale,
+                         src->reg2, src->reg, src->off);
+        break;
+      case RT_F64:
+        AIWNIOS_ADD_CODE(X86MovRegIndirF64, dst->reg, src->__SIB_scale,
+                         src->reg2, src->reg, src->off);
+      }
+      return code_off;
+    } else if (src->mode == MD_CODE_MISC_PTR) {
+      if ((src->raw_type == RT_F64) != (dst->raw_type == RT_F64))
+        goto dft;
+      switch (src->raw_type) {
+      case RT_U0:
+        break;
+      case RT_U8i:
+        AIWNIOS_ADD_CODE(X86MovZXRegIndirI8, dst->reg, -1, -1, RIP, 0);
+        break;
+      case RT_I8i:
+        AIWNIOS_ADD_CODE(X86MovSXRegIndirI8, dst->reg, -1, -1, RIP, 0);
+        break;
+      case RT_U16i:
+        AIWNIOS_ADD_CODE(X86MovZXRegIndirI16, dst->reg, -1, -1, RIP, 0);
+        break;
+      case RT_I16i:
+        AIWNIOS_ADD_CODE(X86MovSXRegIndirI16, dst->reg, -1, -1, RIP, 0);
+        break;
+      case RT_U32i:
+        AIWNIOS_ADD_CODE(X86MovRegIndirI32, dst->reg, -1, -1, RIP, 0);
+        break;
+      case RT_I32i:
+        AIWNIOS_ADD_CODE(X86MovSXRegIndirI32, dst->reg, -1, -1, RIP, 0);
+        break;
+      case RT_U64i:
+      case RT_PTR:
+      case RT_FUNC:
+      case RT_I64i:
+        AIWNIOS_ADD_CODE(X86MovRegIndirI64, dst->reg, -1, -1, RIP, 0);
+        break;
+      case RT_F64:
+        AIWNIOS_ADD_CODE(X86MovRegIndirF64, dst->reg, -1, -1, RIP, 0);
+      }
+      if (bin)
+        CodeMiscAddRef(src->code_misc, bin + code_off - 4);
+      return code_off;
+    } else if (src->mode == MD_REG) {
+      if (src->raw_type == RT_F64 && src->raw_type == dst->raw_type) {
+        AIWNIOS_ADD_CODE(X86MovRegRegF64, dst->reg, src->reg);
+      } else if (src->raw_type != RT_F64 && dst->raw_type != RT_F64) {
+        AIWNIOS_ADD_CODE(X86MovRegReg, dst->reg, src->reg);
+      } else if (src->raw_type == RT_F64 && dst->raw_type != RT_F64) {
+        goto dft;
+      } else if (src->raw_type != RT_F64 && dst->raw_type == RT_F64) {
+        goto dft;
+      }
+    } else if (src->mode == MD_PTR) {
+      if (src->raw_type == RT_F64 && src->raw_type == dst->raw_type) {
+        use_reg2 = (cctrl->flags & CCF_ICMOV_NO_USE_RAX)
+                       ? AIWNIOS_TMP_IREG_POOP2
+                       : RAX;
+        code_off = __ICMoveI64(cctrl, use_reg2, src->off, bin, code_off);
+        goto load_r2;
+      } else if ((src->raw_type == RT_F64) ^ (RT_F64 == dst->raw_type)) {
+        goto dft;
+      }
+      if (Is32Bit((char *)src->integer - (bin + code_off))) {
+        switch (src->raw_type) {
+        case RT_U0:
+          break;
+        case RT_U8i:
+          AIWNIOS_ADD_CODE(X86MovZXRegIndirI8, dst->reg, -1, -1, RIP,
+                           (char *)src->integer - (bin + code_off));
+          break;
+        case RT_I8i:
+          AIWNIOS_ADD_CODE(X86MovSXRegIndirI8, dst->reg, -1, -1, RIP,
+                           (char *)src->integer - (bin + code_off));
+          break;
+        case RT_U16i:
+          AIWNIOS_ADD_CODE(X86MovZXRegIndirI16, dst->reg, -1, -1, RIP,
+                           (char *)src->integer - (bin + code_off));
+          break;
+        case RT_I16i:
+          AIWNIOS_ADD_CODE(X86MovSXRegIndirI16, dst->reg, -1, -1, RIP,
+                           (char *)src->integer - (bin + code_off));
+          break;
+        case RT_U32i:
+          AIWNIOS_ADD_CODE(X86MovRegIndirI32, dst->reg, -1, -1, RIP,
+                           (char *)src->integer - (bin + code_off));
+          break;
+        case RT_I32i:
+          AIWNIOS_ADD_CODE(X86MovSXRegIndirI32, dst->reg, -1, -1, RIP,
+                           (char *)src->integer - (bin + code_off));
+          break;
+        case RT_U64i:
+        case RT_PTR:
+        case RT_FUNC:
+        case RT_I64i:
+          AIWNIOS_ADD_CODE(X86MovRegIndirI64, dst->reg, -1, -1, RIP,
+                           (char *)src->integer - (bin + code_off));
+          break;
+        case RT_F64:
+          AIWNIOS_ADD_CODE(X86MovRegIndirF64, dst->reg, -1, -1, RIP,
+                           (char *)src->integer - (bin + code_off));
+        }
+      } else {
+        use_reg2 = (cctrl->flags & CCF_ICMOV_NO_USE_RAX)
+                       ? AIWNIOS_TMP_IREG_POOP2
+                       : RAX;
+        code_off = __ICMoveI64(cctrl, use_reg2, src->off, bin, code_off);
+        goto load_r2;
+      }
+      return code_off;
+    load_r2:
+      switch (src->raw_type) {
+      case RT_U0:
+        break;
+      case RT_U8i:
+        AIWNIOS_ADD_CODE(X86MovZXRegIndirI8, dst->reg, -1, -1, use_reg2,
+                         indir_off);
+        break;
+      case RT_I8i:
+        AIWNIOS_ADD_CODE(X86MovSXRegIndirI8, dst->reg, -1, -1, use_reg2,
+                         indir_off);
+        break;
+      case RT_U16i:
+        AIWNIOS_ADD_CODE(X86MovZXRegIndirI16, dst->reg, -1, -1, use_reg2,
+                         indir_off);
+        break;
+      case RT_I16i:
+        AIWNIOS_ADD_CODE(X86MovSXRegIndirI16, dst->reg, -1, -1, use_reg2,
+                         indir_off);
+        break;
+      case RT_U32i:
+        AIWNIOS_ADD_CODE(X86MovRegIndirI32, dst->reg, -1, -1, use_reg2,
+                         indir_off);
+        break;
+      case RT_I32i:
+        AIWNIOS_ADD_CODE(X86MovSXRegIndirI32, dst->reg, -1, -1, use_reg2,
+                         indir_off);
+        break;
+      case RT_U64i:
+      case RT_PTR:
+      case RT_FUNC:
+      case RT_I64i:
+        AIWNIOS_ADD_CODE(X86MovRegIndirI64, dst->reg, -1, -1, use_reg2,
+                         indir_off);
+        break;
+      case RT_F64:
+        AIWNIOS_ADD_CODE(X86MovRegIndirF64, dst->reg, -1, -1, use_reg2,
+                         indir_off);
+        break;
+      default:
+        abort();
+      }
+    } else if (src->mode == MD_INDIR_REG) {
+      use_reg2 = src->reg;
+      indir_off = src->off;
+      if (src->raw_type == RT_F64 && src->raw_type == dst->raw_type) {
+        use_reg2 = src->reg;
+      } else if ((src->raw_type == RT_F64) ^ (RT_F64 == dst->raw_type)) {
+        goto dft;
+      }
+      goto load_r2;
+    } else if (src->mode == MD_I64 && dst->raw_type != RT_F64) {
+      code_off = __ICMoveI64(cctrl, dst->reg, src->integer, bin, code_off);
+    } else if (src->mode == MD_F64 && dst->raw_type == RT_F64) {
+      code_off = __ICMoveF64(cctrl, dst->reg, src->flt, bin, code_off);
+    } else if (src->mode == MD_I64 && dst->raw_type == RT_F64) {
+      code_off = __ICMoveF64(cctrl, dst->reg, src->integer, bin, code_off);
+    } else if (src->mode == MD_F64 && dst->raw_type != RT_F64) {
+      code_off = __ICMoveI64(cctrl, dst->reg, src->flt, bin, code_off);
+    } else if (src->mode == MD_STATIC) {
+      if (dst->mode == MD_REG &&
+          (dst->raw_type == RT_F64) == (src->raw_type == RT_F64)) {
+        switch (src->raw_type) {
+        case RT_U0:
+          break;
+        case RT_U8i:
+          AIWNIOS_ADD_CODE(X86MovZXRegIndirI8, dst->reg, -1, -1, RIP, 1000);
+          break;
+        case RT_I8i:
+          AIWNIOS_ADD_CODE(X86MovSXRegIndirI8, dst->reg, -1, -1, RIP, 1000);
+          break;
+        case RT_U16i:
+          AIWNIOS_ADD_CODE(X86MovZXRegIndirI16, dst->reg, -1, -1, RIP, 1000);
+          break;
+        case RT_I16i:
+          AIWNIOS_ADD_CODE(X86MovSXRegIndirI16, dst->reg, -1, -1, RIP, 1000);
+          break;
+        case RT_U32i:
+          AIWNIOS_ADD_CODE(X86MovRegIndirI32, dst->reg, -1, -1, RIP, 1000);
+          break;
+        case RT_I32i:
+          AIWNIOS_ADD_CODE(X86MovSXRegIndirI32, dst->reg, -1, -1, RIP, 1000);
+          break;
+        case RT_U64i:
+        case RT_PTR:
+        case RT_FUNC:
+        case RT_I64i:
+          AIWNIOS_ADD_CODE(X86MovRegIndirI64, dst->reg, -1, -1, RIP, 0);
+          break;
+        case RT_F64:
+          AIWNIOS_ADD_CODE(X86MovRegIndirF64, dst->reg, -1, -1, RIP, 0);
+        }
+        if (bin)
+          CodeMiscAddRef(cctrl->statics_label, bin + code_off - 4)->offset =
+              dst->off;
+      }
+      return code_off;
+    } else
+      goto dft;
+    break;
+  case MD_I64:
+  case MD_F64:
+    break;
+  default:
+    abort();
+  }
+  return code_off;
 }
 
-static int64_t __SexyAssignOp(CCmpCtrl* cctrl, CRPN* rpn,
-	char* bin, int64_t code_off)
-{
-	CRPN *next = ICArgN(rpn, 1), *next2 = ICArgN(rpn, 0);
-	CICArg old = rpn->res, dummy, old2 = { 0 };
+static int64_t DerefToICArg(CCmpCtrl *cctrl, CICArg *res, CRPN *rpn,
+                            int64_t base_reg_fallback, char *bin,
+                            int64_t code_off) {
+  if (rpn->res.mode == __MD_X86_64_SIB) {
+    if (rpn->res.__sib_base_rpn)
+      code_off = __OptPassFinal(cctrl, rpn->res.__sib_base_rpn, bin, code_off);
+    if (rpn->res.__sib_idx_rpn)
+      code_off = __OptPassFinal(cctrl, rpn->res.__sib_idx_rpn, bin, code_off);
+    *res = rpn->res;
+    return code_off;
+  }
+  if (rpn->type != IC_DEREF) {
+    code_off = __OptPassFinal(cctrl, rpn, bin, code_off);
+    if (rpn->res.mode == MD_FRAME) {
+      res->raw_type = rpn->raw_type;
+      res->mode = __MD_X86_64_SIB;
+      res->reg = RBP;
+      res->reg2 = -1;
+      res->off = -rpn->res.off;
+      res->__SIB_scale = -1;
+      return code_off;
+    }
+    *res = rpn->res;
+    return code_off;
+  }
+  int64_t r = rpn->raw_type, rsz, off, mul, lea = 0, reg;
+  CRPN *next = rpn->base.next, *next2, *next3, *next4, *tmp;
+  switch (r) {
+    break;
+  case RT_I8i:
+    rsz = 1;
+    break;
+  case RT_U8i:
+    rsz = 1;
+    break;
+  case RT_I16i:
+    rsz = 2;
+    break;
+  case RT_U16i:
+    rsz = 2;
+    break;
+  case RT_I32i:
+    rsz = 4;
+    break;
+  case RT_U32i:
+    rsz = 4;
+    break;
+  default:
+    rsz = 8;
+  }
+  code_off = __OptPassFinal(cctrl, next, bin, code_off);
+  code_off = PutICArgIntoReg(cctrl, &next->res, RT_PTR, base_reg_fallback, bin,
+                             code_off);
+  res->mode = __MD_X86_64_SIB;
+  res->reg = next->res.reg;
+  res->reg2 = -1;
+  res->off = 0;
+  res->__SIB_scale = -1;
+  res->raw_type = r;
+  return code_off;
+}
+
+#define TYPECAST_ASSIGN_BEGIN(DST, SRC)                                        \
+  {                                                                            \
+    int64_t pop = 0, pop2 = 0;                                                 \
+    CICArg _orig = {0};                                                        \
+    CRPN *_tc = DST;                                                           \
+    CRPN *SRC2 = SRC;                                                          \
+    DST = DST->base.next;                                                      \
+    if (DST->type == IC_DEREF) {                                               \
+      code_off = DerefToICArg(cctrl, &_orig, DST, 1, bin, code_off);           \
+      DST->res = _orig;                                                        \
+      DST->raw_type = _tc->raw_type;                                           \
+    } else if ((DST->raw_type == RT_F64) ^ (SRC2->raw_type == RT_F64)) {       \
+      pop2 = pop = 1;                                                          \
+      _orig = DST->res;                                                        \
+      code_off =                                                               \
+          PutICArgIntoReg(cctrl, &DST->res, DST->raw_type, 0, bin, code_off);  \
+      code_off = PushToStack(cctrl, &DST->res, bin, code_off);                 \
+      DST->res.mode = MD_INDIR_REG;                                            \
+      DST->res.off = 0;                                                        \
+      DST->res.reg = X86_64_STACK_REG;                                         \
+      DST->res.raw_type = _tc->raw_type;                                       \
+      DST->raw_type = _tc->raw_type;                                           \
+    } else {                                                                   \
+      pop2 = 1;                                                                \
+      DST->res.raw_type = _tc->raw_type;                                       \
+      DST->raw_type = _tc->raw_type;                                           \
+    }
+#define TYPECAST_ASSIGN_END(DST)                                               \
+  if (pop)                                                                     \
+    code_off = PopFromStack(cctrl, &_orig, bin, code_off);                     \
+  }
+
+static int64_t __SexyPreOp(
+    CCmpCtrl *cctrl, CRPN *rpn, int64_t (*i_imm)(char *, int64_t, int64_t),
+    int64_t (*ireg)(char *, int64_t, int64_t),
+    int64_t (*freg)(char *, int64_t, int64_t), int64_t (*incr)(char *, int64_t),
+    int64_t (*incr_sib)(char *, int64_t, int64_t, int64_t, int64_t), char *bin,
+    int64_t code_off) {
+  int64_t code;
+  CRPN *next = rpn->base.next, *tc;
+  CICArg derefed = {0}, tmp = {0}, tmp2 = {0};
+  if (next->type == IC_TYPECAST) {
+    TYPECAST_ASSIGN_BEGIN(next, next);
+    if (next->raw_type == RT_F64) {
+      code_off = DerefToICArg(cctrl, &derefed, next, AIWNIOS_TMP_IREG_POOP2,
+                              bin, code_off);
+      tmp = derefed; //==RT_F64
+      code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, 1, bin, code_off);
+      code_off = __ICMoveF64(cctrl, 0, rpn->integer, bin, code_off);
+      AIWNIOS_ADD_CODE(freg, tmp.reg, 0);
+      code_off = ICMov(cctrl, &derefed, &tmp, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    } else if (rpn->integer != 1) {
+      code_off = DerefToICArg(cctrl, &derefed, next, 3, bin, code_off);
+      tmp = derefed;
+      code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, 2, bin, code_off);
+      AIWNIOS_ADD_CODE(i_imm, tmp.reg, rpn->integer);
+      code_off = ICMov(cctrl, &derefed, &tmp, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    } else if (ModeIsDerefToSIB(next) && RawTypeIs64(next->raw_type)) {
+      code_off = DerefToICArg(cctrl, &derefed, next, AIWNIOS_TMP_IREG_POOP2,
+                              bin, code_off);
+      AIWNIOS_ADD_CODE(incr_sib, derefed.__SIB_scale, derefed.reg2, derefed.reg,
+                       derefed.off);
+      code_off = ICMov(cctrl, &rpn->res, &derefed, bin, code_off);
+    } else {
+      CICArg orig;
+      code_off = DerefToICArg(cctrl, &next->res, next, AIWNIOS_TMP_IREG_POOP2,
+                              bin, code_off);
+      orig = next->res;
+      tmp = next->res;
+      code_off = PutICArgIntoReg(cctrl, &tmp, RT_I64i, RAX, bin, code_off);
+      AIWNIOS_ADD_CODE(incr, tmp.reg);
+      code_off = ICMov(cctrl, &orig, &tmp, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    }
+    TYPECAST_ASSIGN_END(next);
+  } else {
+    if (next->raw_type == RT_F64) {
+      code_off = DerefToICArg(cctrl, &derefed, next, AIWNIOS_TMP_IREG_POOP2,
+                              bin, code_off);
+      tmp = derefed; //==RT_F64
+      code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, 1, bin, code_off);
+      code_off = __ICMoveF64(cctrl, 0, rpn->integer, bin, code_off);
+      AIWNIOS_ADD_CODE(freg, tmp.reg, 0);
+      code_off = ICMov(cctrl, &derefed, &tmp, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    } else if (rpn->integer != 1) {
+      code_off = DerefToICArg(cctrl, &derefed, next, 3, bin, code_off);
+      tmp = derefed;
+      code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, 2, bin, code_off);
+      AIWNIOS_ADD_CODE(i_imm, tmp.reg, rpn->integer);
+      code_off = ICMov(cctrl, &derefed, &tmp, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    } else if (ModeIsDerefToSIB(next) && RawTypeIs64(next->raw_type)) {
+      code_off = DerefToICArg(cctrl, &derefed, next, AIWNIOS_TMP_IREG_POOP2,
+                              bin, code_off);
+      AIWNIOS_ADD_CODE(incr_sib, derefed.__SIB_scale, derefed.reg2, derefed.reg,
+                       derefed.off);
+      code_off = ICMov(cctrl, &rpn->res, &derefed, bin, code_off);
+    } else {
+      CICArg orig;
+      code_off = DerefToICArg(cctrl, &next->res, next, AIWNIOS_TMP_IREG_POOP2,
+                              bin, code_off);
+      orig = next->res;
+      tmp = next->res;
+      code_off = PutICArgIntoReg(cctrl, &tmp, RT_I64i, RAX, bin, code_off);
+      AIWNIOS_ADD_CODE(incr, tmp.reg);
+      code_off = ICMov(cctrl, &orig, &tmp, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    }
+  }
+  return code_off;
+}
+
+static int64_t __SexyAssignOp(CCmpCtrl *cctrl, CRPN *rpn, char *bin,
+                              int64_t code_off) {
+  CRPN *next = ICArgN(rpn, 1), *next2 = ICArgN(rpn, 0);
+  CICArg old = rpn->res, dummy, old2 = {0};
 enter:;
-	int64_t old_type = rpn->type, od = cctrl->backend_user_data2, next_old = next->type, decr = 0,
-			old_next2 = next2->type, pop = 0, use_tc = 0, use_raw_type = rpn->raw_type, use_f64 = 0,
-			old_raw_type = rpn->raw_type, old_flags = next->flags, old_flags2 = next2->flags,set_flags=0;
-	if (next->type == IC_TYPECAST) {
-		use_raw_type = next->raw_type;
-		next = ICArgN(next, 0);
-		use_tc = 1;
-		goto enter;
-	}
-	switch (rpn->type) {
-		break;
-	case IC_ADD_EQ:
+  int64_t old_type = rpn->type, od = cctrl->backend_user_data2,
+          next_old = next->type, decr = 0, old_next2 = next2->type, pop = 0,
+          use_tc = 0, use_raw_type = rpn->raw_type, use_f64 = 0,
+          old_raw_type = rpn->raw_type, old_flags = next->flags,
+          old_flags2 = next2->flags, set_flags = 0;
+  if (next->type == IC_TYPECAST) {
+    use_raw_type = next->raw_type;
+    next = ICArgN(next, 0);
+    use_tc = 1;
+    goto enter;
+  }
+  switch (rpn->type) {
+    break;
+  case IC_ADD_EQ:
 // PushTmp will set next->res
-#define XXX_EQ_OP(op)                                                                                                                             \
-	rpn->type = op;                                                                                                                               \
-	use_f64 = next2->raw_type == RT_F64 || next->raw_type == RT_F64;                                                                              \
-	switch (next->type) {                                                                                                                         \
-	case IC_IREG:                                                                                                                                 \
-	case IC_FREG:                                                                                                                                 \
-	case IC_BASE_PTR:                                                                                                                             \
-		rpn->res = next->res;                                                                                                                     \
-		if (use_f64)                                                                                                                              \
-			rpn->raw_type = RT_F64;                                                                                                               \
-		code_off = __OptPassFinal(cctrl, rpn, bin, code_off);                                                                                     \
-		set_flags=rpn->res.set_flags; \
-		rpn->raw_type = old_raw_type;                                                                                                             \
-		code_off = ICMov(cctrl, &old, &rpn->res, bin, code_off);                                                                                  \
-		break;                                                                                                                                    \
-	case IC_DEREF:                                                                                                                                \
-		code_off = __OptPassFinal(cctrl, next->base.next, bin, code_off);                                                                         \
-		code_off = __OptPassFinal(cctrl, next2, bin, code_off);                                                                                   \
-		dummy = ((CRPN*)next->base.next)->res;                                                                                                    \
-		old2 = dummy;                                                                                                                             \
-		code_off = PutICArgIntoReg(cctrl, &next2->res, next2->res.raw_type,                                                                       \
-			use_f64 ? AIWNIOS_TMP_IREG_POOP2 : 1, bin, code_off);                                                                                 \
-		code_off = PutICArgIntoReg(cctrl, &dummy, RT_U64i, AIWNIOS_TMP_IREG_POOP, bin, code_off);                                                 \
-		next->res.reg = dummy.reg;                                                                                                                \
-		next->res.mode = MD_INDIR_REG;                                                                                                            \
-		next->res.off = 0;                                                                                                                        \
-		code_off = PutICArgIntoReg(cctrl, &next->res, use_f64 ? RT_F64 : next->res.raw_type, use_f64 ? 0 : AIWNIOS_TMP_IREG_POOP, bin, code_off); \
-		next->flags = ICF_PRECOMPUTED;                                                                                                            \
-		next2->flags = ICF_PRECOMPUTED;                                                                                                           \
-		rpn->res.mode = MD_REG;                                                                                                                   \
-		rpn->res.reg = use_f64 ? 1 : RAX;                                                                                                         \
-		if (use_f64)                                                                                                                              \
-			rpn->raw_type = RT_F64;                                                                                                               \
-		rpn->res.raw_type = rpn->raw_type;                                                                                                        \
-		code_off = __OptPassFinal(cctrl, rpn, bin, code_off);                                                                                     \
-		set_flags=rpn->res.set_flags; \
-		rpn->raw_type = old_raw_type;                                                                                                             \
-		next->flags &= ~ICF_PRECOMPUTED;                                                                                                          \
-		next2->flags &= ~ICF_PRECOMPUTED;                                                                                                         \
-		code_off = PutICArgIntoReg(cctrl, &old2, RT_PTR, RDX, bin, code_off);                                                                     \
-		if (!use_tc)                                                                                                                              \
-			old2.raw_type = next->raw_type;                                                                                                       \
-		else                                                                                                                                      \
-			old2.raw_type = use_raw_type;                                                                                                         \
-		old2.mode = MD_INDIR_REG;                                                                                                                 \
-		old2.off = 0;                                                                                                                             \
-		code_off = ICMov(cctrl, &old2, &rpn->res, bin, code_off);                                                                                 \
-		code_off = ICMov(cctrl, &old, &rpn->res, bin, code_off);                                                                                  \
-		next->flags = old_flags, next2->flags = old_flags2;                                                                                       \
-		break;                                                                                                                                    \
-	default:                                                                                                                                      \
-		rpn->res = next->res;                                                                                                                     \
-		if (use_f64)                                                                                                                              \
-			rpn->raw_type = RT_F64;                                                                                                               \
-		code_off = __OptPassFinal(cctrl, rpn, bin, code_off);                                                                                     \
-		set_flags=rpn->res.set_flags; \
-		rpn->raw_type = old_raw_type;                                                                                                             \
-		code_off = ICMov(cctrl, &next->res, &rpn->res, bin, code_off);                                                                            \
-	}                                                                                                                                             \
-	rpn->type = old_type, rpn->res = old;                                                                                                         \
-	next->type = next_old;                                                                                                                        \
-	next2->type = old_next2;
-		XXX_EQ_OP(IC_ADD);
-		break;
-	case IC_SUB_EQ:
-		XXX_EQ_OP(IC_SUB);
-		break;
-	case IC_MUL_EQ:
-		XXX_EQ_OP(IC_MUL);
-		break;
-	case IC_DIV_EQ:
-		XXX_EQ_OP(IC_DIV);
-		break;
-	case IC_LSH_EQ:
-		XXX_EQ_OP(IC_LSH);
-		break;
-	case IC_RSH_EQ:
-		XXX_EQ_OP(IC_RSH);
-		break;
-	case IC_AND_EQ:
-		XXX_EQ_OP(IC_AND);
-		break;
-	case IC_OR_EQ:
-		XXX_EQ_OP(IC_OR);
-		break;
-	case IC_XOR_EQ:
-		XXX_EQ_OP(IC_XOR);
-		break;
-	case IC_MOD_EQ:
-		XXX_EQ_OP(IC_MOD);
-	}
-	if(set_flags) rpn->res.set_flags=1;
-	return code_off;
+#define XXX_EQ_OP(op)                                                          \
+  rpn->type = op;                                                              \
+  use_f64 = next2->raw_type == RT_F64 || next->raw_type == RT_F64;             \
+  switch (next->type) {                                                        \
+  case IC_IREG:                                                                \
+  case IC_FREG:                                                                \
+  case IC_BASE_PTR:                                                            \
+    rpn->res = next->res;                                                      \
+    if (use_f64)                                                               \
+      rpn->raw_type = RT_F64;                                                  \
+    code_off = __OptPassFinal(cctrl, rpn, bin, code_off);                      \
+    set_flags = rpn->res.set_flags;                                            \
+    rpn->raw_type = old_raw_type;                                              \
+    code_off = ICMov(cctrl, &old, &rpn->res, bin, code_off);                   \
+    break;                                                                     \
+  case IC_DEREF:                                                               \
+    code_off = __OptPassFinal(cctrl, next->base.next, bin, code_off);          \
+    code_off = __OptPassFinal(cctrl, next2, bin, code_off);                    \
+    dummy = ((CRPN *)next->base.next)->res;                                    \
+    old2 = dummy;                                                              \
+    code_off =                                                                 \
+        PutICArgIntoReg(cctrl, &next2->res, next2->res.raw_type,               \
+                        use_f64 ? AIWNIOS_TMP_IREG_POOP2 : 1, bin, code_off);  \
+    code_off = PutICArgIntoReg(cctrl, &dummy, RT_U64i, AIWNIOS_TMP_IREG_POOP,  \
+                               bin, code_off);                                 \
+    next->res.reg = dummy.reg;                                                 \
+    next->res.mode = MD_INDIR_REG;                                             \
+    next->res.off = 0;                                                         \
+    code_off = PutICArgIntoReg(                                                \
+        cctrl, &next->res, use_f64 ? RT_F64 : next->res.raw_type,              \
+        use_f64 ? 0 : AIWNIOS_TMP_IREG_POOP, bin, code_off);                   \
+    next->flags = ICF_PRECOMPUTED;                                             \
+    next2->flags = ICF_PRECOMPUTED;                                            \
+    rpn->res.mode = MD_REG;                                                    \
+    rpn->res.reg = use_f64 ? 1 : RAX;                                          \
+    if (use_f64)                                                               \
+      rpn->raw_type = RT_F64;                                                  \
+    rpn->res.raw_type = rpn->raw_type;                                         \
+    code_off = __OptPassFinal(cctrl, rpn, bin, code_off);                      \
+    set_flags = rpn->res.set_flags;                                            \
+    rpn->raw_type = old_raw_type;                                              \
+    next->flags &= ~ICF_PRECOMPUTED;                                           \
+    next2->flags &= ~ICF_PRECOMPUTED;                                          \
+    code_off = PutICArgIntoReg(cctrl, &old2, RT_PTR, RDX, bin, code_off);      \
+    if (!use_tc)                                                               \
+      old2.raw_type = next->raw_type;                                          \
+    else                                                                       \
+      old2.raw_type = use_raw_type;                                            \
+    old2.mode = MD_INDIR_REG;                                                  \
+    old2.off = 0;                                                              \
+    code_off = ICMov(cctrl, &old2, &rpn->res, bin, code_off);                  \
+    code_off = ICMov(cctrl, &old, &rpn->res, bin, code_off);                   \
+    next->flags = old_flags, next2->flags = old_flags2;                        \
+    break;                                                                     \
+  default:                                                                     \
+    rpn->res = next->res;                                                      \
+    if (use_f64)                                                               \
+      rpn->raw_type = RT_F64;                                                  \
+    code_off = __OptPassFinal(cctrl, rpn, bin, code_off);                      \
+    set_flags = rpn->res.set_flags;                                            \
+    rpn->raw_type = old_raw_type;                                              \
+    code_off = ICMov(cctrl, &next->res, &rpn->res, bin, code_off);             \
+  }                                                                            \
+  rpn->type = old_type, rpn->res = old;                                        \
+  next->type = next_old;                                                       \
+  next2->type = old_next2;
+    XXX_EQ_OP(IC_ADD);
+    break;
+  case IC_SUB_EQ:
+    XXX_EQ_OP(IC_SUB);
+    break;
+  case IC_MUL_EQ:
+    XXX_EQ_OP(IC_MUL);
+    break;
+  case IC_DIV_EQ:
+    XXX_EQ_OP(IC_DIV);
+    break;
+  case IC_LSH_EQ:
+    XXX_EQ_OP(IC_LSH);
+    break;
+  case IC_RSH_EQ:
+    XXX_EQ_OP(IC_RSH);
+    break;
+  case IC_AND_EQ:
+    XXX_EQ_OP(IC_AND);
+    break;
+  case IC_OR_EQ:
+    XXX_EQ_OP(IC_OR);
+    break;
+  case IC_XOR_EQ:
+    XXX_EQ_OP(IC_XOR);
+    break;
+  case IC_MOD_EQ:
+    XXX_EQ_OP(IC_MOD);
+  }
+  if (set_flags)
+    rpn->res.set_flags = 1;
+  return code_off;
 }
 
-static int64_t IsSavedIReg(int64_t r)
-{
-	switch (r) {
-	case RSI:
-	case RDI:
-	case RSP:
-	case RBP:
-	case R10:
-	case R11:
-	case R12:
-	case R13:
-	case R14:
-	case R15:;
-	return 1;
-	}
-	return 0;
+static int64_t IsSavedIReg(int64_t r) {
+  switch (r) {
+  case RSI:
+  case RDI:
+  case RSP:
+  case RBP:
+  case R10:
+  case R11:
+  case R12:
+  case R13:
+  case R14:
+  case R15:;
+    return 1;
+  }
+  return 0;
 }
 
 // This is used for FuncProlog/Epilog. It is used for finding the non-violatle
@@ -3795,62 +3936,62 @@ static int64_t IsSavedIReg(int64_t r)
 //
 // Returns number of pushed regs
 //
-static int64_t __FindPushedIRegs(CCmpCtrl* cctrl, char* to_push)
-{
-	CMemberLst* lst;
-	CRPN* r;
-	int64_t cnt = 0;
-	memset(to_push, 0, 16);
-	if (!cctrl->cur_fun) {
-		// Perhaps we are being called from HolyC and we aren't using a "cur_fun"
-		for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code; r = r->base.next) {
-			if (r->type == IC_IREG && r->raw_type != RT_F64) {
-				if (!to_push[r->integer])
-					if (IsSavedIReg(r->integer)) {
-						to_push[r->integer] = 1;
-						cnt++;
-					}
-			}
-		}
-		return cnt;
-	}
-	for (lst = cctrl->cur_fun->base.members_lst; lst; lst = lst->next) {
-		if (lst->reg != REG_NONE && lst->member_class->raw_type != RT_F64) {
-			assert(lst->reg >= 0);
-			to_push[lst->reg] = 1;
-			cnt++;
-		}
-	}
-	return cnt;
+static int64_t __FindPushedIRegs(CCmpCtrl *cctrl, char *to_push) {
+  CMemberLst *lst;
+  CRPN *r;
+  int64_t cnt = 0;
+  memset(to_push, 0, 16);
+  if (!cctrl->cur_fun) {
+    // Perhaps we are being called from HolyC and we aren't using a "cur_fun"
+    for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code;
+         r = r->base.next) {
+      if (r->type == IC_IREG && r->raw_type != RT_F64) {
+        if (!to_push[r->integer])
+          if (IsSavedIReg(r->integer)) {
+            to_push[r->integer] = 1;
+            cnt++;
+          }
+      }
+    }
+    return cnt;
+  }
+  for (lst = cctrl->cur_fun->base.members_lst; lst; lst = lst->next) {
+    if (lst->reg != REG_NONE && lst->member_class->raw_type != RT_F64) {
+      assert(lst->reg >= 0);
+      to_push[lst->reg] = 1;
+      cnt++;
+    }
+  }
+  return cnt;
 }
 
-static int64_t __FindPushedFRegs(CCmpCtrl* cctrl, char* to_push)
-{
-	CMemberLst* lst;
-	int64_t cnt = 0;
-	memset(to_push, 0, 16);
-	CRPN* r;
-	if (!cctrl->cur_fun) {
-		// Perhaps we are being called from HolyC and we aren't using a "cur_fun"
-		for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code; r = r->base.next) {
-			if (r->type == IC_FREG && r->raw_type == RT_F64) {
-				if (!to_push[r->integer])
-					if (IsSavedFReg(r->integer)) {
-						to_push[r->integer] = 1;
-						cnt++;
-					}
-			}
-		}
-		return cctrl->backend_user_data7 = cnt;
-	}
-	for (lst = cctrl->cur_fun->base.members_lst; lst; lst = lst->next) {
-		if (lst->reg != REG_NONE && lst->member_class->raw_type == RT_F64) {
-			assert(lst->reg >= 0);
-			to_push[lst->reg] = 1;
-			cnt++;
-		}
-	}
-	return cctrl->backend_user_data7 = cnt;
+static int64_t __FindPushedFRegs(CCmpCtrl *cctrl, char *to_push) {
+  CMemberLst *lst;
+  int64_t cnt = 0;
+  memset(to_push, 0, 16);
+  CRPN *r;
+  if (!cctrl->cur_fun) {
+    // Perhaps we are being called from HolyC and we aren't using a "cur_fun"
+    for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code;
+         r = r->base.next) {
+      if (r->type == IC_FREG && r->raw_type == RT_F64) {
+        if (!to_push[r->integer])
+          if (IsSavedFReg(r->integer)) {
+            to_push[r->integer] = 1;
+            cnt++;
+          }
+      }
+    }
+    return cctrl->backend_user_data7 = cnt;
+  }
+  for (lst = cctrl->cur_fun->base.members_lst; lst; lst = lst->next) {
+    if (lst->reg != REG_NONE && lst->member_class->raw_type == RT_F64) {
+      assert(lst->reg >= 0);
+      to_push[lst->reg] = 1;
+      cnt++;
+    }
+  }
+  return cctrl->backend_user_data7 = cnt;
 }
 
 // Add 1 in first bit for oppositive
@@ -3865,76 +4006,76 @@ static int64_t __FindPushedFRegs(CCmpCtrl* cctrl, char* to_push)
 #define X86_COND_GE 0x80
 #define X86_COND_L 0x90
 #define X86_COND_LE 0xa0
-static int64_t X86Jcc(char* to, int64_t cond, int64_t off)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	ADD_U8(0x0f);
-	switch (cond) {
-		break;
-	case X86_COND_A:
-		ADD_U8(0x87);
-		break;
-	case X86_COND_AE:
-		ADD_U8(0x83);
-		break;
-	case X86_COND_B:
-		ADD_U8(0x82);
-		break;
-	case X86_COND_BE:
-		ADD_U8(0x86);
-		break;
-	case X86_COND_C:
-		ADD_U8(0x82);
-		break;
-	case X86_COND_E:
-		ADD_U8(0x84);
-		break;
-	case X86_COND_G:
-		ADD_U8(0x8f);
-		break;
-	case X86_COND_GE:
-		ADD_U8(0x8d);
-		break;
-	case X86_COND_L:
-		ADD_U8(0x8c);
-		break;
-	case X86_COND_LE:
-		ADD_U8(0x8e);
-		break;
-	case X86_COND_A | 1:
-		ADD_U8(0x86);
-		break;
-	case X86_COND_AE | 1:
-		ADD_U8(0x82);
-		break;
-	case X86_COND_B | 1:
-		ADD_U8(0x83);
-		break;
-	case X86_COND_BE | 1:
-		ADD_U8(0x87);
-		break;
-	case X86_COND_C | 1:
-		ADD_U8(0x83);
-		break;
-	case X86_COND_E | 1:
-		ADD_U8(0x85);
-		break;
-	case X86_COND_G | 1:
-		ADD_U8(0x8e);
-		break;
-	case X86_COND_GE | 1:
-		ADD_U8(0x8c);
-		break;
-	case X86_COND_L | 1:
-		ADD_U8(0x8d);
-		break;
-	case X86_COND_LE | 1:
-		ADD_U8(0x8f);
-	}
-	ADD_U32(off - 6); //-6 as inst is 6 bytes long(RIP comes after INST);
-	return len;
+static int64_t X86Jcc(char *to, int64_t cond, int64_t off) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  ADD_U8(0x0f);
+  switch (cond) {
+    break;
+  case X86_COND_A:
+    ADD_U8(0x87);
+    break;
+  case X86_COND_AE:
+    ADD_U8(0x83);
+    break;
+  case X86_COND_B:
+    ADD_U8(0x82);
+    break;
+  case X86_COND_BE:
+    ADD_U8(0x86);
+    break;
+  case X86_COND_C:
+    ADD_U8(0x82);
+    break;
+  case X86_COND_E:
+    ADD_U8(0x84);
+    break;
+  case X86_COND_G:
+    ADD_U8(0x8f);
+    break;
+  case X86_COND_GE:
+    ADD_U8(0x8d);
+    break;
+  case X86_COND_L:
+    ADD_U8(0x8c);
+    break;
+  case X86_COND_LE:
+    ADD_U8(0x8e);
+    break;
+  case X86_COND_A | 1:
+    ADD_U8(0x86);
+    break;
+  case X86_COND_AE | 1:
+    ADD_U8(0x82);
+    break;
+  case X86_COND_B | 1:
+    ADD_U8(0x83);
+    break;
+  case X86_COND_BE | 1:
+    ADD_U8(0x87);
+    break;
+  case X86_COND_C | 1:
+    ADD_U8(0x83);
+    break;
+  case X86_COND_E | 1:
+    ADD_U8(0x85);
+    break;
+  case X86_COND_G | 1:
+    ADD_U8(0x8e);
+    break;
+  case X86_COND_GE | 1:
+    ADD_U8(0x8c);
+    break;
+  case X86_COND_L | 1:
+    ADD_U8(0x8d);
+    break;
+  case X86_COND_LE | 1:
+    ADD_U8(0x8f);
+  }
+  ADD_U32(off - 6); //-6 as inst is 6 bytes long(RIP comes after INST);
+  return len;
 }
 // 1st MOV RDI,1
 //...
@@ -3943,1007 +4084,1067 @@ static int64_t X86Jcc(char* to, int64_t cond, int64_t off)
 // CALL FOO
 // ADD RSP,8 //To remove 7 from the stack
 
-static int64_t X86Setcc(char* to, int64_t cond, int64_t r)
-{
-	int64_t len = 0;
-	char buf[16];
-	if(!to) to=buf;
-	if ((r & 0b1000) || r == RSI || r == RDI)
-		ADD_U8(ErectREX(0, 0, 0, r))
-	ADD_U8(0x0f);
-	switch (cond) {
-		break;
-	case X86_COND_A:
-		ADD_U8(0x97);
-		break;
-	case X86_COND_AE:
-		ADD_U8(0x93);
-		break;
-	case X86_COND_B:
-		ADD_U8(0x92);
-		break;
-	case X86_COND_BE:
-		ADD_U8(0x96);
-		break;
-	case X86_COND_C:
-		ADD_U8(0x92);
-		break;
-	case X86_COND_E:
-		ADD_U8(0x94);
-		break;
-	case X86_COND_G:
-		ADD_U8(0x9f);
-		break;
-	case X86_COND_GE:
-		ADD_U8(0x9d);
-		break;
-	case X86_COND_L:
-		ADD_U8(0x9c);
-		break;
-	case X86_COND_LE:
-		ADD_U8(0x9e);
+static int64_t X86Setcc(char *to, int64_t cond, int64_t r) {
+  int64_t len = 0;
+  char buf[16];
+  if (!to)
+    to = buf;
+  if ((r & 0b1000) || r == RSI || r == RDI)
+    ADD_U8(ErectREX(0, 0, 0, r))
+  ADD_U8(0x0f);
+  switch (cond) {
+    break;
+  case X86_COND_A:
+    ADD_U8(0x97);
+    break;
+  case X86_COND_AE:
+    ADD_U8(0x93);
+    break;
+  case X86_COND_B:
+    ADD_U8(0x92);
+    break;
+  case X86_COND_BE:
+    ADD_U8(0x96);
+    break;
+  case X86_COND_C:
+    ADD_U8(0x92);
+    break;
+  case X86_COND_E:
+    ADD_U8(0x94);
+    break;
+  case X86_COND_G:
+    ADD_U8(0x9f);
+    break;
+  case X86_COND_GE:
+    ADD_U8(0x9d);
+    break;
+  case X86_COND_L:
+    ADD_U8(0x9c);
+    break;
+  case X86_COND_LE:
+    ADD_U8(0x9e);
 
-		break;
-	case X86_COND_A | 1:
-		ADD_U8(0x96);
-		break;
-	case X86_COND_AE | 1:
-		ADD_U8(0x92);
-		break;
-	case X86_COND_B | 1:
-		ADD_U8(0x93);
-		break;
-	case X86_COND_BE | 1:
-		ADD_U8(0x97);
-		break;
-	case X86_COND_C | 1:
-		ADD_U8(0x93);
-		break;
-	case X86_COND_E | 1:
-		ADD_U8(0x95);
-		break;
-	case X86_COND_G | 1:
-		ADD_U8(0x9e);
-		break;
-	case X86_COND_GE | 1:
-		ADD_U8(0x9c);
-		break;
-	case X86_COND_L | 1:
-		ADD_U8(0x9d);
-		break;
-	case X86_COND_LE | 1:
-		ADD_U8(0x9f);
-	}
-	ADD_U8(MODRMRegReg(0, r));
-	if (!to)
-		len += X86MovZXRegRegI8(NULL, r, r);
-	else
-		len += X86MovZXRegRegI8(to + len, r, r);
-	return len;
+    break;
+  case X86_COND_A | 1:
+    ADD_U8(0x96);
+    break;
+  case X86_COND_AE | 1:
+    ADD_U8(0x92);
+    break;
+  case X86_COND_B | 1:
+    ADD_U8(0x93);
+    break;
+  case X86_COND_BE | 1:
+    ADD_U8(0x97);
+    break;
+  case X86_COND_C | 1:
+    ADD_U8(0x93);
+    break;
+  case X86_COND_E | 1:
+    ADD_U8(0x95);
+    break;
+  case X86_COND_G | 1:
+    ADD_U8(0x9e);
+    break;
+  case X86_COND_GE | 1:
+    ADD_U8(0x9c);
+    break;
+  case X86_COND_L | 1:
+    ADD_U8(0x9d);
+    break;
+  case X86_COND_LE | 1:
+    ADD_U8(0x9f);
+  }
+  ADD_U8(MODRMRegReg(0, r));
+  if (!to)
+    len += X86MovZXRegRegI8(NULL, r, r);
+  else
+    len += X86MovZXRegRegI8(to + len, r, r);
+  return len;
 }
 
-static int64_t FuncProlog(CCmpCtrl* cctrl, char* bin, int64_t code_off)
-{
-	char push_ireg[16];
-	char push_freg[16];
-	char ilist[16];
-	char flist[16];
-	int64_t i, i2, i3, r, r2, ireg_arg_cnt, freg_arg_cnt, stk_arg_cnt, fsz, code, off;
-	int64_t has_vargs=0,arg_cnt=0;
-	CMemberLst* lst;
-	CICArg fun_arg = { 0 }, write_to = { 0 }, stack = { 0 }, tmp = { 0 };
-	CRPN *rpn, *arg;
-	if (cctrl->cur_fun) {
-		fsz = cctrl->cur_fun->base.sz + 16; //+16 for RBP/return address
-		arg_cnt=cctrl->cur_fun->argc;
-		if(cctrl->cur_fun->base.flags&CLSF_VARGS)
-			arg_cnt--; //argv
-	} else {
-		fsz = 16;
-		for (rpn = cctrl->code_ctrl->ir_code->next; rpn != cctrl->code_ctrl->ir_code; rpn = rpn->base.next) {
-			switch(rpn->type) {
-				case __IC_SET_FRAME_SIZE:
-					fsz = rpn->integer;
-					break;
-				case IC_GET_VARGS_PTR:
-					has_vargs=1;
-					break;
-				case __IC_ARG:
-					arg_cnt++;
-					break;
-			}
-		}
-	}
-	// ALIGN TO 8
-	if (fsz % 8)
-		fsz += 8 - fsz % 8;
-	int64_t to_push = (i2 = __FindPushedIRegs(cctrl, push_ireg)) * 8 + (i3 = __FindPushedFRegs(cctrl, push_freg)) * 8 + cctrl->backend_user_data0 + fsz + 16, old_regs_start;
-	if (i2 % 2)
-		to_push += 8; // We push a dummy register in a pair if not aligned to 2
-	if (i3 % 2)
-		to_push += 8; // Ditto
+static int64_t FuncProlog(CCmpCtrl *cctrl, char *bin, int64_t code_off) {
+  char push_ireg[16];
+  char push_freg[16];
+  char ilist[16];
+  char flist[16];
+  int64_t i, i2, i3, r, r2, ireg_arg_cnt, freg_arg_cnt, stk_arg_cnt, fsz, code,
+      off;
+  int64_t has_vargs = 0, arg_cnt = 0;
+  CMemberLst *lst;
+  CICArg fun_arg = {0}, write_to = {0}, stack = {0}, tmp = {0};
+  CRPN *rpn, *arg;
+  if (cctrl->cur_fun) {
+    fsz = cctrl->cur_fun->base.sz + 16; //+16 for RBP/return address
+    arg_cnt = cctrl->cur_fun->argc;
+    if (cctrl->cur_fun->base.flags & CLSF_VARGS)
+      arg_cnt--; // argv
+  } else {
+    fsz = 16;
+    for (rpn = cctrl->code_ctrl->ir_code->next;
+         rpn != cctrl->code_ctrl->ir_code; rpn = rpn->base.next) {
+      switch (rpn->type) {
+      case __IC_SET_FRAME_SIZE:
+        fsz = rpn->integer;
+        break;
+      case IC_GET_VARGS_PTR:
+        has_vargs = 1;
+        break;
+      case __IC_ARG:
+        arg_cnt++;
+        break;
+      }
+    }
+  }
+  // ALIGN TO 8
+  if (fsz % 8)
+    fsz += 8 - fsz % 8;
+  int64_t to_push = (i2 = __FindPushedIRegs(cctrl, push_ireg)) * 8 +
+                    (i3 = __FindPushedFRegs(cctrl, push_freg)) * 8 +
+                    cctrl->backend_user_data0 + fsz + 16,
+          old_regs_start;
+  if (i2 % 2)
+    to_push += 8; // We push a dummy register in a pair if not aligned to 2
+  if (i3 % 2)
+    to_push += 8; // Ditto
 
-	if (to_push % 16)
-		to_push += 8;
-	cctrl->backend_user_data4 = fsz;
-	old_regs_start = fsz + cctrl->backend_user_data0;
+  if (to_push % 16)
+    to_push += 8;
+  cctrl->backend_user_data4 = fsz;
+  old_regs_start = fsz + cctrl->backend_user_data0;
 
-	i2 = 0;
-	for (i = 0; i != 16; i++)
-		if (push_ireg[i])
-			ilist[i2++] = i;
-	if (i2 % 2)
-		ilist[i2++] = 1; // Dont use 0 as it is a reutrn register
-	i3 = 0;
-	for (i = 0; i != 16; i++)
-		if (push_freg[i])
-			flist[i3++] = i;
-	if (i3 % 2)
-		flist[i3++] = 1; // Dont use 0 as it is a reutrn register
+  i2 = 0;
+  for (i = 0; i != 16; i++)
+    if (push_ireg[i])
+      ilist[i2++] = i;
+  if (i2 % 2)
+    ilist[i2++] = 1; // Dont use 0 as it is a reutrn register
+  i3 = 0;
+  for (i = 0; i != 16; i++)
+    if (push_freg[i])
+      flist[i3++] = i;
+  if (i3 % 2)
+    flist[i3++] = 1; // Dont use 0 as it is a reutrn register
 
-	AIWNIOS_ADD_CODE(X86PushReg, RBP);
-	AIWNIOS_ADD_CODE(X86MovRegReg, RBP, RSP);
-	AIWNIOS_ADD_CODE(X86SubImm32, RSP, to_push);
-	off = -old_regs_start;
-	for (i = 0; i != i2; i++) {
-		AIWNIOS_ADD_CODE(X86MovIndirRegI64, ilist[i], -1, -1, RBP, off);
-		off -= 8;
-	}
-	for (i = 0; i != i3; i++) {
-		AIWNIOS_ADD_CODE(X86MovIndirRegF64, flist[i], -1, -1, RBP, off);
-		off -= 8;
-	}
-	stk_arg_cnt = ireg_arg_cnt = freg_arg_cnt = 0;
-	if (cctrl->cur_fun) {
-		lst = cctrl->cur_fun->base.members_lst;
-		for (i = 0; i != cctrl->cur_fun->argc; i++) {
-			fun_arg.mode = MD_INDIR_REG;
-			fun_arg.raw_type = lst->member_class->raw_type;
-			fun_arg.reg = RBP;
-			fun_arg.off = 16 + stk_arg_cnt++ * 8;
-			// This *shoudlnt* mutate any of the argument registers
-			if (lst->reg >= 0 && lst->reg != REG_NONE) {
-				write_to.mode = MD_REG;
-				write_to.reg = lst->reg;
-				write_to.off = 0;
-				write_to.raw_type = lst->member_class->raw_type;
-			} else {
-				write_to.mode = MD_FRAME;
-				write_to.off = lst->off;
-				write_to.raw_type = lst->member_class->raw_type;
-			}
-			if((cctrl->cur_fun->base.flags&CLSF_VARGS)&&!strcmp("argv",lst->str)) {
-				AIWNIOS_ADD_CODE(X86LeaSIB,0,-1,-1,RBP,16+arg_cnt*8);
-				fun_arg.reg=0;
-				fun_arg.mode=MD_REG;
-				fun_arg.raw_type=RT_I64i;
-			}
-			code_off = ICMov(cctrl, &write_to, &fun_arg, bin, code_off);
-			lst = lst->next;
-		}
-	} else {
-		// Things from the HolyC side use __IC_ARG
-		// We go backwards as this is REVERSE polish notation
-		for (i = 0, rpn = cctrl->code_ctrl->ir_code->last; rpn != cctrl->code_ctrl->ir_code; rpn = rpn->base.last) {
-			if (rpn->type == __IC_ARG) {
-				fun_arg.mode = MD_INDIR_REG;
-				fun_arg.raw_type = (arg = ICArgN(rpn, 0))->raw_type == RT_F64 ? RT_F64 : RT_I64i;
-				fun_arg.reg = RBP;
-				fun_arg.off = 16 + stk_arg_cnt++ * 8;
-				PushTmp(cctrl, arg, NULL);
-				PopTmp(cctrl, arg);
-				if (fun_arg.mode == MD_FRAME && write_to.mode == MD_FRAME) {
-					// DONT DIRTY THE POOP REGISTER THAT IS USED AS AN ARGUMENT
-					tmp.reg = 0;
-					tmp.mode = MD_REG;
-					tmp.raw_type = write_to.raw_type;
-					code_off = ICMov(cctrl, &tmp, &fun_arg, bin, code_off);
-					fun_arg = tmp;
-				}
-				code_off = ICMov(cctrl, &arg->res, &fun_arg, bin, code_off);
-			} else if(rpn->type==IC_GET_VARGS_PTR) {
-				arg = ICArgN(rpn, 0);
-				PushTmp(cctrl, arg, NULL);
-				PopTmp(cctrl, arg);
-				if(arg->res.mode==MD_REG) {
-					AIWNIOS_ADD_CODE(X86LeaSIB,arg->res.reg,-1,-1,RBP,16+arg_cnt*8);
-				} else {
-					AIWNIOS_ADD_CODE(X86LeaSIB,0,-1,-1,RBP,16+arg_cnt*8);
-					tmp.reg=0;
-					tmp.mode=MD_REG;
-					tmp.raw_type=RT_I64i;
-					code_off = ICMov(cctrl, &arg->res, &tmp, bin, code_off);
-				}
-			}
-		}
-	}
-	return code_off;
+  AIWNIOS_ADD_CODE(X86PushReg, RBP);
+  AIWNIOS_ADD_CODE(X86MovRegReg, RBP, RSP);
+  AIWNIOS_ADD_CODE(X86SubImm32, RSP, to_push);
+  off = -old_regs_start;
+  for (i = 0; i != i2; i++) {
+    AIWNIOS_ADD_CODE(X86MovIndirRegI64, ilist[i], -1, -1, RBP, off);
+    off -= 8;
+  }
+  for (i = 0; i != i3; i++) {
+    AIWNIOS_ADD_CODE(X86MovIndirRegF64, flist[i], -1, -1, RBP, off);
+    off -= 8;
+  }
+  stk_arg_cnt = ireg_arg_cnt = freg_arg_cnt = 0;
+  if (cctrl->cur_fun) {
+    lst = cctrl->cur_fun->base.members_lst;
+    for (i = 0; i != cctrl->cur_fun->argc; i++) {
+      fun_arg.mode = MD_INDIR_REG;
+      fun_arg.raw_type = lst->member_class->raw_type;
+      fun_arg.reg = RBP;
+      fun_arg.off = 16 + stk_arg_cnt++ * 8;
+      // This *shoudlnt* mutate any of the argument registers
+      if (lst->reg >= 0 && lst->reg != REG_NONE) {
+        write_to.mode = MD_REG;
+        write_to.reg = lst->reg;
+        write_to.off = 0;
+        write_to.raw_type = lst->member_class->raw_type;
+      } else {
+        write_to.mode = MD_FRAME;
+        write_to.off = lst->off;
+        write_to.raw_type = lst->member_class->raw_type;
+      }
+      if ((cctrl->cur_fun->base.flags & CLSF_VARGS) &&
+          !strcmp("argv", lst->str)) {
+        AIWNIOS_ADD_CODE(X86LeaSIB, 0, -1, -1, RBP, 16 + arg_cnt * 8);
+        fun_arg.reg = 0;
+        fun_arg.mode = MD_REG;
+        fun_arg.raw_type = RT_I64i;
+      }
+      code_off = ICMov(cctrl, &write_to, &fun_arg, bin, code_off);
+      lst = lst->next;
+    }
+  } else {
+    // Things from the HolyC side use __IC_ARG
+    // We go backwards as this is REVERSE polish notation
+    for (i = 0, rpn = cctrl->code_ctrl->ir_code->last;
+         rpn != cctrl->code_ctrl->ir_code; rpn = rpn->base.last) {
+      if (rpn->type == __IC_ARG) {
+        fun_arg.mode = MD_INDIR_REG;
+        fun_arg.raw_type =
+            (arg = ICArgN(rpn, 0))->raw_type == RT_F64 ? RT_F64 : RT_I64i;
+        fun_arg.reg = RBP;
+        fun_arg.off = 16 + stk_arg_cnt++ * 8;
+        PushTmp(cctrl, arg, NULL);
+        PopTmp(cctrl, arg);
+        if (fun_arg.mode == MD_FRAME && write_to.mode == MD_FRAME) {
+          // DONT DIRTY THE POOP REGISTER THAT IS USED AS AN ARGUMENT
+          tmp.reg = 0;
+          tmp.mode = MD_REG;
+          tmp.raw_type = write_to.raw_type;
+          code_off = ICMov(cctrl, &tmp, &fun_arg, bin, code_off);
+          fun_arg = tmp;
+        }
+        code_off = ICMov(cctrl, &arg->res, &fun_arg, bin, code_off);
+      } else if (rpn->type == IC_GET_VARGS_PTR) {
+        arg = ICArgN(rpn, 0);
+        PushTmp(cctrl, arg, NULL);
+        PopTmp(cctrl, arg);
+        if (arg->res.mode == MD_REG) {
+          AIWNIOS_ADD_CODE(X86LeaSIB, arg->res.reg, -1, -1, RBP,
+                           16 + arg_cnt * 8);
+        } else {
+          AIWNIOS_ADD_CODE(X86LeaSIB, 0, -1, -1, RBP, 16 + arg_cnt * 8);
+          tmp.reg = 0;
+          tmp.mode = MD_REG;
+          tmp.raw_type = RT_I64i;
+          code_off = ICMov(cctrl, &arg->res, &tmp, bin, code_off);
+        }
+      }
+    }
+  }
+  return code_off;
 }
 
 //
 // DO NOT CHANGE WITHOUT LOOKING CLOSEY AT FuncProlog
 //
-static int64_t FuncEpilog(CCmpCtrl* cctrl, char* bin, int64_t code_off)
-{
-	char push_ireg[16], ilist[16];
-	char push_freg[16], flist[16];
-	int64_t i, r, r2, fsz, i2, i3, off,is_vargs=0,arg_cnt=0;
-	CICArg spill_loc = { 0 }, write_to = { 0 };
-	CRPN* rpn;
-	/* <== OLD SP
-	 * saved regs
-	 * wiggle room
-	 * locals
-	 * OLD FP,LR<===FP=SP
-	 */
-	if (cctrl->cur_fun) {
-		fsz = cctrl->cur_fun->base.sz + 16; //+16 for LR/FP
-		arg_cnt=cctrl->cur_fun->argc;
-		is_vargs=!!(cctrl->cur_fun->base.flags&CLSF_VARGS);
-	} else {
-		fsz = 16;
-		for (rpn = cctrl->code_ctrl->ir_code->next; rpn != cctrl->code_ctrl->ir_code; rpn = rpn->base.next) {
-			if (rpn->type == __IC_SET_FRAME_SIZE) {
-				fsz = rpn->integer;
-				break;
-			} else if(rpn->type==IC_GET_VARGS_PTR) {
-				is_vargs=1;
-			} else if(rpn->type==__IC_ARG) {
-				arg_cnt++;
-			}
-		}
-	}
-	// ALIGN TO 8
-	if (fsz % 8)
-		fsz += 8 - fsz % 8;
-	int64_t to_push = (i2 = __FindPushedIRegs(cctrl, push_ireg)) * 8 + (i3 = __FindPushedFRegs(cctrl, push_freg)) * 8 + fsz + cctrl->backend_user_data0, old_regs_start; // old_FP,old_LR
-	if (i2 % 2)
-		to_push += 8; // We push a dummy register in a pair if not aligned to 2
-	if (i3 % 2)
-		to_push += 8; // Ditto
-	if (to_push % 16)
-		to_push += 8;
-	old_regs_start = fsz + cctrl->backend_user_data0;
-	i2 = 0;
-	for (i = 0; i != 16; i++)
-		if (push_ireg[i])
-			ilist[i2++] = i;
-	if (i2 % 2)
-		ilist[i2++] = 1; // Dont use 0 as it is a reutrn register
-	i3 = 0;
-	for (i = 0; i != 16; i++)
-		if (push_freg[i])
-			flist[i3++] = i;
-	if (i3 % 2)
-		flist[i3++] = 1; // Dont use 0 as it is a reutrn register
-	//<==== OLD SP
-	// first saved reg pair<==-16
-	// next saved reg pair<===-32
-	//
-	off = -old_regs_start;
-	for (i = 0; i != i2; i++) {
-		AIWNIOS_ADD_CODE(X86MovRegIndirI64, ilist[i], -1, -1, RBP, off);
-		off -= 8;
-	}
-	for (i = 0; i != i3; i++) {
-		AIWNIOS_ADD_CODE(X86MovRegIndirF64, flist[i], -1, -1, RBP, off);
-		off -= 8;
-	}
-	AIWNIOS_ADD_CODE(X86Leave, 0);
-	if(is_vargs) {
-		AIWNIOS_ADD_CODE(X86Ret, 0);
-	} else {
-		AIWNIOS_ADD_CODE(X86Ret, 8*arg_cnt);
-	}
-	return code_off;
+static int64_t FuncEpilog(CCmpCtrl *cctrl, char *bin, int64_t code_off) {
+  char push_ireg[16], ilist[16];
+  char push_freg[16], flist[16];
+  int64_t i, r, r2, fsz, i2, i3, off, is_vargs = 0, arg_cnt = 0;
+  CICArg spill_loc = {0}, write_to = {0};
+  CRPN *rpn;
+  /* <== OLD SP
+   * saved regs
+   * wiggle room
+   * locals
+   * OLD FP,LR<===FP=SP
+   */
+  if (cctrl->cur_fun) {
+    fsz = cctrl->cur_fun->base.sz + 16; //+16 for LR/FP
+    arg_cnt = cctrl->cur_fun->argc;
+    is_vargs = !!(cctrl->cur_fun->base.flags & CLSF_VARGS);
+  } else {
+    fsz = 16;
+    for (rpn = cctrl->code_ctrl->ir_code->next;
+         rpn != cctrl->code_ctrl->ir_code; rpn = rpn->base.next) {
+      if (rpn->type == __IC_SET_FRAME_SIZE) {
+        fsz = rpn->integer;
+        break;
+      } else if (rpn->type == IC_GET_VARGS_PTR) {
+        is_vargs = 1;
+      } else if (rpn->type == __IC_ARG) {
+        arg_cnt++;
+      }
+    }
+  }
+  // ALIGN TO 8
+  if (fsz % 8)
+    fsz += 8 - fsz % 8;
+  int64_t to_push = (i2 = __FindPushedIRegs(cctrl, push_ireg)) * 8 +
+                    (i3 = __FindPushedFRegs(cctrl, push_freg)) * 8 + fsz +
+                    cctrl->backend_user_data0,
+          old_regs_start; // old_FP,old_LR
+  if (i2 % 2)
+    to_push += 8; // We push a dummy register in a pair if not aligned to 2
+  if (i3 % 2)
+    to_push += 8; // Ditto
+  if (to_push % 16)
+    to_push += 8;
+  old_regs_start = fsz + cctrl->backend_user_data0;
+  i2 = 0;
+  for (i = 0; i != 16; i++)
+    if (push_ireg[i])
+      ilist[i2++] = i;
+  if (i2 % 2)
+    ilist[i2++] = 1; // Dont use 0 as it is a reutrn register
+  i3 = 0;
+  for (i = 0; i != 16; i++)
+    if (push_freg[i])
+      flist[i3++] = i;
+  if (i3 % 2)
+    flist[i3++] = 1; // Dont use 0 as it is a reutrn register
+  //<==== OLD SP
+  // first saved reg pair<==-16
+  // next saved reg pair<===-32
+  //
+  off = -old_regs_start;
+  for (i = 0; i != i2; i++) {
+    AIWNIOS_ADD_CODE(X86MovRegIndirI64, ilist[i], -1, -1, RBP, off);
+    off -= 8;
+  }
+  for (i = 0; i != i3; i++) {
+    AIWNIOS_ADD_CODE(X86MovRegIndirF64, flist[i], -1, -1, RBP, off);
+    off -= 8;
+  }
+  AIWNIOS_ADD_CODE(X86Leave, 0);
+  if (is_vargs) {
+    AIWNIOS_ADD_CODE(X86Ret, 0);
+  } else {
+    AIWNIOS_ADD_CODE(X86Ret, 8 * arg_cnt);
+  }
+  return code_off;
 }
 
-static int64_t __SexyPostOp(CCmpCtrl* cctrl, CRPN* rpn, int64_t (*i_imm)(char*, int64_t, int64_t),
-	int64_t (*ireg)(char*, int64_t, int64_t),
-	int64_t (*freg)(char*, int64_t, int64_t),
-	int64_t (*incr)(char*, int64_t),
-	int64_t (*incr_sib)(char*, int64_t, int64_t, int64_t, int64_t),
-	char* bin, int64_t code_off)
-{
-	//
-	// See hack in PushTmpDepthFirst motherfucker
-	//
-	CRPN *next = rpn->base.next, *tc;
-	int64_t code;
-	CICArg derefed = { 0 }, tmp = { 0 }, tmp2 = { 0 };
-	if (next->type == IC_TYPECAST) {
-		TYPECAST_ASSIGN_BEGIN(next, next);
-		if (next->raw_type == RT_F64) {
-			code_off = DerefToICArg(cctrl, &derefed, next, AIWNIOS_TMP_IREG_POOP2, bin, code_off);
-			tmp = derefed; //==RT_F64
-			code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, 1, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-			code_off = __ICMoveF64(cctrl, 0, rpn->integer, bin, code_off);
-			AIWNIOS_ADD_CODE(freg, tmp.reg, 0);
-			code_off = ICMov(cctrl, &derefed, &tmp, bin, code_off);
-		} else if (rpn->integer != 1) {
-			code_off = DerefToICArg(cctrl, &derefed, next, AIWNIOS_TMP_IREG_POOP2, bin, code_off);
-			tmp = derefed;
-			code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, AIWNIOS_TMP_IREG_POOP, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-			AIWNIOS_ADD_CODE(i_imm, tmp.reg, rpn->integer);
-			code_off = ICMov(cctrl, &derefed, &tmp, bin, code_off);
-		} else if (ModeIsDerefToSIB(next) && RawTypeIs64(next->raw_type)) {
-			code_off = DerefToICArg(cctrl, &derefed, next, AIWNIOS_TMP_IREG_POOP2, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &derefed, bin, code_off);
-			AIWNIOS_ADD_CODE(incr_sib, derefed.__SIB_scale, derefed.reg2, derefed.reg, derefed.off);
-		} else {
-			code_off = DerefToICArg(cctrl, &derefed, next, AIWNIOS_TMP_IREG_POOP2, bin, code_off);
-			tmp = derefed;
-			code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, AIWNIOS_TMP_IREG_POOP, bin, code_off);
-			AIWNIOS_ADD_CODE(incr, tmp.reg);
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		}
-		TYPECAST_ASSIGN_END(next);
-	} else {
-		if (next->raw_type == RT_F64) {
-			code_off = DerefToICArg(cctrl, &derefed, next, AIWNIOS_TMP_IREG_POOP2, bin, code_off);
-			tmp = derefed; //==RT_F64
-			code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, 1, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-			code_off = __ICMoveF64(cctrl, 0, rpn->integer, bin, code_off);
-			AIWNIOS_ADD_CODE(freg, tmp.reg, 0);
-			code_off = ICMov(cctrl, &derefed, &tmp, bin, code_off);
-		} else if (rpn->integer != 1) {
-			code_off = DerefToICArg(cctrl, &derefed, next, AIWNIOS_TMP_IREG_POOP2, bin, code_off);
-			tmp = derefed;
-			code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, AIWNIOS_TMP_IREG_POOP, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-			AIWNIOS_ADD_CODE(i_imm, tmp.reg, rpn->integer);
-			code_off = ICMov(cctrl, &derefed, &tmp, bin, code_off);
-		} else if (ModeIsDerefToSIB(next) && RawTypeIs64(next->raw_type)) {
-			code_off = DerefToICArg(cctrl, &derefed, next, AIWNIOS_TMP_IREG_POOP2, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &derefed, bin, code_off);
-			AIWNIOS_ADD_CODE(incr_sib, derefed.__SIB_scale, derefed.reg2, derefed.reg, derefed.off);
-		} else {
-			code_off = DerefToICArg(cctrl, &derefed, next, AIWNIOS_TMP_IREG_POOP2, bin, code_off);
-			tmp = derefed;
-			code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, AIWNIOS_TMP_IREG_POOP, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-			AIWNIOS_ADD_CODE(incr, tmp.reg);
-			code_off = ICMov(cctrl, &derefed, &tmp, bin, code_off);
-		}
-	}
-	return code_off;
+static int64_t __SexyPostOp(
+    CCmpCtrl *cctrl, CRPN *rpn, int64_t (*i_imm)(char *, int64_t, int64_t),
+    int64_t (*ireg)(char *, int64_t, int64_t),
+    int64_t (*freg)(char *, int64_t, int64_t), int64_t (*incr)(char *, int64_t),
+    int64_t (*incr_sib)(char *, int64_t, int64_t, int64_t, int64_t), char *bin,
+    int64_t code_off) {
+  //
+  // See hack in PushTmpDepthFirst motherfucker
+  //
+  CRPN *next = rpn->base.next, *tc;
+  int64_t code;
+  CICArg derefed = {0}, tmp = {0}, tmp2 = {0};
+  if (next->type == IC_TYPECAST) {
+    TYPECAST_ASSIGN_BEGIN(next, next);
+    if (next->raw_type == RT_F64) {
+      code_off = DerefToICArg(cctrl, &derefed, next, AIWNIOS_TMP_IREG_POOP2,
+                              bin, code_off);
+      tmp = derefed; //==RT_F64
+      code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, 1, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+      code_off = __ICMoveF64(cctrl, 0, rpn->integer, bin, code_off);
+      AIWNIOS_ADD_CODE(freg, tmp.reg, 0);
+      code_off = ICMov(cctrl, &derefed, &tmp, bin, code_off);
+    } else if (rpn->integer != 1) {
+      code_off = DerefToICArg(cctrl, &derefed, next, AIWNIOS_TMP_IREG_POOP2,
+                              bin, code_off);
+      tmp = derefed;
+      code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type,
+                                 AIWNIOS_TMP_IREG_POOP, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+      AIWNIOS_ADD_CODE(i_imm, tmp.reg, rpn->integer);
+      code_off = ICMov(cctrl, &derefed, &tmp, bin, code_off);
+    } else if (ModeIsDerefToSIB(next) && RawTypeIs64(next->raw_type)) {
+      code_off = DerefToICArg(cctrl, &derefed, next, AIWNIOS_TMP_IREG_POOP2,
+                              bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &derefed, bin, code_off);
+      AIWNIOS_ADD_CODE(incr_sib, derefed.__SIB_scale, derefed.reg2, derefed.reg,
+                       derefed.off);
+    } else {
+      code_off = DerefToICArg(cctrl, &derefed, next, AIWNIOS_TMP_IREG_POOP2,
+                              bin, code_off);
+      tmp = derefed;
+      code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type,
+                                 AIWNIOS_TMP_IREG_POOP, bin, code_off);
+      AIWNIOS_ADD_CODE(incr, tmp.reg);
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    }
+    TYPECAST_ASSIGN_END(next);
+  } else {
+    if (next->raw_type == RT_F64) {
+      code_off = DerefToICArg(cctrl, &derefed, next, AIWNIOS_TMP_IREG_POOP2,
+                              bin, code_off);
+      tmp = derefed; //==RT_F64
+      code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type, 1, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+      code_off = __ICMoveF64(cctrl, 0, rpn->integer, bin, code_off);
+      AIWNIOS_ADD_CODE(freg, tmp.reg, 0);
+      code_off = ICMov(cctrl, &derefed, &tmp, bin, code_off);
+    } else if (rpn->integer != 1) {
+      code_off = DerefToICArg(cctrl, &derefed, next, AIWNIOS_TMP_IREG_POOP2,
+                              bin, code_off);
+      tmp = derefed;
+      code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type,
+                                 AIWNIOS_TMP_IREG_POOP, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+      AIWNIOS_ADD_CODE(i_imm, tmp.reg, rpn->integer);
+      code_off = ICMov(cctrl, &derefed, &tmp, bin, code_off);
+    } else if (ModeIsDerefToSIB(next) && RawTypeIs64(next->raw_type)) {
+      code_off = DerefToICArg(cctrl, &derefed, next, AIWNIOS_TMP_IREG_POOP2,
+                              bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &derefed, bin, code_off);
+      AIWNIOS_ADD_CODE(incr_sib, derefed.__SIB_scale, derefed.reg2, derefed.reg,
+                       derefed.off);
+    } else {
+      code_off = DerefToICArg(cctrl, &derefed, next, AIWNIOS_TMP_IREG_POOP2,
+                              bin, code_off);
+      tmp = derefed;
+      code_off = PutICArgIntoReg(cctrl, &tmp, tmp.raw_type,
+                                 AIWNIOS_TMP_IREG_POOP, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+      AIWNIOS_ADD_CODE(incr, tmp.reg);
+      code_off = ICMov(cctrl, &derefed, &tmp, bin, code_off);
+    }
+  }
+  return code_off;
 }
 
-static void DoNothing()
-{
+static void DoNothing() {
 }
 
-static int64_t IsCompoundCompare(CRPN* r)
-{
-	CRPN* next = r->base.next;
-	switch (r->type) {
-	case IC_LT:
-	case IC_GT:
-	case IC_LE:
-	case IC_GE:
-		next = ICFwd(next);
-		switch (next->type) {
-		case IC_LT:
-		case IC_GT:
-		case IC_LE:
-		case IC_GE:
-			return 1;
-		}
-		return 0;
-	/*case IC_NE:
-	case IC_EQ_EQ:
-		next = ICFwd(next);
-		switch (next->type) {
-		case IC_EQ_EQ:
-		case IC_NE:
-			return 1;
-		}
-		return 0;
-		*/
-	}
-	return 0;
+static int64_t IsCompoundCompare(CRPN *r) {
+  CRPN *next = r->base.next;
+  switch (r->type) {
+  case IC_LT:
+  case IC_GT:
+  case IC_LE:
+  case IC_GE:
+    next = ICFwd(next);
+    switch (next->type) {
+    case IC_LT:
+    case IC_GT:
+    case IC_LE:
+    case IC_GE:
+      return 1;
+    }
+    return 0;
+    /*case IC_NE:
+    case IC_EQ_EQ:
+      next = ICFwd(next);
+      switch (next->type) {
+      case IC_EQ_EQ:
+      case IC_NE:
+        return 1;
+      }
+      return 0;
+      */
+  }
+  return 0;
 }
 //
 // ALWAYS ASSUME WORST CASE if we dont have a ALLOC'ed peice of RAM
 //
-int64_t __OptPassFinal(CCmpCtrl* cctrl, CRPN* rpn, char* bin,
-	int64_t code_off)
-{
-	CCodeMisc *misc, *misc2;
-	CRPN *next, *next2, **range, **range_args, *next3, *a, *b;
-	CICArg tmp = { 0 }, orig_dst = { 0 }, tmp2 = { 0 }, derefed = { 0 };
-	int64_t i = 0, cnt, i2, use_reg, a_reg, b_reg, into_reg, use_flt_cmp, reverse, is_typecast;
-	int64_t *range_cmp_types, use_flags = rpn->res.set_flags;
-	CCodeMisc *old_fail_misc = (CCodeMisc*)cctrl->backend_user_data5, *old_pass_misc = (CCodeMisc*)cctrl->backend_user_data6;
-	cctrl->backend_user_data5 = 0;
-	cctrl->backend_user_data6 = 0;
-	rpn->res.set_flags = 0;
-	if (rpn->flags & ICF_PRECOMPUTED)
-		goto ret;
-	char *enter_addr2, *enter_addr, *exit_addr, **fail1_addr, **fail2_addr, ***range_fail_addrs;
-	if (cctrl->code_ctrl->dbg_info && cctrl->code_ctrl->final_pass && rpn->ic_line) { // Final run
-		if (MSize(cctrl->code_ctrl->dbg_info) / 8 > rpn->ic_line - cctrl->code_ctrl->min_ln) {
-			i = (int64_t)(cctrl->code_ctrl->dbg_info[rpn->ic_line - cctrl->code_ctrl->min_ln]);
-			if (!i)
-				cctrl->code_ctrl->dbg_info[rpn->ic_line - cctrl->code_ctrl->min_ln] = bin + code_off;
-			else if ((int64_t)bin + code_off < i)
-				cctrl->code_ctrl->dbg_info[rpn->ic_line - cctrl->code_ctrl->min_ln] = bin + code_off;
-		}
-	}
-	static const void* poop_ants[IC_CNT] = {
-		[IC_GOTO] = &&ic_goto,
-		[IC_GOTO_IF] = &&ic_goto_if,
-		[IC_TO_I64] = &&ic_to_i64,
-		[IC_TO_F64] = &&ic_to_f64,
-		[IC_LABEL] = &&ic_label,
-		[IC_STATIC] = &&ic_static,
-		[IC_GLOBAL] = &&ic_global,
-		[IC_NOP] = &&ic_nop,
-		[IC_NEG] = &&ic_neg,
-		[IC_POS] = &&ic_pos,
-		[IC_STR] = &&ic_str,
-		[IC_CHR] = &&ic_chr,
-		[IC_POW] = &&ic_pow,
-		[IC_ADD] = &&ic_add,
-		[IC_EQ] = &&ic_eq,
-		[IC_SUB] = &&ic_sub,
-		[IC_DIV] = &&ic_div,
-		[IC_MUL] = &&ic_mul,
-		[IC_DEREF] = &&ic_deref,
-		[IC_AND] = &&ic_and,
-		[IC_ADDR_OF] = &&ic_addr_of,
-		[IC_XOR] = &&ic_xor,
-		[IC_MOD] = &&ic_mod,
-		[IC_OR] = &&ic_or,
-		[IC_LT] = &&ic_lt,
-		[IC_GT] = &&ic_gt,
-		[IC_LNOT] = &&ic_lnot,
-		[IC_BNOT] = &&ic_bnot,
-		[IC_POST_INC] = &&ic_post_inc,
-		[IC_POST_DEC] = &&ic_post_dec,
-		[IC_PRE_INC] = &&ic_pre_inc,
-		[IC_PRE_DEC] = &&ic_pre_dec,
-		[IC_AND_AND] = &&ic_and_and,
-		[IC_OR_OR] = &&ic_or_or,
-		[IC_XOR_XOR] = &&ic_xor_xor,
-		[IC_EQ_EQ] = &&ic_eq_eq,
-		[IC_NE] = &&ic_ne,
-		[IC_LE] = &&ic_le,
-		[IC_GE] = &&ic_ge,
-		[IC_LSH] = &&ic_lsh,
-		[IC_RSH] = &&ic_rsh,
-		[IC_ADD_EQ] = &&ic_add_eq,
-		[IC_SUB_EQ] = &&ic_sub_eq,
-		[IC_MUL_EQ] = &&ic_mul_eq,
-		[IC_DIV_EQ] = &&ic_div_eq,
-		[IC_LSH_EQ] = &&ic_lsh_eq,
-		[IC_RSH_EQ] = &&ic_rsh_eq,
-		[IC_AND_EQ] = &&ic_and_eq,
-		[IC_OR_EQ] = &&ic_or_eq,
-		[IC_XOR_EQ] = &&ic_xor_eq,
-		[IC_MOD_EQ] = &&ic_mod_eq,
-		[IC_I64] = &&ic_i64,
-		[IC_F64] = &&ic_f64,
-		[IC_ARRAY_ACC] = &&ic_array_acc,
-		[IC_RET] = &&ic_ret,
-		[IC_CALL] = &&ic_call,
-		[IC_COMMA] = &&ic_comma,
-		[IC_UNBOUNDED_SWITCH] = &&ic_unbounded_switch,
-		[IC_BOUNDED_SWITCH] = &&ic_bounded_switch,
-		[IC_SUB_RET] = &&ic_sub_ret,
-		[IC_SUB_PROLOG] = &&ic_sub_prolog,
-		[IC_SUB_CALL] = &&ic_sub_call,
-		[IC_TYPECAST] = &&ic_typecast,
-		[IC_BASE_PTR] = &&ic_base_ptr,
-		[IC_IREG] = &&ic_ireg,
-		[IC_FREG] = &&ic_freg,
-		[__IC_VARGS] = &&ic_vargs,
-		[IC_RELOC] = &&ic_reloc,
-		[__IC_CALL] = &&ic_call,
-		[__IC_STATIC_REF] = &&ic_static_ref,
-		[__IC_SET_STATIC_DATA] = &&ic_set_static_data,
-		[IC_SHORT_ADDR] = &&ic_short_addr,
-		[IC_BT] = &&ic_bt,
-		[IC_BTC] = &&ic_btc,
-		[IC_BTS] = &&ic_bts,
-		[IC_BTR] = &&ic_btr,
-		[IC_LBTC] = &&ic_lbtc,
-		[IC_LBTS] = &&ic_lbts,
-		[IC_LBTR] = &&ic_lbtr,
-		[IC_MAX_I64] = &&ic_max_i64,
-		[IC_MIN_I64] = &&ic_min_i64,
-		[IC_MAX_U64] = &&ic_max_u64,
-		[IC_MIN_U64] = &&ic_min_i64,
-		[IC_SIGN_I64] = &&ic_sign_i64,
-		[IC_SQR_I64] = &&ic_sqr_i64,
-		[IC_SQR_U64] = &&ic_sqr_u64,
-		[IC_SQR] = &&ic_sqr,
-		[IC_ABS] = &&ic_abs,
-		[IC_SQRT] = &&ic_sqrt,
-		[IC_SIN] = &&ic_sin,
-		[IC_COS] = &&ic_cos,
-		[IC_TAN] = &&ic_tan,
-		[IC_ATAN] = &&ic_atan,
-		[IC_RAW_BYTES]= &&ic_raw_bytes,
-	};
-	if (!poop_ants[rpn->type])
-		goto ret;
-	goto* poop_ants[rpn->type];
-	do {
-	ic_short_addr:
-		if (rpn->res.mode == MD_REG)
-			into_reg = rpn->res.reg;
-		else
-			into_reg = 0;
-		tmp.mode = __MD_X86_64_SIB;
-		tmp.raw_type = RT_I64i;
-		tmp.reg = RIP;
-		tmp.__SIB_scale = -1;
-		tmp.reg2 = -1;
-		// CCF_AOT_COMPILE will trigger a IET_REL_I32 on this location
-		tmp.off = rpn->integer;
-		AIWNIOS_ADD_CODE(X86LeaSIB, into_reg, -1, -1, RIP, tmp.off);
-		if (bin)
-			CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
-		if (rpn->res.mode != MD_REG) {
-			tmp.mode = MD_REG;
-			tmp.raw_type = RT_I64i;
-			tmp.reg = 0;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		}
-		break;
-	ic_reloc:
-		if (rpn->res.mode == MD_REG)
-			into_reg = rpn->res.reg;
-		else
-			into_reg = 0;
-		misc = rpn->code_misc;
-		i = -code_off + misc->aot_before_hint;
-		AIWNIOS_ADD_CODE(X86MovRegIndirI64, into_reg, -1, -1, RIP, X86MovRegIndirI64(NULL, into_reg, -1, -1, RIP, 0)); // X86MovRegIndirI64 Will return inst length
-		CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
-		if (rpn->res.mode != MD_REG) {
-			tmp.mode = MD_REG;
-			tmp.raw_type = RT_I64i;
-			tmp.reg = 0;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		}
-		break;
-	ic_goto_if:
-		reverse = 0;
-		next = rpn->base.next;
-	gti_enter:
-		if (!IsCompoundCompare(next))
-			switch (next->type) {
-				break;
-			case IC_LNOT:
-				reverse = !reverse;
-				next = next->base.next;
-				goto gti_enter;
-				break;
-			case IC_EQ_EQ:
-#define CMP_AND_JMP(COND)                                                                                   \
-	{                                                                                                       \
-		next3 = next->base.next;                                                                            \
-		next2 = ICFwd(next3);                                                                               \
-		PushTmpDepthFirst(cctrl, next3, SpillsTmpRegs(next2));                                              \
-		PushTmpDepthFirst(cctrl, next2, 0);                                                                 \
-		PopTmp(cctrl, next2);                                                                               \
-		PopTmp(cctrl, next3);                                                                               \
-		if (next3->raw_type != RT_F64 && next2->raw_type != RT_F64 && IsConst(next3) &&Is32Bit(next3->integer)) { \
-			if(ModeIsDerefToSIB(next2)) { \
-				code_off = DerefToICArg(cctrl, &tmp, next2, AIWNIOS_TMP_IREG_POOP, bin, code_off);  \
-				switch(next2->raw_type) { \
-					case RT_I8i: \
-					case RT_U8i: \
-						AIWNIOS_ADD_CODE(X86CmpSIB8Imm,next3->integer,tmp.__SIB_scale,tmp.reg2,tmp.reg,tmp.off); \
-					break; \
-					case RT_I16i: \
-					case RT_U16i: \
-						AIWNIOS_ADD_CODE(X86CmpSIB16Imm,next3->integer,tmp.__SIB_scale,tmp.reg2,tmp.reg,tmp.off); \
-					break; \
-					case RT_I32i: \
-					case RT_U32i: \
-						AIWNIOS_ADD_CODE(X86CmpSIB16Imm,next3->integer,tmp.__SIB_scale,tmp.reg2,tmp.reg,tmp.off); \
-					break; \
-					default: \
-						AIWNIOS_ADD_CODE(X86CmpSIB64Imm,next3->integer,tmp.__SIB_scale,tmp.reg2,tmp.reg,tmp.off); \
-				} \
-			}  else {\
-				code_off = __OptPassFinal(cctrl, next2, bin, code_off);                                     \
-				code_off = PutICArgIntoReg(cctrl, &next2->res, RT_I64i, AIWNIOS_TMP_IREG_POOP2, bin, code_off); \
-				AIWNIOS_ADD_CODE(X86CmpRegImm,next2->res.reg,next3->integer); \
-			} \
-		} else if (next3->raw_type == RT_F64 || next2->raw_type == RT_F64) {                                       \
-			code_off = __OptPassFinal(cctrl, next3, bin, code_off);                                         \
-			code_off = __OptPassFinal(cctrl, next2, bin, code_off);                                         \
-			code_off = PutICArgIntoReg(cctrl, &next2->res, RT_F64, 1, bin, code_off);                       \
-			code_off = PutICArgIntoReg(cctrl, &next3->res, RT_F64, 0, bin, code_off);                       \
-			AIWNIOS_ADD_CODE(X86COMISDRegReg, next2->res.reg, next3->res.reg);                              \
-		} else if (ModeIsDerefToSIB(next3) && RawTypeIs64(next3->res.raw_type)) {                           \
-			code_off = DerefToICArg(cctrl, &tmp, next3, AIWNIOS_TMP_IREG_POOP, bin, code_off);              \
-			code_off = __OptPassFinal(cctrl, next2, bin, code_off);                                         \
-			code_off = PutICArgIntoReg(cctrl, &next2->res, RT_I64i, AIWNIOS_TMP_IREG_POOP2, bin, code_off); \
-			AIWNIOS_ADD_CODE(X86CmpRegSIB64, next2->res.reg, tmp.__SIB_scale, tmp.reg2, tmp.reg, tmp.off);  \
-		} else if (ModeIsDerefToSIB(next2) && RawTypeIs64(next2->res.raw_type)) {                           \
-			code_off = __OptPassFinal(cctrl, next3, bin, code_off);                                         \
-			code_off = DerefToICArg(cctrl, &tmp, next2, AIWNIOS_TMP_IREG_POOP, bin, code_off);              \
-			code_off = PutICArgIntoReg(cctrl, &next3->res, RT_I64i, AIWNIOS_TMP_IREG_POOP2, bin, code_off); \
-			AIWNIOS_ADD_CODE(X86CmpSIBReg64, next3->res.reg, tmp.__SIB_scale, tmp.reg2, tmp.reg, tmp.off);  \
-		} else {                                                                                            \
-			code_off = __OptPassFinal(cctrl, next3, bin, code_off);                                         \
-			code_off = __OptPassFinal(cctrl, next2, bin, code_off);                                         \
-			code_off = PutICArgIntoReg(cctrl, &next2->res, RT_I64i, AIWNIOS_TMP_IREG_POOP2, bin, code_off); \
-			code_off = PutICArgIntoReg(cctrl, &next3->res, RT_I64i, AIWNIOS_TMP_IREG_POOP, bin, code_off);  \
-			AIWNIOS_ADD_CODE(X86CmpRegReg, next2->res.reg, next3->res.reg);                                 \
-		}                                                                                                   \
-		AIWNIOS_ADD_CODE(X86Jcc, (COND) ^ reverse, 6);                                                      \
-		CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);                                                 \
-	}
-				CMP_AND_JMP(X86_COND_E);
-				goto ret;
-				break;
-			case IC_NE:
-				CMP_AND_JMP(X86_COND_E | 1);
-				goto ret;
-				break;
-			case IC_LT:
-				next3 = next->base.next;
-				next2 = ICFwd(next3);
-				if (next3->raw_type == RT_U64i || next2->raw_type == RT_U64i || next3->raw_type == RT_F64 || next2->raw_type == RT_F64) {
-					CMP_AND_JMP(X86_COND_B);
-				} else {
-					CMP_AND_JMP(X86_COND_L);
-				}
-				goto ret;
-				break;
-			case IC_GT:
-				next3 = next->base.next;
-				next2 = ICFwd(next3);
-				if (next3->raw_type == RT_U64i || next2->raw_type == RT_U64i || next3->raw_type == RT_F64 || next2->raw_type == RT_F64) {
-					CMP_AND_JMP(X86_COND_A);
-				} else {
-					CMP_AND_JMP(X86_COND_G);
-				}
-				goto ret;
-				break;
-			case IC_LE:
-				next3 = next->base.next;
-				next2 = ICFwd(next3);
-				if (next3->raw_type == RT_U64i || next2->raw_type == RT_U64i || next3->raw_type == RT_F64 || next2->raw_type == RT_F64) {
-					CMP_AND_JMP(X86_COND_BE);
-				} else {
-					CMP_AND_JMP(X86_COND_LE);
-				}
-				goto ret;
-				break;
-			case IC_GE:
-				next3 = next->base.next;
-				next2 = ICFwd(next3);
-				if (next3->raw_type == RT_U64i || next2->raw_type == RT_U64i || next3->raw_type == RT_F64 || next2->raw_type == RT_F64) {
-					CMP_AND_JMP(X86_COND_AE);
-				} else {
-					CMP_AND_JMP(X86_COND_GE);
-				}
-				goto ret;
-			case IC_BT:
-			case IC_BTC:
-			case IC_BTS:
-			case IC_BTR:
-			case IC_LBTC:
-			case IC_LBTS:
-			case IC_LBTR:
-				PushTmpDepthFirst(cctrl, next, 0);
-				PopTmp(cctrl, next);
-				if (!rpn->code_misc2)
-					rpn->code_misc2 = CodeMiscNew(cctrl, CMT_LABEL);
-				if (!reverse) {
-					cctrl->backend_user_data5 = (int64_t)rpn->code_misc2;
-					cctrl->backend_user_data6 = (int64_t)rpn->code_misc;
-					code_off = __OptPassFinal(cctrl, next, bin, code_off);
-					rpn->code_misc2->addr = bin + code_off;
-					goto ret;
-				} else {
-					cctrl->backend_user_data5 = (int64_t)rpn->code_misc;
-					cctrl->backend_user_data6 = (int64_t)rpn->code_misc2;
-					code_off = __OptPassFinal(cctrl, next, bin, code_off);
-					rpn->code_misc2->addr = bin + code_off;
-					goto ret;
-				}
-			case IC_OR_OR:
-			case IC_AND_AND:
-				PushTmpDepthFirst(cctrl, next, 0);
-				PopTmp(cctrl, next);
-				if (!rpn->code_misc2)
-					rpn->code_misc2 = CodeMiscNew(cctrl, CMT_LABEL);
-				if (!reverse) {
-					cctrl->backend_user_data5 = (int64_t)rpn->code_misc2;
-					cctrl->backend_user_data6 = (int64_t)rpn->code_misc;
-					code_off = __OptPassFinal(cctrl, next, bin, code_off);
-					rpn->code_misc2->addr = bin + code_off;
-					goto ret;
-				} else {
-					cctrl->backend_user_data5 = (int64_t)rpn->code_misc;
-					cctrl->backend_user_data6 = (int64_t)rpn->code_misc2;
-					code_off = __OptPassFinal(cctrl, next, bin, code_off);
-					rpn->code_misc2->addr = bin + code_off;
-					goto ret;
-				}
-			}
-		PushTmpDepthFirst(cctrl, next, 0);
-		PopTmp(cctrl, next);
-		code_off = __OptPassFinal(cctrl, next, bin, code_off);
-		if (next->res.set_flags) {
-			if (!reverse) {
-				AIWNIOS_ADD_CODE(X86Jcc, X86_COND_E | 1, 6);
-				CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
-			} else {
-				AIWNIOS_ADD_CODE(X86Jcc, X86_COND_E, 6);
-				CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
-			}
-		} else if (next->raw_type == RT_F64) {
-			code_off = PutICArgIntoReg(cctrl, &next->res, RT_F64, 1, bin, code_off);
-			code_off = __ICMoveF64(cctrl, 0, 0, bin, code_off);
-			AIWNIOS_ADD_CODE(X86COMISDRegReg, next->res.reg, 0);
-			if (!reverse) {
-				AIWNIOS_ADD_CODE(X86Jcc, X86_COND_E | 1, 6);
-				CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
-			} else {
-				AIWNIOS_ADD_CODE(X86Jcc, X86_COND_E, 6);
-				CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
-			}
-		} else {
-			code_off = PutICArgIntoReg(cctrl, &next->res, RT_I64i, 0, bin, code_off);
-			AIWNIOS_ADD_CODE(X86Test, next->res.reg, next->res.reg);
-			if (!reverse) {
-				AIWNIOS_ADD_CODE(X86Jcc, X86_COND_E | 1, 6);
-				CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
-			} else {
-				AIWNIOS_ADD_CODE(X86Jcc, X86_COND_E, 6);
-				CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
-			}
-		}
-		break;
-		// These both do the same thing,only thier type detirmines what happens
-	ic_to_i64:
-	ic_to_f64:
-		next = rpn->base.next;
-		code_off = __OptPassFinal(cctrl, next, bin, code_off);
-		if (rpn->res.keep_in_tmp)
-			rpn->res = next->res;
-		code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
-		break;
-	ic_typecast:
-		next = rpn->base.next;
-		if (next->raw_type == RT_F64 && rpn->raw_type != RT_F64) {
-			code_off = __OptPassFinal(cctrl, next, bin, code_off);
-			code_off = PutICArgIntoReg(cctrl, &next->res, next->raw_type, 0, bin, code_off);
-			tmp.mode = MD_REG;
-			tmp.reg = 0;
-			tmp.raw_type = rpn->raw_type;
-			if (rpn->res.mode == MD_REG)
-				tmp.reg = rpn->res.reg;
-			AIWNIOS_ADD_CODE(X86MovQI64F64, tmp.reg, next->res.reg);
-			if (rpn->res.keep_in_tmp)
-				rpn->res = next->res;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		} else if (next->raw_type != RT_F64 && rpn->raw_type == RT_F64) {
-			code_off = __OptPassFinal(cctrl, next, bin, code_off);
-			code_off = PutICArgIntoReg(cctrl, &next->res, next->raw_type, 0, bin, code_off);
-			tmp.mode = MD_REG;
-			tmp.reg = 0;
-			tmp.raw_type = rpn->raw_type;
-			if (rpn->res.mode == MD_REG)
-				tmp.reg = rpn->res.reg;
-			AIWNIOS_ADD_CODE(X86MovQF64I64, tmp.reg, next->res.reg);
-			if (rpn->res.keep_in_tmp)
-				rpn->res = next->res;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		} else if (next->type == IC_DEREF) {
-			code_off = DerefToICArg(cctrl, &tmp, next, 1, bin, code_off);
-			tmp.raw_type = rpn->raw_type;
-			if (rpn->res.keep_in_tmp)
-				rpn->res = next->res;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		} else {
-			code_off = __OptPassFinal(cctrl, next, bin, code_off);
-			if (rpn->res.keep_in_tmp)
-				rpn->res = next->res;
-			code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
-		}
-		break;
-	ic_goto:
-		if (cctrl->code_ctrl->final_pass) {
-			AIWNIOS_ADD_CODE(X86Jmp, 5); // 1 for opcode,4 for offsetr
-			CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
-		} else
-			AIWNIOS_ADD_CODE(X86Jmp, 0);
-		break;
-	ic_label:
-		rpn->code_misc->addr = bin + code_off;
-		break;
-	ic_global:
-		//
-		// Here's the deal. Global arrays should be acceessed via
-		// IC_ADDR_OF. So loading int register here
-		//
-		if (rpn->global_var->base.type & HTT_FUN) {
-			next = rpn;
-			goto get_glbl_ptr;
-		} else {
-			assert(!rpn->global_var->dim.next);
-			tmp.mode = MD_PTR;
-			tmp.off = (int64_t)rpn->global_var->data_addr;
-			tmp.raw_type = rpn->global_var->var_class->raw_type;
-			if (rpn->res.keep_in_tmp)
-				rpn->res = next->res;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		}
-		break;
-	ic_nop:
-		// Bungis
-		break;
-		abort();
-		break;
-	ic_neg:
-#define BACKEND_UNOP(flt_op, int_op)                          \
-	next = rpn->base.next;                                    \
-	code_off = __OptPassFinal(cctrl, next, bin, code_off);    \
-	into_reg = 0;                                             \
-	if (rpn->res.mode == MD_REG)                              \
-		into_reg = rpn->res.reg;                              \
-	if (rpn->res.mode == MD_NULL)                             \
-		break;                                                \
-	tmp.mode = MD_REG;                                        \
-	tmp.raw_type = RT_I64i;                                   \
-	tmp.reg = into_reg;                                       \
-	code_off = ICMov(cctrl, &tmp, &next->res, bin, code_off); \
-	if (rpn->raw_type == RT_F64) {                            \
-		AIWNIOS_ADD_CODE(flt_op, into_reg);                   \
-	} else                                                    \
-		AIWNIOS_ADD_CODE(int_op, into_reg);                   \
-	if (rpn->res.keep_in_tmp)                                 \
-		rpn->res = next->res;                                 \
-	code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		if (rpn->raw_type == RT_F64) {
-			next = ICArgN(rpn, 0);
-			static double ul;
-			((int64_t*)&ul)[0] = 0x80000000ll << 32;
-			code_off = __OptPassFinal(cctrl, next, bin, code_off);
-			tmp = rpn->res;
-			code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
-			code_off = PutICArgIntoReg(cctrl, &tmp, RT_F64, 1, bin, code_off);
-			code_off = __ICMoveF64(cctrl, 0, ul, bin, code_off);
-			AIWNIOS_ADD_CODE(X86XorPDReg, tmp.reg, 0);
-			if (rpn->res.keep_in_tmp)
-				rpn->res = tmp;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		} else {
-			BACKEND_UNOP(X86NegReg, X86NegReg);
-			if(rpn->raw_type!=RT_F64)
-				rpn->res.set_flags=1;
-		}
-		break;
-	ic_pos:
-		next = ICArgN(rpn, 0);
-		code_off = __OptPassFinal(cctrl, next, bin, code_off);
-		if (rpn->res.keep_in_tmp)
-			rpn->res = next->res;
-		code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
-		break;
-		abort();
-		break;
-	ic_str:
-		if (rpn->res.mode == MD_REG) {
-			into_reg = rpn->res.reg;
-		} else
-			into_reg = 0; // Store into reg 0
+int64_t __OptPassFinal(CCmpCtrl *cctrl, CRPN *rpn, char *bin,
+                       int64_t code_off) {
+  CCodeMisc *misc, *misc2;
+  CRPN *next, *next2, **range, **range_args, *next3, *a, *b;
+  CICArg tmp = {0}, orig_dst = {0}, tmp2 = {0}, derefed = {0};
+  int64_t i = 0, cnt, i2, use_reg, a_reg, b_reg, into_reg, use_flt_cmp, reverse,
+          is_typecast;
+  int64_t *range_cmp_types, use_flags = rpn->res.set_flags;
+  CCodeMisc *old_fail_misc = (CCodeMisc *)cctrl->backend_user_data5,
+            *old_pass_misc = (CCodeMisc *)cctrl->backend_user_data6;
+  cctrl->backend_user_data5 = 0;
+  cctrl->backend_user_data6 = 0;
+  rpn->res.set_flags = 0;
+  if (rpn->flags & ICF_PRECOMPUTED)
+    goto ret;
+  char *enter_addr2, *enter_addr, *exit_addr, **fail1_addr, **fail2_addr,
+      ***range_fail_addrs;
+  if (cctrl->code_ctrl->dbg_info && cctrl->code_ctrl->final_pass &&
+      rpn->ic_line) { // Final run
+    if (MSize(cctrl->code_ctrl->dbg_info) / 8 >
+        rpn->ic_line - cctrl->code_ctrl->min_ln) {
+      i = (int64_t)(cctrl->code_ctrl
+                        ->dbg_info[rpn->ic_line - cctrl->code_ctrl->min_ln]);
+      if (!i)
+        cctrl->code_ctrl->dbg_info[rpn->ic_line - cctrl->code_ctrl->min_ln] =
+            bin + code_off;
+      else if ((int64_t)bin + code_off < i)
+        cctrl->code_ctrl->dbg_info[rpn->ic_line - cctrl->code_ctrl->min_ln] =
+            bin + code_off;
+    }
+  }
+  static const void *poop_ants[IC_CNT] = {
+      [IC_GOTO] = &&ic_goto,
+      [IC_GOTO_IF] = &&ic_goto_if,
+      [IC_TO_I64] = &&ic_to_i64,
+      [IC_TO_F64] = &&ic_to_f64,
+      [IC_LABEL] = &&ic_label,
+      [IC_STATIC] = &&ic_static,
+      [IC_GLOBAL] = &&ic_global,
+      [IC_NOP] = &&ic_nop,
+      [IC_NEG] = &&ic_neg,
+      [IC_POS] = &&ic_pos,
+      [IC_STR] = &&ic_str,
+      [IC_CHR] = &&ic_chr,
+      [IC_POW] = &&ic_pow,
+      [IC_ADD] = &&ic_add,
+      [IC_EQ] = &&ic_eq,
+      [IC_SUB] = &&ic_sub,
+      [IC_DIV] = &&ic_div,
+      [IC_MUL] = &&ic_mul,
+      [IC_DEREF] = &&ic_deref,
+      [IC_AND] = &&ic_and,
+      [IC_ADDR_OF] = &&ic_addr_of,
+      [IC_XOR] = &&ic_xor,
+      [IC_MOD] = &&ic_mod,
+      [IC_OR] = &&ic_or,
+      [IC_LT] = &&ic_lt,
+      [IC_GT] = &&ic_gt,
+      [IC_LNOT] = &&ic_lnot,
+      [IC_BNOT] = &&ic_bnot,
+      [IC_POST_INC] = &&ic_post_inc,
+      [IC_POST_DEC] = &&ic_post_dec,
+      [IC_PRE_INC] = &&ic_pre_inc,
+      [IC_PRE_DEC] = &&ic_pre_dec,
+      [IC_AND_AND] = &&ic_and_and,
+      [IC_OR_OR] = &&ic_or_or,
+      [IC_XOR_XOR] = &&ic_xor_xor,
+      [IC_EQ_EQ] = &&ic_eq_eq,
+      [IC_NE] = &&ic_ne,
+      [IC_LE] = &&ic_le,
+      [IC_GE] = &&ic_ge,
+      [IC_LSH] = &&ic_lsh,
+      [IC_RSH] = &&ic_rsh,
+      [IC_ADD_EQ] = &&ic_add_eq,
+      [IC_SUB_EQ] = &&ic_sub_eq,
+      [IC_MUL_EQ] = &&ic_mul_eq,
+      [IC_DIV_EQ] = &&ic_div_eq,
+      [IC_LSH_EQ] = &&ic_lsh_eq,
+      [IC_RSH_EQ] = &&ic_rsh_eq,
+      [IC_AND_EQ] = &&ic_and_eq,
+      [IC_OR_EQ] = &&ic_or_eq,
+      [IC_XOR_EQ] = &&ic_xor_eq,
+      [IC_MOD_EQ] = &&ic_mod_eq,
+      [IC_I64] = &&ic_i64,
+      [IC_F64] = &&ic_f64,
+      [IC_ARRAY_ACC] = &&ic_array_acc,
+      [IC_RET] = &&ic_ret,
+      [IC_CALL] = &&ic_call,
+      [IC_COMMA] = &&ic_comma,
+      [IC_UNBOUNDED_SWITCH] = &&ic_unbounded_switch,
+      [IC_BOUNDED_SWITCH] = &&ic_bounded_switch,
+      [IC_SUB_RET] = &&ic_sub_ret,
+      [IC_SUB_PROLOG] = &&ic_sub_prolog,
+      [IC_SUB_CALL] = &&ic_sub_call,
+      [IC_TYPECAST] = &&ic_typecast,
+      [IC_BASE_PTR] = &&ic_base_ptr,
+      [IC_IREG] = &&ic_ireg,
+      [IC_FREG] = &&ic_freg,
+      [__IC_VARGS] = &&ic_vargs,
+      [IC_RELOC] = &&ic_reloc,
+      [__IC_CALL] = &&ic_call,
+      [__IC_STATIC_REF] = &&ic_static_ref,
+      [__IC_SET_STATIC_DATA] = &&ic_set_static_data,
+      [IC_SHORT_ADDR] = &&ic_short_addr,
+      [IC_BT] = &&ic_bt,
+      [IC_BTC] = &&ic_btc,
+      [IC_BTS] = &&ic_bts,
+      [IC_BTR] = &&ic_btr,
+      [IC_LBTC] = &&ic_lbtc,
+      [IC_LBTS] = &&ic_lbts,
+      [IC_LBTR] = &&ic_lbtr,
+      [IC_MAX_I64] = &&ic_max_i64,
+      [IC_MIN_I64] = &&ic_min_i64,
+      [IC_MAX_U64] = &&ic_max_u64,
+      [IC_MIN_U64] = &&ic_min_i64,
+      [IC_SIGN_I64] = &&ic_sign_i64,
+      [IC_SQR_I64] = &&ic_sqr_i64,
+      [IC_SQR_U64] = &&ic_sqr_u64,
+      [IC_SQR] = &&ic_sqr,
+      [IC_ABS] = &&ic_abs,
+      [IC_SQRT] = &&ic_sqrt,
+      [IC_SIN] = &&ic_sin,
+      [IC_COS] = &&ic_cos,
+      [IC_TAN] = &&ic_tan,
+      [IC_ATAN] = &&ic_atan,
+      [IC_RAW_BYTES] = &&ic_raw_bytes,
+  };
+  if (!poop_ants[rpn->type])
+    goto ret;
+  goto *poop_ants[rpn->type];
+  do {
+  ic_short_addr:
+    if (rpn->res.mode == MD_REG)
+      into_reg = rpn->res.reg;
+    else
+      into_reg = 0;
+    tmp.mode = __MD_X86_64_SIB;
+    tmp.raw_type = RT_I64i;
+    tmp.reg = RIP;
+    tmp.__SIB_scale = -1;
+    tmp.reg2 = -1;
+    // CCF_AOT_COMPILE will trigger a IET_REL_I32 on this location
+    tmp.off = rpn->integer;
+    AIWNIOS_ADD_CODE(X86LeaSIB, into_reg, -1, -1, RIP, tmp.off);
+    if (bin)
+      CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
+    if (rpn->res.mode != MD_REG) {
+      tmp.mode = MD_REG;
+      tmp.raw_type = RT_I64i;
+      tmp.reg = 0;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    }
+    break;
+  ic_reloc:
+    if (rpn->res.mode == MD_REG)
+      into_reg = rpn->res.reg;
+    else
+      into_reg = 0;
+    misc = rpn->code_misc;
+    i = -code_off + misc->aot_before_hint;
+    AIWNIOS_ADD_CODE(
+        X86MovRegIndirI64, into_reg, -1, -1, RIP,
+        X86MovRegIndirI64(NULL, into_reg, -1, -1, RIP,
+                          0)); // X86MovRegIndirI64 Will return inst length
+    CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
+    if (rpn->res.mode != MD_REG) {
+      tmp.mode = MD_REG;
+      tmp.raw_type = RT_I64i;
+      tmp.reg = 0;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    }
+    break;
+  ic_goto_if:
+    reverse = 0;
+    next = rpn->base.next;
+  gti_enter:
+    if (!IsCompoundCompare(next))
+      switch (next->type) {
+        break;
+      case IC_LNOT:
+        reverse = !reverse;
+        next = next->base.next;
+        goto gti_enter;
+        break;
+      case IC_EQ_EQ:
+#define CMP_AND_JMP(COND)                                                      \
+  {                                                                            \
+    next3 = next->base.next;                                                   \
+    next2 = ICFwd(next3);                                                      \
+    PushTmpDepthFirst(cctrl, next3, SpillsTmpRegs(next2));                     \
+    PushTmpDepthFirst(cctrl, next2, 0);                                        \
+    PopTmp(cctrl, next2);                                                      \
+    PopTmp(cctrl, next3);                                                      \
+    if (next3->raw_type != RT_F64 && next2->raw_type != RT_F64 &&              \
+        IsConst(next3) && Is32Bit(next3->integer)) {                           \
+      if (ModeIsDerefToSIB(next2)) {                                           \
+        code_off = DerefToICArg(cctrl, &tmp, next2, AIWNIOS_TMP_IREG_POOP,     \
+                                bin, code_off);                                \
+        switch (next2->raw_type) {                                             \
+        case RT_I8i:                                                           \
+        case RT_U8i:                                                           \
+          AIWNIOS_ADD_CODE(X86CmpSIB8Imm, next3->integer, tmp.__SIB_scale,     \
+                           tmp.reg2, tmp.reg, tmp.off);                        \
+          break;                                                               \
+        case RT_I16i:                                                          \
+        case RT_U16i:                                                          \
+          AIWNIOS_ADD_CODE(X86CmpSIB16Imm, next3->integer, tmp.__SIB_scale,    \
+                           tmp.reg2, tmp.reg, tmp.off);                        \
+          break;                                                               \
+        case RT_I32i:                                                          \
+        case RT_U32i:                                                          \
+          AIWNIOS_ADD_CODE(X86CmpSIB16Imm, next3->integer, tmp.__SIB_scale,    \
+                           tmp.reg2, tmp.reg, tmp.off);                        \
+          break;                                                               \
+        default:                                                               \
+          AIWNIOS_ADD_CODE(X86CmpSIB64Imm, next3->integer, tmp.__SIB_scale,    \
+                           tmp.reg2, tmp.reg, tmp.off);                        \
+        }                                                                      \
+      } else {                                                                 \
+        code_off = __OptPassFinal(cctrl, next2, bin, code_off);                \
+        code_off = PutICArgIntoReg(cctrl, &next2->res, RT_I64i,                \
+                                   AIWNIOS_TMP_IREG_POOP2, bin, code_off);     \
+        AIWNIOS_ADD_CODE(X86CmpRegImm, next2->res.reg, next3->integer);        \
+      }                                                                        \
+    } else if (next3->raw_type == RT_F64 || next2->raw_type == RT_F64) {       \
+      code_off = __OptPassFinal(cctrl, next3, bin, code_off);                  \
+      code_off = __OptPassFinal(cctrl, next2, bin, code_off);                  \
+      code_off =                                                               \
+          PutICArgIntoReg(cctrl, &next2->res, RT_F64, 1, bin, code_off);       \
+      code_off =                                                               \
+          PutICArgIntoReg(cctrl, &next3->res, RT_F64, 0, bin, code_off);       \
+      AIWNIOS_ADD_CODE(X86COMISDRegReg, next2->res.reg, next3->res.reg);       \
+    } else if (ModeIsDerefToSIB(next3) && RawTypeIs64(next3->res.raw_type)) {  \
+      code_off = DerefToICArg(cctrl, &tmp, next3, AIWNIOS_TMP_IREG_POOP, bin,  \
+                              code_off);                                       \
+      code_off = __OptPassFinal(cctrl, next2, bin, code_off);                  \
+      code_off = PutICArgIntoReg(cctrl, &next2->res, RT_I64i,                  \
+                                 AIWNIOS_TMP_IREG_POOP2, bin, code_off);       \
+      AIWNIOS_ADD_CODE(X86CmpRegSIB64, next2->res.reg, tmp.__SIB_scale,        \
+                       tmp.reg2, tmp.reg, tmp.off);                            \
+    } else if (ModeIsDerefToSIB(next2) && RawTypeIs64(next2->res.raw_type)) {  \
+      code_off = __OptPassFinal(cctrl, next3, bin, code_off);                  \
+      code_off = DerefToICArg(cctrl, &tmp, next2, AIWNIOS_TMP_IREG_POOP, bin,  \
+                              code_off);                                       \
+      code_off = PutICArgIntoReg(cctrl, &next3->res, RT_I64i,                  \
+                                 AIWNIOS_TMP_IREG_POOP2, bin, code_off);       \
+      AIWNIOS_ADD_CODE(X86CmpSIBReg64, next3->res.reg, tmp.__SIB_scale,        \
+                       tmp.reg2, tmp.reg, tmp.off);                            \
+    } else {                                                                   \
+      code_off = __OptPassFinal(cctrl, next3, bin, code_off);                  \
+      code_off = __OptPassFinal(cctrl, next2, bin, code_off);                  \
+      code_off = PutICArgIntoReg(cctrl, &next2->res, RT_I64i,                  \
+                                 AIWNIOS_TMP_IREG_POOP2, bin, code_off);       \
+      code_off = PutICArgIntoReg(cctrl, &next3->res, RT_I64i,                  \
+                                 AIWNIOS_TMP_IREG_POOP, bin, code_off);        \
+      AIWNIOS_ADD_CODE(X86CmpRegReg, next2->res.reg, next3->res.reg);          \
+    }                                                                          \
+    AIWNIOS_ADD_CODE(X86Jcc, (COND) ^ reverse, 6);                             \
+    CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);                        \
+  }
+        CMP_AND_JMP(X86_COND_E);
+        goto ret;
+        break;
+      case IC_NE:
+        CMP_AND_JMP(X86_COND_E | 1);
+        goto ret;
+        break;
+      case IC_LT:
+        next3 = next->base.next;
+        next2 = ICFwd(next3);
+        if (next3->raw_type == RT_U64i || next2->raw_type == RT_U64i ||
+            next3->raw_type == RT_F64 || next2->raw_type == RT_F64) {
+          CMP_AND_JMP(X86_COND_B);
+        } else {
+          CMP_AND_JMP(X86_COND_L);
+        }
+        goto ret;
+        break;
+      case IC_GT:
+        next3 = next->base.next;
+        next2 = ICFwd(next3);
+        if (next3->raw_type == RT_U64i || next2->raw_type == RT_U64i ||
+            next3->raw_type == RT_F64 || next2->raw_type == RT_F64) {
+          CMP_AND_JMP(X86_COND_A);
+        } else {
+          CMP_AND_JMP(X86_COND_G);
+        }
+        goto ret;
+        break;
+      case IC_LE:
+        next3 = next->base.next;
+        next2 = ICFwd(next3);
+        if (next3->raw_type == RT_U64i || next2->raw_type == RT_U64i ||
+            next3->raw_type == RT_F64 || next2->raw_type == RT_F64) {
+          CMP_AND_JMP(X86_COND_BE);
+        } else {
+          CMP_AND_JMP(X86_COND_LE);
+        }
+        goto ret;
+        break;
+      case IC_GE:
+        next3 = next->base.next;
+        next2 = ICFwd(next3);
+        if (next3->raw_type == RT_U64i || next2->raw_type == RT_U64i ||
+            next3->raw_type == RT_F64 || next2->raw_type == RT_F64) {
+          CMP_AND_JMP(X86_COND_AE);
+        } else {
+          CMP_AND_JMP(X86_COND_GE);
+        }
+        goto ret;
+      case IC_BT:
+      case IC_BTC:
+      case IC_BTS:
+      case IC_BTR:
+      case IC_LBTC:
+      case IC_LBTS:
+      case IC_LBTR:
+        PushTmpDepthFirst(cctrl, next, 0);
+        PopTmp(cctrl, next);
+        if (!rpn->code_misc2)
+          rpn->code_misc2 = CodeMiscNew(cctrl, CMT_LABEL);
+        if (!reverse) {
+          cctrl->backend_user_data5 = (int64_t)rpn->code_misc2;
+          cctrl->backend_user_data6 = (int64_t)rpn->code_misc;
+          code_off = __OptPassFinal(cctrl, next, bin, code_off);
+          rpn->code_misc2->addr = bin + code_off;
+          goto ret;
+        } else {
+          cctrl->backend_user_data5 = (int64_t)rpn->code_misc;
+          cctrl->backend_user_data6 = (int64_t)rpn->code_misc2;
+          code_off = __OptPassFinal(cctrl, next, bin, code_off);
+          rpn->code_misc2->addr = bin + code_off;
+          goto ret;
+        }
+      case IC_OR_OR:
+      case IC_AND_AND:
+        PushTmpDepthFirst(cctrl, next, 0);
+        PopTmp(cctrl, next);
+        if (!rpn->code_misc2)
+          rpn->code_misc2 = CodeMiscNew(cctrl, CMT_LABEL);
+        if (!reverse) {
+          cctrl->backend_user_data5 = (int64_t)rpn->code_misc2;
+          cctrl->backend_user_data6 = (int64_t)rpn->code_misc;
+          code_off = __OptPassFinal(cctrl, next, bin, code_off);
+          rpn->code_misc2->addr = bin + code_off;
+          goto ret;
+        } else {
+          cctrl->backend_user_data5 = (int64_t)rpn->code_misc;
+          cctrl->backend_user_data6 = (int64_t)rpn->code_misc2;
+          code_off = __OptPassFinal(cctrl, next, bin, code_off);
+          rpn->code_misc2->addr = bin + code_off;
+          goto ret;
+        }
+      }
+    PushTmpDepthFirst(cctrl, next, 0);
+    PopTmp(cctrl, next);
+    code_off = __OptPassFinal(cctrl, next, bin, code_off);
+    if (next->res.set_flags) {
+      if (!reverse) {
+        AIWNIOS_ADD_CODE(X86Jcc, X86_COND_E | 1, 6);
+        CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
+      } else {
+        AIWNIOS_ADD_CODE(X86Jcc, X86_COND_E, 6);
+        CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
+      }
+    } else if (next->raw_type == RT_F64) {
+      code_off = PutICArgIntoReg(cctrl, &next->res, RT_F64, 1, bin, code_off);
+      code_off = __ICMoveF64(cctrl, 0, 0, bin, code_off);
+      AIWNIOS_ADD_CODE(X86COMISDRegReg, next->res.reg, 0);
+      if (!reverse) {
+        AIWNIOS_ADD_CODE(X86Jcc, X86_COND_E | 1, 6);
+        CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
+      } else {
+        AIWNIOS_ADD_CODE(X86Jcc, X86_COND_E, 6);
+        CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
+      }
+    } else {
+      code_off = PutICArgIntoReg(cctrl, &next->res, RT_I64i, 0, bin, code_off);
+      AIWNIOS_ADD_CODE(X86Test, next->res.reg, next->res.reg);
+      if (!reverse) {
+        AIWNIOS_ADD_CODE(X86Jcc, X86_COND_E | 1, 6);
+        CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
+      } else {
+        AIWNIOS_ADD_CODE(X86Jcc, X86_COND_E, 6);
+        CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
+      }
+    }
+    break;
+    // These both do the same thing,only thier type detirmines what happens
+  ic_to_i64:
+  ic_to_f64:
+    next = rpn->base.next;
+    code_off = __OptPassFinal(cctrl, next, bin, code_off);
+    if (rpn->res.keep_in_tmp)
+      rpn->res = next->res;
+    code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
+    break;
+  ic_typecast:
+    next = rpn->base.next;
+    if (next->raw_type == RT_F64 && rpn->raw_type != RT_F64) {
+      code_off = __OptPassFinal(cctrl, next, bin, code_off);
+      code_off =
+          PutICArgIntoReg(cctrl, &next->res, next->raw_type, 0, bin, code_off);
+      tmp.mode = MD_REG;
+      tmp.reg = 0;
+      tmp.raw_type = rpn->raw_type;
+      if (rpn->res.mode == MD_REG)
+        tmp.reg = rpn->res.reg;
+      AIWNIOS_ADD_CODE(X86MovQI64F64, tmp.reg, next->res.reg);
+      if (rpn->res.keep_in_tmp)
+        rpn->res = next->res;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    } else if (next->raw_type != RT_F64 && rpn->raw_type == RT_F64) {
+      code_off = __OptPassFinal(cctrl, next, bin, code_off);
+      code_off =
+          PutICArgIntoReg(cctrl, &next->res, next->raw_type, 0, bin, code_off);
+      tmp.mode = MD_REG;
+      tmp.reg = 0;
+      tmp.raw_type = rpn->raw_type;
+      if (rpn->res.mode == MD_REG)
+        tmp.reg = rpn->res.reg;
+      AIWNIOS_ADD_CODE(X86MovQF64I64, tmp.reg, next->res.reg);
+      if (rpn->res.keep_in_tmp)
+        rpn->res = next->res;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    } else if (next->type == IC_DEREF) {
+      code_off = DerefToICArg(cctrl, &tmp, next, 1, bin, code_off);
+      tmp.raw_type = rpn->raw_type;
+      if (rpn->res.keep_in_tmp)
+        rpn->res = next->res;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    } else {
+      code_off = __OptPassFinal(cctrl, next, bin, code_off);
+      if (rpn->res.keep_in_tmp)
+        rpn->res = next->res;
+      code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
+    }
+    break;
+  ic_goto:
+    if (cctrl->code_ctrl->final_pass) {
+      AIWNIOS_ADD_CODE(X86Jmp, 5); // 1 for opcode,4 for offsetr
+      CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
+    } else
+      AIWNIOS_ADD_CODE(X86Jmp, 0);
+    break;
+  ic_label:
+    rpn->code_misc->addr = bin + code_off;
+    break;
+  ic_global:
+    //
+    // Here's the deal. Global arrays should be acceessed via
+    // IC_ADDR_OF. So loading int register here
+    //
+    if (rpn->global_var->base.type & HTT_FUN) {
+      next = rpn;
+      goto get_glbl_ptr;
+    } else {
+      assert(!rpn->global_var->dim.next);
+      tmp.mode = MD_PTR;
+      tmp.off = (int64_t)rpn->global_var->data_addr;
+      tmp.raw_type = rpn->global_var->var_class->raw_type;
+      if (rpn->res.keep_in_tmp)
+        rpn->res = next->res;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    }
+    break;
+  ic_nop:
+    // Bungis
+    break;
+    abort();
+    break;
+  ic_neg:
+#define BACKEND_UNOP(flt_op, int_op)                                           \
+  next = rpn->base.next;                                                       \
+  code_off = __OptPassFinal(cctrl, next, bin, code_off);                       \
+  into_reg = 0;                                                                \
+  if (rpn->res.mode == MD_REG)                                                 \
+    into_reg = rpn->res.reg;                                                   \
+  if (rpn->res.mode == MD_NULL)                                                \
+    break;                                                                     \
+  tmp.mode = MD_REG;                                                           \
+  tmp.raw_type = RT_I64i;                                                      \
+  tmp.reg = into_reg;                                                          \
+  code_off = ICMov(cctrl, &tmp, &next->res, bin, code_off);                    \
+  if (rpn->raw_type == RT_F64) {                                               \
+    AIWNIOS_ADD_CODE(flt_op, into_reg);                                        \
+  } else                                                                       \
+    AIWNIOS_ADD_CODE(int_op, into_reg);                                        \
+  if (rpn->res.keep_in_tmp)                                                    \
+    rpn->res = next->res;                                                      \
+  code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    if (rpn->raw_type == RT_F64) {
+      next = ICArgN(rpn, 0);
+      static double ul;
+      ((int64_t *)&ul)[0] = 0x80000000ll << 32;
+      code_off = __OptPassFinal(cctrl, next, bin, code_off);
+      tmp = rpn->res;
+      code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
+      code_off = PutICArgIntoReg(cctrl, &tmp, RT_F64, 1, bin, code_off);
+      code_off = __ICMoveF64(cctrl, 0, ul, bin, code_off);
+      AIWNIOS_ADD_CODE(X86XorPDReg, tmp.reg, 0);
+      if (rpn->res.keep_in_tmp)
+        rpn->res = tmp;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    } else {
+      BACKEND_UNOP(X86NegReg, X86NegReg);
+      if (rpn->raw_type != RT_F64)
+        rpn->res.set_flags = 1;
+    }
+    break;
+  ic_pos:
+    next = ICArgN(rpn, 0);
+    code_off = __OptPassFinal(cctrl, next, bin, code_off);
+    if (rpn->res.keep_in_tmp)
+      rpn->res = next->res;
+    code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
+    break;
+    abort();
+    break;
+  ic_str:
+    if (rpn->res.mode == MD_REG) {
+      into_reg = rpn->res.reg;
+    } else
+      into_reg = 0; // Store into reg 0
 
-		if (cctrl->flags & CCF_STRINGS_ON_HEAP) {
-			//
-			// README: We will "NULL"ify the rpn->code_misc->str later so we dont free it
-			//
-			code_off = __ICMoveI64(cctrl, into_reg, (int64_t)rpn->code_misc->str, bin, code_off);
-		} else {
-			AIWNIOS_ADD_CODE(X86LeaSIB, into_reg, -1, -1, RIP, 0); // X86LeaSIB will return inst size
-			CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
-		}
-		if (rpn->res.mode != MD_REG) {
-			tmp.raw_type = rpn->raw_type;
-			tmp.reg = 0;
-			tmp.mode = MD_REG;
-			if (rpn->res.keep_in_tmp)
-				rpn->res = tmp;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		}
-		break;
-	ic_chr:
-		if (rpn->res.mode == MD_REG) {
-			into_reg = rpn->res.reg;
-		} else
-			into_reg = 0; // Store into reg 0
+    if (cctrl->flags & CCF_STRINGS_ON_HEAP) {
+      //
+      // README: We will "NULL"ify the rpn->code_misc->str later so we dont free
+      // it
+      //
+      code_off = __ICMoveI64(cctrl, into_reg, (int64_t)rpn->code_misc->str, bin,
+                             code_off);
+    } else {
+      AIWNIOS_ADD_CODE(X86LeaSIB, into_reg, -1, -1, RIP,
+                       0); // X86LeaSIB will return inst size
+      CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
+    }
+    if (rpn->res.mode != MD_REG) {
+      tmp.raw_type = rpn->raw_type;
+      tmp.reg = 0;
+      tmp.mode = MD_REG;
+      if (rpn->res.keep_in_tmp)
+        rpn->res = tmp;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    }
+    break;
+  ic_chr:
+    if (rpn->res.mode == MD_REG) {
+      into_reg = rpn->res.reg;
+    } else
+      into_reg = 0; // Store into reg 0
 
-		code_off = __ICMoveI64(cctrl, into_reg, rpn->integer, bin, code_off);
+    code_off = __ICMoveI64(cctrl, into_reg, rpn->integer, bin, code_off);
 
-		if (rpn->res.mode != MD_REG) {
-			tmp.raw_type = rpn->raw_type;
-			tmp.reg = 0;
-			tmp.mode = MD_REG;
-			if (rpn->res.keep_in_tmp)
-				rpn->res = tmp;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		}
-		break;
-	ic_pow:
-		// TODO
-		break;
-		break;
-	ic_unbounded_switch:
-		//
-		// Load poop into tmp,then we continue the sexyness as normal
-		//
-		// Also make sure R8 has lo bound(See IC_BOUNDED_SWITCH)
-		//
-		next2 = ICArgN(rpn, 0);
-		PushTmpDepthFirst(cctrl, next2, 0);
-		PopTmp(cctrl, next2);
-		code_off = __OptPassFinal(cctrl, next2, bin, code_off);
-		tmp.raw_type = RT_I64i;
-		tmp.mode = MD_REG;
-		tmp.reg = 0;
-		code_off = ICMov(cctrl, &tmp, &next2->res, bin, code_off);
-		code_off = __ICMoveI64(cctrl, R8, rpn->code_misc->lo, bin, code_off); // X1
-		goto jmp_tab_sexy;
-		break;
-	ic_bounded_switch:
-		next2 = ICArgN(rpn, 0);
-		PushTmpDepthFirst(cctrl, next2, 0);
-		PopTmp(cctrl, next2);
-		code_off = __OptPassFinal(cctrl, next2, bin, code_off);
-		tmp.raw_type = RT_I64i;
-		tmp.mode = MD_REG;
-		tmp.reg = RCX;
-		code_off = ICMov(cctrl, &tmp, &next2->res, bin, code_off);
-		code_off = __ICMoveI64(cctrl, RAX, rpn->code_misc->hi, bin, code_off);
-		code_off = __ICMoveI64(cctrl, R8, rpn->code_misc->lo, bin, code_off);
-		AIWNIOS_ADD_CODE(X86CmpRegReg, tmp.reg, R8);
-		fail1_addr = bin + code_off;
-		AIWNIOS_ADD_CODE(X86Jcc, X86_COND_L, 6);
-		CodeMiscAddRef(rpn->code_misc->dft_lab, bin + code_off - 4);
-		AIWNIOS_ADD_CODE(X86CmpRegReg, tmp.reg, RAX);
-		fail2_addr = bin + code_off;
-		AIWNIOS_ADD_CODE(X86Jcc, X86_COND_G, 6);
-		CodeMiscAddRef(rpn->code_misc->dft_lab, bin + code_off - 4);
-	jmp_tab_sexy:
-		AIWNIOS_ADD_CODE(X86LeaSIB, RDX, -1, -1, RIP, 0);
-		CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
-		//-8*rpn->code_misc->lo offsets our tmp.reg by lo
-		AIWNIOS_ADD_CODE(X86JmpSIB, 8, tmp.reg, RDX, -8 * rpn->code_misc->lo);
-		break;
-	ic_sub_ret:
-		AIWNIOS_ADD_CODE(X86Ret, 0);
-		break;
-	ic_sub_prolog:
-		break;
-	ic_sub_call:
-		AIWNIOS_ADD_CODE(X86Call32, 5);
-		CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
-		break;
-	ic_add:
-		if (rpn->res.mode == __MD_X86_64_LEA_SIB) {
-			if (rpn->res.__sib_base_rpn)
-				code_off = __OptPassFinal(cctrl, rpn->res.__sib_base_rpn, bin, code_off);
-			if (rpn->res.__sib_idx_rpn)
-				code_off = __OptPassFinal(cctrl, rpn->res.__sib_idx_rpn, bin, code_off);
-			AIWNIOS_ADD_CODE(X86LeaSIB, rpn->res.fallback_reg, rpn->res.__SIB_scale, rpn->res.reg2, rpn->res.reg, rpn->res.off);
-			tmp.mode = MD_REG;
-			tmp.raw_type = RT_I64i;
-			tmp.reg = rpn->res.fallback_reg;
-			rpn->res = tmp; // Swap out the old mode with the new one
-			goto ret;
-		}
+    if (rpn->res.mode != MD_REG) {
+      tmp.raw_type = rpn->raw_type;
+      tmp.reg = 0;
+      tmp.mode = MD_REG;
+      if (rpn->res.keep_in_tmp)
+        rpn->res = tmp;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    }
+    break;
+  ic_pow:
+    // TODO
+    break;
+    break;
+  ic_unbounded_switch:
+    //
+    // Load poop into tmp,then we continue the sexyness as normal
+    //
+    // Also make sure R8 has lo bound(See IC_BOUNDED_SWITCH)
+    //
+    next2 = ICArgN(rpn, 0);
+    PushTmpDepthFirst(cctrl, next2, 0);
+    PopTmp(cctrl, next2);
+    code_off = __OptPassFinal(cctrl, next2, bin, code_off);
+    tmp.raw_type = RT_I64i;
+    tmp.mode = MD_REG;
+    tmp.reg = 0;
+    code_off = ICMov(cctrl, &tmp, &next2->res, bin, code_off);
+    code_off = __ICMoveI64(cctrl, R8, rpn->code_misc->lo, bin, code_off); // X1
+    goto jmp_tab_sexy;
+    break;
+  ic_bounded_switch:
+    next2 = ICArgN(rpn, 0);
+    PushTmpDepthFirst(cctrl, next2, 0);
+    PopTmp(cctrl, next2);
+    code_off = __OptPassFinal(cctrl, next2, bin, code_off);
+    tmp.raw_type = RT_I64i;
+    tmp.mode = MD_REG;
+    tmp.reg = RCX;
+    code_off = ICMov(cctrl, &tmp, &next2->res, bin, code_off);
+    code_off = __ICMoveI64(cctrl, RAX, rpn->code_misc->hi, bin, code_off);
+    code_off = __ICMoveI64(cctrl, R8, rpn->code_misc->lo, bin, code_off);
+    AIWNIOS_ADD_CODE(X86CmpRegReg, tmp.reg, R8);
+    fail1_addr = bin + code_off;
+    AIWNIOS_ADD_CODE(X86Jcc, X86_COND_L, 6);
+    CodeMiscAddRef(rpn->code_misc->dft_lab, bin + code_off - 4);
+    AIWNIOS_ADD_CODE(X86CmpRegReg, tmp.reg, RAX);
+    fail2_addr = bin + code_off;
+    AIWNIOS_ADD_CODE(X86Jcc, X86_COND_G, 6);
+    CodeMiscAddRef(rpn->code_misc->dft_lab, bin + code_off - 4);
+  jmp_tab_sexy:
+    AIWNIOS_ADD_CODE(X86LeaSIB, RDX, -1, -1, RIP, 0);
+    CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
+    //-8*rpn->code_misc->lo offsets our tmp.reg by lo
+    AIWNIOS_ADD_CODE(X86JmpSIB, 8, tmp.reg, RDX, -8 * rpn->code_misc->lo);
+    break;
+  ic_sub_ret:
+    AIWNIOS_ADD_CODE(X86Ret, 0);
+    break;
+  ic_sub_prolog:
+    break;
+  ic_sub_call:
+    AIWNIOS_ADD_CODE(X86Call32, 5);
+    CodeMiscAddRef(rpn->code_misc, bin + code_off - 4);
+    break;
+  ic_add:
+    if (rpn->res.mode == __MD_X86_64_LEA_SIB) {
+      if (rpn->res.__sib_base_rpn)
+        code_off =
+            __OptPassFinal(cctrl, rpn->res.__sib_base_rpn, bin, code_off);
+      if (rpn->res.__sib_idx_rpn)
+        code_off = __OptPassFinal(cctrl, rpn->res.__sib_idx_rpn, bin, code_off);
+      AIWNIOS_ADD_CODE(X86LeaSIB, rpn->res.fallback_reg, rpn->res.__SIB_scale,
+                       rpn->res.reg2, rpn->res.reg, rpn->res.off);
+      tmp.mode = MD_REG;
+      tmp.raw_type = RT_I64i;
+      tmp.reg = rpn->res.fallback_reg;
+      rpn->res = tmp; // Swap out the old mode with the new one
+      goto ret;
+    }
 //
 //  /\   /\      ____
 //  ||___||     /    \
@@ -4959,1256 +5160,1335 @@ int64_t __OptPassFinal(CCmpCtrl* cctrl, CRPN* rpn, char* bin,
 // LEFT ==> may have a MD_INDIR_REG(where reg is a tmp reg)
 // *LEFT=RIHGT ==> Write into the left's address
 //
-#define BACKEND_BINOP(f_op, i_op, f_sib_op, i_sib_op)                                                                 \
-	do {                                                                                                              \
-		next = ICArgN(rpn, 1);                                                                                        \
-		next2 = ICArgN(rpn, 0);                                                                                       \
-		orig_dst = next->res;                                                                                         \
-		if (ModeIsDerefToSIB(next2) && ((next2->raw_type == RT_F64) == (rpn->raw_type == RT_F64))) {                  \
-			if (!(next->raw_type != RT_F64 && next->res.mode != MD_REG) && RawTypeIs64(next2->raw_type)) {            \
-				code_off = __OptPassFinal(cctrl, next, bin, code_off);                                                \
-				code_off = DerefToICArg(cctrl, &derefed, next2, AIWNIOS_TMP_IREG_POOP2, bin, code_off);               \
-				if (rpn->res.mode == MD_NULL)                                                                         \
-					break;                                                                                            \
-				if (rpn->res.mode == MD_REG && !DstRegAffectsMode(&rpn->res, &derefed)) {                             \
-					into_reg = rpn->res.reg;                                                                          \
-				} else                                                                                                \
-					into_reg = 0;                                                                                     \
-				tmp.mode = MD_REG;                                                                                    \
-				tmp.raw_type = rpn->raw_type;                                                                         \
-				tmp.reg = into_reg;                                                                                   \
-				code_off = ICMov(cctrl, &tmp, &next->res, bin, code_off);                                             \
-				if (rpn->raw_type == RT_F64) {                                                                        \
-					AIWNIOS_ADD_CODE(f_sib_op, tmp.reg, derefed.__SIB_scale, derefed.reg2, derefed.reg, derefed.off); \
-				} else {                                                                                              \
-					AIWNIOS_ADD_CODE(i_sib_op, tmp.reg, derefed.__SIB_scale, derefed.reg2, derefed.reg, derefed.off); \
-				}                                                                                                     \
-				if (rpn->res.keep_in_tmp)                                                                             \
-					rpn->res = next->res;                                                                             \
-				if (rpn->res.mode != MD_NULL) {                                                                       \
-					code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);                                          \
-				}                                                                                                     \
-				break;                                                                                                \
-			}                                                                                                         \
-		}                                                                                                             \
-		code_off = __OptPassFinal(cctrl, next, bin, code_off);                                                        \
-		code_off = __OptPassFinal(cctrl, next2, bin, code_off);                                                       \
-		if (rpn->res.mode == MD_NULL)                                                                                 \
-			break;                                                                                                    \
-		if (rpn->res.mode == MD_REG && !DstRegAffectsMode(&rpn->res, &next2->res)) {                                  \
-			into_reg = rpn->res.reg;                                                                                  \
-		} else                                                                                                        \
-			into_reg = 0;                                                                                             \
-		tmp.mode = MD_REG;                                                                                            \
-		tmp.raw_type = rpn->raw_type;                                                                                 \
-		tmp.reg = into_reg;                                                                                           \
-		code_off = ICMov(cctrl, &tmp, &next->res, bin, code_off);                                                     \
-		if (rpn->raw_type == RT_F64) {                                                                                \
-			code_off = PutICArgIntoReg(cctrl, &tmp, rpn->raw_type, 0, bin, code_off);                                 \
-			code_off = PutICArgIntoReg(cctrl, &next2->res, rpn->raw_type, 1, bin, code_off);                          \
-		} else {                                                                                                      \
-			code_off = PutICArgIntoReg(cctrl, &tmp, rpn->raw_type, AIWNIOS_TMP_IREG_POOP, bin, code_off);             \
-			code_off = PutICArgIntoReg(cctrl, &next2->res, rpn->raw_type, AIWNIOS_TMP_IREG_POOP2, bin, code_off);     \
-		}                                                                                                             \
-		if (rpn->raw_type == RT_F64) {                                                                                \
-			AIWNIOS_ADD_CODE(f_op, tmp.reg, next2->res.reg);                                                          \
-		} else {                                                                                                      \
-			AIWNIOS_ADD_CODE(i_op, tmp.reg, next2->res.reg);                                                          \
-		}                                                                                                             \
-		if (rpn->res.keep_in_tmp)                                                                                     \
-			rpn->res = tmp;                                                                                           \
-		if (rpn->res.mode != MD_NULL) {                                                                               \
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);                                                  \
-		}                                                                                                             \
-	} while (0);
-#define BACKEND_BINOP_IMM(i_imm_op, i_op)                                                                                        \
-	next = ICArgN(rpn, 1);                                                                                                       \
-	next2 = ICArgN(rpn, 0);                                                                                                      \
-	if (rpn->raw_type != RT_F64 && IsConst(next2) && Is32Bit(ConstVal(next2)) && next2->type != IC_F64 && next2->integer >= 0) { \
-		code_off = __OptPassFinal(cctrl, next, bin, code_off);                                                                   \
-		tmp2 = next->res;                                                                                                        \
-		if (rpn->res.mode == MD_NULL)                                                                                            \
-			break;                                                                                                               \
-		if (rpn->res.mode == MD_REG)                                                                                             \
-			into_reg = rpn->res.reg;                                                                                             \
-		else                                                                                                                     \
-			into_reg = 0;                                                                                                        \
-		code_off = PutICArgIntoReg(cctrl, &tmp2, RT_I64i, into_reg, bin, code_off);                                              \
-		if (Is32Bit(next2->integer)) {                                                                                           \
-			tmp.reg = into_reg;                                                                                                  \
-			tmp.mode = MD_REG;                                                                                                   \
-			tmp.raw_type = rpn->raw_type;                                                                                        \
-			code_off = ICMov(cctrl, &tmp, &tmp2, bin, code_off);                                                                 \
-			AIWNIOS_ADD_CODE(i_imm_op, into_reg, next2->integer);                                                                \
-		} else {                                                                                                                 \
-			tmp.mode = MD_REG;                                                                                                   \
-			tmp.reg = AIWNIOS_TMP_IREG_POOP;                                                                                     \
-			tmp.raw_type = RT_I64i;                                                                                              \
-			code_off = ICMov(cctrl, &tmp, &next2->res, bin, code_off);                                                           \
-			AIWNIOS_ADD_CODE(i_op, into_reg, tmp.reg);                                                                           \
-		}                                                                                                                        \
-		if (rpn->res.keep_in_tmp)                                                                                                \
-			rpn->res = tmp;                                                                                                      \
-		if (rpn->res.mode != MD_REG && rpn->res.mode != MD_NULL) {                                                               \
-			tmp.raw_type = rpn->raw_type;                                                                                        \
-			tmp.reg = into_reg;                                                                                                  \
-			tmp.mode = MD_REG;                                                                                                   \
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);                                                             \
-		}                                                                                                                        \
-		break;                                                                                                                   \
-	}
-		if(rpn->raw_type!=RT_F64)
-			rpn->res.set_flags=1;
-		BACKEND_BINOP_IMM(X86AddImm32, X86AddReg);
-		BACKEND_BINOP(X86AddSDReg, X86AddReg, X86AddSDSIB64, X86AddSIB64);
-		break;
-	ic_comma:
-		next = ICArgN(rpn, 1);
-		next2 = ICArgN(rpn, 0);
-		orig_dst = next->res;
-		code_off = __OptPassFinal(cctrl, next2, bin, code_off);
-		code_off = __OptPassFinal(cctrl, next, bin, code_off);
-		code_off = ICMov(cctrl, &rpn->res, &next2->res, bin, code_off);
-		break;
-	ic_eq:
-		next = ICArgN(rpn, 1);
-		next2 = ICArgN(rpn, 0);
-		orig_dst = next->res;
-		code_off = __OptPassFinal(cctrl, next2, bin, code_off);
-		if (next->type == IC_TYPECAST) {
-			TYPECAST_ASSIGN_BEGIN(next, next2);
-			if (rpn->res.mode != MD_NULL) {
-				// Avoid a double-derefernce
-				code_off = PutICArgIntoReg(cctrl, &next2->res, rpn->raw_type, rpn->raw_type == RT_F64 ? 0 : AIWNIOS_TMP_IREG_POOP, bin, code_off);
-			}
-			code_off = ICMov(cctrl, &next->res, &next2->res, bin, code_off);
-			TYPECAST_ASSIGN_END(next);
-		} else if (next->type == IC_DEREF) {
-			tmp = next->res;
-			code_off = DerefToICArg(cctrl, &tmp, next, AIWNIOS_TMP_IREG_POOP2, bin, code_off);
-			if (rpn->res.mode != MD_NULL) {
-				// Avoid a double-derefernce
-				code_off = PutICArgIntoReg(cctrl, &next2->res, rpn->raw_type, rpn->raw_type == RT_F64 ? 0 : AIWNIOS_TMP_IREG_POOP, bin, code_off);
-			}
-			code_off = ICMov(cctrl, &tmp, &next2->res, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-			break;
-		} else if (next->type == IC_GLOBAL) {
-			next->res.mode = MD_PTR;
-			next->res.raw_type = next->raw_type;
-			if (next->global_var->base.type & HTT_GLBL_VAR) {
-				next->res.off = (int64_t)next->global_var->data_addr;
-			} else if (next->global_var->base.type & HTT_FUN) {
-				next->res.off = (int64_t)((CHashFun*)next->global_var)->fun_ptr;
-			}
-			code_off = __OptPassFinal(cctrl, next, bin, code_off);
-			if (rpn->res.mode != MD_NULL) {
-				// Avoid a double-derefernce
-				code_off = PutICArgIntoReg(cctrl, &next2->res, rpn->raw_type, rpn->raw_type == RT_F64 ? 0 : AIWNIOS_TMP_IREG_POOP, bin, code_off);
-			}
-			code_off = ICMov(cctrl, &next->res, &next2->res, bin, code_off);
-		} else {
-			code_off = __OptPassFinal(cctrl, next, bin, code_off);
-			if (rpn->res.mode != MD_NULL) {
-				// Avoid a double-derefernce
-				code_off = PutICArgIntoReg(cctrl, &next2->res, rpn->raw_type, rpn->raw_type == RT_F64 ? 0 : AIWNIOS_TMP_IREG_POOP, bin, code_off);
-			}
-			code_off = ICMov(cctrl, &next->res, &next2->res, bin, code_off);
-		}
-		code_off = ICMov(cctrl, &rpn->res, &next2->res, bin, code_off);
-		break;
-	ic_sub:
-		if(rpn->raw_type!=RT_F64)
-			rpn->res.set_flags=1;
-		BACKEND_BINOP_IMM(X86SubImm32, X86SubReg);
-		BACKEND_BINOP(X86SubSDReg, X86SubReg, X86SubSDSIB64, X86SubSIB64);
-		break;
-	ic_div:
-		next = rpn->base.next;
-		next2 = ICArgN(rpn, 1);
-		if (next->type == IC_I64 && next2->raw_type != RT_F64) {
-			if (__builtin_popcountll(next->integer) == 1) {
-				code_off = __OptPassFinal(cctrl, next2, bin, code_off);
-				if (rpn->res.mode == MD_REG)
-					into_reg = rpn->res.reg;
-				else
-					into_reg = RAX;
-				tmp.mode = MD_REG;
-				tmp.raw_type = RT_I64i;
-				tmp.reg = into_reg;
-				code_off = ICMov(cctrl, &tmp, &next2->res, bin, code_off);
-				switch (next2->raw_type) {
-				case RT_I8i:
-				case RT_I16i:
-				case RT_I32i:
-				case RT_I64i:
-					AIWNIOS_ADD_CODE(X86SarImm, into_reg, __builtin_ffsll(next->integer) - 1);
-					if(rpn->raw_type!=RT_F64) rpn->res.set_flags=1;
-					break;
-				default:
-					AIWNIOS_ADD_CODE(X86ShrImm, into_reg, __builtin_ffsll(next->integer) - 1);
-					if(rpn->raw_type!=RT_F64) rpn->res.set_flags=1;
-					break;
-				}
-				if (rpn->res.keep_in_tmp)
-					rpn->res = tmp;
-				code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-				break;
-			}
-		}
-		if (rpn->raw_type == RT_U64i) {
-#define CQO_OP(use_reg, op, sib_op)                                                                                              \
-	next = ICArgN(rpn, 1);                                                                                                       \
-	next2 = ICArgN(rpn, 0);                                                                                                      \
-	orig_dst = next->res;                                                                                                        \
-	if (ModeIsDerefToSIB(next2) && ((next2->raw_type == RT_F64) == (rpn->raw_type == RT_F64)) && RawTypeIs64(next2->raw_type)) { \
-		code_off = __OptPassFinal(cctrl, next, bin, code_off);                                                                   \
-		code_off = DerefToICArg(cctrl, &derefed, next2, AIWNIOS_TMP_IREG_POOP2, bin, code_off);                                  \
-		tmp.raw_type = RT_I64i;                                                                                                  \
-		tmp.reg = RAX;                                                                                                           \
-		tmp.mode = MD_REG;                                                                                                       \
-		code_off = ICMov(cctrl, &tmp, &next->res, bin, code_off);                                                                \
-		if (rpn->raw_type == RT_U64i) {                                                                                          \
-			AIWNIOS_ADD_CODE(X86XorReg, RDX, RDX);                                                                               \
-		} else {                                                                                                                 \
-			AIWNIOS_ADD_CODE(X86Cqo, 0);                                                                                         \
-		}                                                                                                                        \
-		AIWNIOS_ADD_CODE(sib_op, derefed.__SIB_scale, derefed.reg2, derefed.reg, derefed.off);                                   \
-		tmp.reg = use_reg;                                                                                                       \
-		if (rpn->res.keep_in_tmp)                                                                                                \
-			rpn->res = tmp;                                                                                                      \
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);                                                                 \
-		break;                                                                                                                   \
-	}                                                                                                                            \
-	tmp.raw_type = RT_I64i;                                                                                                      \
-	tmp.reg = RAX;                                                                                                               \
-	tmp.mode = MD_REG;                                                                                                           \
-	code_off = __OptPassFinal(cctrl, next, bin, code_off);                                                                       \
-	code_off = __OptPassFinal(cctrl, next2, bin, code_off);                                                                      \
-	code_off = ICMov(cctrl, &tmp, &next->res, bin, code_off);                                                                    \
-	code_off = PutICArgIntoReg(cctrl, &next2->res, RT_U64i, R8, bin, code_off);                                                  \
-	if (rpn->raw_type == RT_U64i) {                                                                                              \
-		AIWNIOS_ADD_CODE(X86XorReg, RDX, RDX);                                                                                   \
-	} else {                                                                                                                     \
-		AIWNIOS_ADD_CODE(X86Cqo, 0);                                                                                             \
-	}                                                                                                                            \
-	AIWNIOS_ADD_CODE(op, next2->res.reg);                                                                                        \
-	tmp.reg = use_reg;                                                                                                           \
-	if (rpn->res.keep_in_tmp)                                                                                                    \
-		rpn->res = tmp;                                                                                                          \
-	code_off                                                                                                                     \
-		= ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-			CQO_OP(RAX, X86DivReg, X86DivSIB64);
-		} else if (rpn->raw_type != RT_F64) {
-			CQO_OP(RAX, X86IDivReg, X86IDivSIB64);
-		} else {
-			BACKEND_BINOP(X86DivSDReg, X86DivSDReg, X86DivSDSIB64, X86DivSDSIB64);
-		}
-		break;
-	ic_mul:
-		next = rpn->base.next;
-		next2 = ICArgN(rpn, 1);
-		if (next->type == IC_I64 && next2->raw_type != RT_F64) {
-			if (__builtin_popcountll(next->integer) == 1) {
-				code_off = __OptPassFinal(cctrl, next2, bin, code_off);
-				code_off = PutICArgIntoReg(cctrl, &next2->res, next2->raw_type, AIWNIOS_TMP_IREG_POOP, bin, code_off);
-				if (rpn->res.mode == MD_REG) {
-					code_off = ICMov(cctrl, &rpn->res, &next2->res, bin, code_off);
-					AIWNIOS_ADD_CODE(X86ShlImm, rpn->res.reg, __builtin_ffsll(next->integer) - 1);
-				} else {
-					tmp.raw_type = RT_I64i;
-					tmp.reg = RAX;
-					tmp.mode = MD_REG;
-					code_off = ICMov(cctrl, &tmp, &next2->res, bin, code_off);
-					AIWNIOS_ADD_CODE(X86ShlImm, tmp.reg, __builtin_ffsll(next->integer) - 1);
-					if (rpn->res.keep_in_tmp)
-						rpn->res = tmp;
-					code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-				}
-				break;
-			}
-		}
-		if (rpn->raw_type == RT_U64i) {
-			CQO_OP(RAX, X86MulReg, X86MulSIB64);
-		} else {
-			BACKEND_BINOP(X86MulSDReg, X86IMul2Reg, X86MulSDSIB64, X86IMul2SIB64);
-		}
-		break;
-	ic_deref:
-		next = rpn->base.next;
-		i = 0;
-		//
-		// Here's the Donald Trump deal,Derefernced function pointers
-		// don't derefence(you dont copy a function into memory).
-		//
-		// I64 (*fptr)()=&Foo;
-		// (*fptr)(); //Doesn't "dereference"
-		//
-		if (rpn->raw_type == RT_FUNC) {
-			code_off = __OptPassFinal(cctrl, next, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
-			goto ret;
-		}
-		code_off = DerefToICArg(cctrl, &tmp, rpn, AIWNIOS_TMP_IREG_POOP2, bin, code_off);
-		if (rpn->res.keep_in_tmp)
-			rpn->res = tmp;
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		break;
-	ic_and:
-	    if(rpn->raw_type!=RT_F64) rpn->res.set_flags=1;
-		BACKEND_BINOP_IMM(X86AndImm, X86AndImm);
-		BACKEND_BINOP(X86AndPDReg, X86AndReg, X86AndPDSIB64, X86AndSIB64);
-		break;
-	ic_addr_of:
-		next = rpn->base.next;
-		switch (next->type) {
-			break;
-		case __IC_STATIC_REF:
-			if (rpn->res.mode == MD_REG)
-				into_reg = rpn->res.reg;
-			else
-				into_reg = 0;
-			AIWNIOS_ADD_CODE(X86LeaSIB, into_reg, -1, -1, RIP, 0);
-			if (bin)
-				CodeMiscAddRef(cctrl->statics_label, bin + code_off - 4)->offset = rpn->integer;
-			goto restore_reg;
-			break;
-		case IC_DEREF:
-			next = rpn->base.next;
-			code_off = __OptPassFinal(cctrl, next, bin, code_off);
-			code_off = PutICArgIntoReg(cctrl, &next->res, RT_PTR, AIWNIOS_TMP_IREG_POOP2, bin, code_off);
-			code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
-			break;
-		case IC_BASE_PTR:
-			if (rpn->res.mode == MD_REG)
-				into_reg = rpn->res.reg;
-			else
-				into_reg = 0;
-			AIWNIOS_ADD_CODE(X86LeaSIB, into_reg, -1, -1, RBP, -next->integer);
-			goto restore_reg;
-			break;
-		case IC_STATIC:
-			if (rpn->res.mode == MD_REG)
-				into_reg = rpn->res.reg;
-			else
-				into_reg = 0;
-			AIWNIOS_ADD_CODE(X86LeaSIB, into_reg, -1, -1, RIP, (char*)rpn->integer - (bin + code_off));
-			goto restore_reg;
-		case IC_GLOBAL:
-		get_glbl_ptr:
-			if (rpn->res.mode == MD_REG)
-				into_reg = rpn->res.reg;
-			else
-				into_reg = 0;
-			if (next->global_var->base.type & HTT_GLBL_VAR) {
-				enter_addr = next->global_var->data_addr;
-			} else if (next->global_var->base.type & HTT_FUN) {
-				enter_addr = ((CHashFun*)next->global_var)->fun_ptr;
-			} else
-				abort();
-			// Undefined?
-			if (!enter_addr) {
-				misc = AddRelocMisc(cctrl, next->global_var->base.str);
-				AIWNIOS_ADD_CODE(X86MovRegIndirI64, into_reg, -1, -1, RIP, X86MovRegIndirI64(NULL, into_reg, -1, -1, RIP, 0)); // X86MovRegIndirI64 will return inst size
-				CodeMiscAddRef(misc, bin + code_off - 4);
-				goto restore_reg;
-			} else if (Is32Bit(enter_addr - (bin + code_off))) {
-				AIWNIOS_ADD_CODE(X86LeaSIB, into_reg, -1, -1, RIP, enter_addr - (bin + code_off));
-				goto restore_reg;
-			}
-			code_off = __ICMoveI64(cctrl, into_reg, (int64_t)enter_addr, bin,
-				code_off);
-		restore_reg:
-			tmp.mode = MD_REG;
-			tmp.raw_type = rpn->raw_type;
-			tmp.reg = into_reg;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-			break;
-		default:
-			abort();
-		}
-		break;
-	ic_xor:
-		if (rpn->raw_type != RT_F64) {
-			rpn->res.set_flags=1;
-			BACKEND_BINOP_IMM(X86XorImm, X86XorReg);
-		}
-		BACKEND_BINOP(X86XorPDReg, X86XorReg, X86XorPDSIB64, X86XorSIB64);
-		break;
-	ic_mod:
-		next = ICArgN(rpn, 1);
-		next2 = ICArgN(rpn, 0);
-		if (rpn->raw_type != RT_F64) {
-			if (rpn->raw_type == RT_U64i) {
-				CQO_OP(RDX, X86DivReg, X86DivSIB64);
-			} else {
-				CQO_OP(RDX, X86IDivReg, X86IDivSIB64);
-			}
-		} else {
-			code_off = __OptPassFinal(cctrl, next, bin, code_off);
-			code_off = __OptPassFinal(cctrl, next2, bin, code_off);
-			code_off = PutICArgIntoReg(cctrl, &next2->res, RT_F64, 1, bin, code_off);
-			code_off = PutICArgIntoReg(cctrl, &next->res, RT_F64, 0, bin, code_off);
-			tmp2.reg = 2;
-			tmp2.mode = MD_REG;
-			tmp2.raw_type = RT_F64;
-			code_off = ICMov(cctrl, &tmp2, &next->res, bin, code_off);
-			AIWNIOS_ADD_CODE(X86DivSDReg, tmp2.reg, next2->res.reg);
-			code_off = PushToStack(cctrl, &tmp2, bin, code_off);
-			AIWNIOS_ADD_CODE(X86CVTTSD2SIRegSIB64, RAX, -1, -1, RSP, 0);
-			AIWNIOS_ADD_CODE(X86MovIndirRegI64, RAX, -1, -1, RSP, 0);
-			AIWNIOS_ADD_CODE(X86CVTTSI2SDRegSIB64, tmp2.reg, -1, -1, RSP, 0);
-			AIWNIOS_ADD_CODE(X86PopReg, RAX);
-			AIWNIOS_ADD_CODE(X86MulSDReg, tmp2.reg, next2->res.reg);
-			tmp.reg = 0;
-			tmp.mode = MD_REG;
-			tmp.raw_type = RT_F64;
-			code_off = ICMov(cctrl, &tmp, &next->res, bin, code_off); // tmp.reg==0
-			AIWNIOS_ADD_CODE(X86SubSDReg, tmp.reg, tmp2.reg);
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		}
-		break;
-	ic_or:
-		if(rpn->raw_type!=RT_F64) rpn->res.set_flags=1;
-		BACKEND_BINOP_IMM(X86OrImm, X86OrReg);
-		BACKEND_BINOP(X86OrPDReg, X86OrReg, X86OrPDSIB64, X86OrSIB64);
-		break;
-	ic_lt:
-	ic_gt:
-	ic_le:
-	ic_ge:
-		//
-		// Ask nroot how this works if you want to know
-		//
-		// X/V3 is for lefthand side
-		// X/V4 is for righthand side
-		range = NULL;
-		range_args = NULL;
-		range_fail_addrs = NULL;
-		range_cmp_types = NULL;
-	get_range_items:
-		cnt = 0;
-		for (next = rpn; 1; next = ICFwd(next->base.next) // TODO explain
-		) {
-			switch (next->type) {
-			case IC_LT:
-			case IC_GT:
-			case IC_LE:
-			case IC_GE:
-				goto cmp_pass;
-			}
-			if (range_args)
-				range_args[cnt] = next; // See below
-			break;
-		cmp_pass:
-			//
-			// <
-			//    right rpn.next
-			//    left  ICFwd(rpn.next)
-			//
-			if (range_args)
-				range_args[cnt] = next->base.next;
-			if (range)
-				range[cnt] = next;
-			cnt++;
-		}
-		if (!range) {
-			// This are reversed
-			range_args = A_MALLOC(sizeof(CRPN*) * (cnt + 1), cctrl->hc);
-			range = A_MALLOC(sizeof(CRPN*) * cnt, cctrl->hc);
-			range_fail_addrs = A_MALLOC(sizeof(CRPN*) * cnt, cctrl->hc);
-			range_cmp_types = A_MALLOC(sizeof(int64_t) * cnt, cctrl->hc);
-			goto get_range_items;
-		}
-		code_off = __OptPassFinal(cctrl, next = range_args[cnt], bin, code_off);
-		for (i = cnt - 1; i >= 0; i--) {
-			next2 = range_args[i];
-			code_off = __OptPassFinal(cctrl, next2, bin, code_off);
-			memcpy(&tmp, &next->res, sizeof(CICArg));
-			memcpy(&tmp2, &next2->res, sizeof(CICArg));
-			use_flt_cmp = next->raw_type == RT_F64 || next2->raw_type == RT_F64;
-			i2 = RT_I64i;
-			i2 = next->res.raw_type > i2 ? next->res.raw_type : i2;
-			i2 = next2->res.raw_type > i2 ? next2->res.raw_type : i2;
-			code_off = PutICArgIntoReg(cctrl, &tmp, i2, AIWNIOS_TMP_IREG_POOP2, bin, code_off);
-			code_off = PutICArgIntoReg(cctrl, &tmp2, i2, 0, bin, code_off);
-			if (use_flt_cmp) {
-				AIWNIOS_ADD_CODE(X86COMISDRegReg, tmp.reg, tmp2.reg);
-			} else {
-				AIWNIOS_ADD_CODE(X86CmpRegReg, tmp.reg, tmp2.reg);
-			}
-			//
-			// We use the opposite compare because if fail we jump to the fail
-			// zone
-			//
-			if (use_flt_cmp) {
-			unsigned_cmp:
-				switch (range[i]->type) {
-					break;
-				case IC_LT:
-					range_cmp_types[i] = X86_COND_B | 1;
-					break;
-				case IC_GT:
-					range_cmp_types[i] = X86_COND_A | 1;
-					break;
-				case IC_LE:
-					range_cmp_types[i] = X86_COND_BE | 1;
-					break;
-				case IC_GE:
-					range_cmp_types[i] = X86_COND_AE | 1;
-				}
-			} else if (next->raw_type == RT_U64i || next2->raw_type == RT_U64i) {
-				goto unsigned_cmp;
-			} else {
-				switch (range[i]->type) {
-					break;
-				case IC_LT:
-					range_cmp_types[i] = X86_COND_L | 1;
-					break;
-				case IC_GT:
-					range_cmp_types[i] = X86_COND_G | 1;
-					break;
-				case IC_LE:
-					range_cmp_types[i] = X86_COND_LE | 1;
-					break;
-				case IC_GE:
-					range_cmp_types[i] = X86_COND_GE | 1;
-				}
-			}
-			range_fail_addrs[i] = bin + code_off;
-			AIWNIOS_ADD_CODE(X86Jcc, range_cmp_types[i], 0); // WILL BE FILLED IN LATER
-			if (old_fail_misc)
-				CodeMiscAddRef(old_fail_misc, bin + code_off - 4);
-			next = next2;
-		}
-		if (!(old_fail_misc && old_pass_misc)) {
-			tmp.mode = MD_I64;
-			tmp.integer = 1;
-			tmp.raw_type = RT_I64i;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-			exit_addr = bin + code_off;
-			AIWNIOS_ADD_CODE(X86Jmp, 0);
-			if (bin)
-				for (i = 0; i != cnt; i++) {
-					X86Jcc(range_fail_addrs[i], range_cmp_types[i],
-						(bin + code_off) - (char*)range_fail_addrs[i]); // TODO unsigned
-				}
-			tmp.mode = MD_I64;
-			tmp.integer = 0;
-			tmp.raw_type = RT_I64i;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-			if (bin)
-				X86Jmp(exit_addr, (bin + code_off) - exit_addr);
-		} else {
-			AIWNIOS_ADD_CODE(X86Jmp, 0);
-			CodeMiscAddRef(old_pass_misc, bin + code_off - 4);
-		}
-		A_FREE(range);
-		A_FREE(range_args);
-		A_FREE(range_fail_addrs);
-		A_FREE(range_cmp_types);
-		break;
-	ic_lnot:
-		next = rpn->base.next;
-		code_off = __OptPassFinal(cctrl, next, bin, code_off);
-		code_off = PutICArgIntoReg(cctrl, &next->res, rpn->raw_type, 0, bin, code_off);
-		if (next->res.raw_type != RT_F64) {
-			AIWNIOS_ADD_CODE(X86Test, next->res.reg, next->res.reg);
-		} else {
-			code_off = __ICMoveF64(cctrl, 1, 0, bin, code_off);
-			AIWNIOS_ADD_CODE(X86COMISDRegReg, 1, 0);
-		}
-		if (old_pass_misc && old_fail_misc) {
-			AIWNIOS_ADD_CODE(X86Jcc, X86_COND_Z, 0);
-			if (bin)
-				CodeMiscAddRef(old_pass_misc, bin + code_off - 4);
-			AIWNIOS_ADD_CODE(X86Jmp, 0);
-			if (bin)
-				CodeMiscAddRef(old_fail_misc, bin + code_off - 4);
-			goto ret;
-		}
-		if (rpn->res.mode == MD_REG && rpn->res.mode != RT_F64) {
-			into_reg = rpn->res.reg;
-		} else
-			into_reg = 0; // Store into reg 0
-		AIWNIOS_ADD_CODE(X86Setcc, X86_COND_Z, into_reg);
-		if (!(rpn->res.mode == MD_REG && rpn->res.mode != RT_F64)) {
-			tmp.raw_type = RT_I64i;
-			tmp.reg = 0;
-			tmp.mode = MD_REG;
-			if (rpn->res.keep_in_tmp)
-				rpn->res = tmp;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		}
-		break;
-	ic_bnot:
-		if (rpn->raw_type == RT_F64) {
-			code_off = __OptPassFinal(cctrl, next, bin, code_off);
-			code_off = PutICArgIntoReg(cctrl, &next->res, rpn->raw_type, 1, bin, code_off);
-			static double ul;
-			*(int64_t*)&ul = ~0ll;
-			code_off = __ICMoveF64(cctrl, 0, ul, bin, code_off);
-			AIWNIOS_ADD_CODE(X86XorPDReg, next->res.reg, 0);
-			goto ret;
-		}
-		if(rpn->raw_type!=RT_F64) rpn->res.set_flags=1;
-		BACKEND_UNOP(X86NotReg, X86NotReg);
-		break;
-	ic_post_inc:
-		code_off = __SexyPostOp(cctrl, rpn, X86AddImm32, X86AddReg, X86AddSDReg, X86IncReg, X86IncSIB64, bin, code_off);
-		break;
-	ic_post_dec:
-		code_off = __SexyPostOp(cctrl, rpn, X86SubImm32, X86SubReg, X86SubSDReg, X86DecReg, X86DecSIB64, bin, code_off);
-		break;
-	ic_pre_inc:
-		code_off = __SexyPreOp(cctrl, rpn, X86AddImm32, X86AddReg, X86AddSDReg, X86IncReg, X86IncSIB64, bin, code_off);
-		break;
-	ic_pre_dec:
-		code_off = __SexyPreOp(cctrl, rpn, X86SubImm32, X86SubReg, X86SubSDReg, X86DecReg, X86DecSIB64, bin, code_off);
-		break;
-	ic_and_and:
-#define BACKEND_TEST(_res)                                               \
-	{                                                                    \
-		int64_t rt = (_res)->raw_type;                                   \
-		code_off = PutICArgIntoReg(cctrl, (_res), rt, 0, bin, code_off); \
-		int64_t reg = (_res)->reg;                                       \
-		if ((rt) != RT_F64) {                                            \
-			AIWNIOS_ADD_CODE(X86Test, reg, reg);                         \
-		} else {                                                         \
-			code_off = __ICMoveF64(cctrl, 2, 0, bin, code_off);          \
-			AIWNIOS_ADD_CODE(X86COMISDRegReg, reg, 2);                   \
-		}                                                                \
-	}
-		if (old_pass_misc && old_fail_misc) {
-			a = ICArgN(rpn, 1);
-			b = ICArgN(rpn, 0);
-			code_off = __OptPassFinal(cctrl, a, bin, code_off);
-			BACKEND_TEST(&a->res);
-			AIWNIOS_ADD_CODE(X86Jcc, X86_COND_Z, 6);
-			CodeMiscAddRef(old_fail_misc, bin + code_off - 4);
-			code_off = __OptPassFinal(cctrl, b, bin, code_off);
-			BACKEND_TEST(&b->res);
-			AIWNIOS_ADD_CODE(X86Jcc, X86_COND_Z, 6);
-			CodeMiscAddRef(old_fail_misc, bin + code_off - 4);
-			AIWNIOS_ADD_CODE(X86Jmp, 0);
-			CodeMiscAddRef(old_pass_misc, bin + code_off - 4);
-			goto ret;
-		}
-#define BACKEND_BOOLIFY(to, reg, rt)                        \
-	if ((rt) != RT_F64) {                                   \
-		AIWNIOS_ADD_CODE(X86Test, reg, reg);                \
-		AIWNIOS_ADD_CODE(X86Setcc, X86_COND_Z | 1, to);     \
-	} else {                                                \
-		code_off = __ICMoveF64(cctrl, 2, 0, bin, code_off); \
-		AIWNIOS_ADD_CODE(X86COMISDRegReg, reg, 2);          \
-		AIWNIOS_ADD_CODE(X86Setcc, X86_COND_E | 1, to);     \
-	}
-		if (!rpn->code_misc)
-			rpn->code_misc = CodeMiscNew(cctrl, CMT_LABEL);
-		if (!rpn->code_misc2)
-			rpn->code_misc2 = CodeMiscNew(cctrl, CMT_LABEL);
-		if (!rpn->code_misc3)
-			rpn->code_misc3 = CodeMiscNew(cctrl, CMT_LABEL);
-		if (!rpn->code_misc4)
-			rpn->code_misc4 = CodeMiscNew(cctrl, CMT_LABEL);
-		a = ICArgN(rpn, 1);
-		b = ICArgN(rpn, 0);
-		cctrl->backend_user_data5 = (int64_t)rpn->code_misc;
-		cctrl->backend_user_data6 = (int64_t)rpn->code_misc2;
-		code_off = __OptPassFinal(cctrl, a, bin, code_off);
-		cctrl->backend_user_data6 = (int64_t)rpn->code_misc3;
-		rpn->code_misc2->addr = bin + code_off;
-		code_off = __OptPassFinal(cctrl, b, bin, code_off);
-		rpn->code_misc->addr = bin + code_off;
-		tmp.mode = MD_I64;
-		tmp.raw_type = RT_I64i;
-		tmp.integer = 0;
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		AIWNIOS_ADD_CODE(X86Jmp, 0);
-		CodeMiscAddRef(rpn->code_misc4, bin + code_off - 4);
-		rpn->code_misc3->addr = bin + code_off;
-		tmp.integer = 1;
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		rpn->code_misc4->addr = bin + code_off;
-		break;
-	ic_or_or:
-		if (old_pass_misc || old_fail_misc) {
-			a = ICArgN(rpn, 1);
-			b = ICArgN(rpn, 0);
-			code_off = __OptPassFinal(cctrl, a, bin, code_off);
-			BACKEND_TEST(&a->res);
-			AIWNIOS_ADD_CODE(X86Jcc, X86_COND_Z ^ 1, 6);
-			CodeMiscAddRef(old_pass_misc, bin + code_off - 4);
-			code_off = __OptPassFinal(cctrl, b, bin, code_off);
-			BACKEND_TEST(&b->res);
-			AIWNIOS_ADD_CODE(X86Jcc, X86_COND_Z ^ 1, 6);
-			CodeMiscAddRef(old_pass_misc, bin + code_off - 4);
-			AIWNIOS_ADD_CODE(X86Jmp, 0);
-			CodeMiscAddRef(old_fail_misc, bin + code_off - 4);
-			goto ret;
-		}
-		// A
-		// rpn->code_misc3:
-		// B
-		// rpn->code_misc4:
-		// res=0;
-		// JMP rpn->code_misc2
-		// rpn->code_misc:
-		// res=1
-		// rpn->code_misc2:
-		if (!rpn->code_misc)
-			rpn->code_misc = CodeMiscNew(cctrl, CMT_LABEL);
-		if (!rpn->code_misc2)
-			rpn->code_misc2 = CodeMiscNew(cctrl, CMT_LABEL);
-		if (!rpn->code_misc3)
-			rpn->code_misc3 = CodeMiscNew(cctrl, CMT_LABEL);
-		if (!rpn->code_misc4)
-			rpn->code_misc4 = CodeMiscNew(cctrl, CMT_LABEL);
-		a = ICArgN(rpn, 1);
-		b = ICArgN(rpn, 0);
-		cctrl->backend_user_data5 = (int64_t)rpn->code_misc3;
-		cctrl->backend_user_data6 = (int64_t)rpn->code_misc;
-		code_off = __OptPassFinal(cctrl, a, bin, code_off);
-		rpn->code_misc3->addr = bin + code_off;
-		cctrl->backend_user_data5 = (int64_t)rpn->code_misc4;
-		code_off = __OptPassFinal(cctrl, b, bin, code_off);
-		rpn->code_misc4->addr = bin + code_off;
-		tmp.mode = MD_I64;
-		tmp.integer = 0;
-		tmp.raw_type = RT_I64i;
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		AIWNIOS_ADD_CODE(X86Jmp, 0);
-		CodeMiscAddRef(rpn->code_misc2, bin + code_off - 4);
-		rpn->code_misc->addr = bin + code_off;
-		tmp.integer = 1;
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		rpn->code_misc2->addr = bin + code_off;
-		break;
-	ic_xor_xor:
-#define BACKEND_LOGICAL_BINOP(op)                                                                        \
-	next = ICArgN(rpn, 1);                                                                               \
-	next2 = ICArgN(rpn, 0);                                                                              \
-	code_off = __OptPassFinal(cctrl, next2, bin, code_off);                                              \
-	code_off = __OptPassFinal(cctrl, next, bin, code_off);                                               \
-	if (rpn->res.mode == MD_REG) {                                                                       \
-		into_reg = rpn->res.reg;                                                                         \
-	} else                                                                                               \
-		into_reg = 0;                                                                                    \
-	code_off = PutICArgIntoReg(cctrl, &next->res, rpn->raw_type, AIWNIOS_TMP_IREG_POOP2, bin, code_off); \
-	code_off = PutICArgIntoReg(cctrl, &next2->res, rpn->raw_type, AIWNIOS_TMP_IREG_POOP, bin, code_off); \
-	BACKEND_BOOLIFY(AIWNIOS_TMP_IREG_POOP2, next->res.reg, next->res.raw_type);                          \
-	BACKEND_BOOLIFY(into_reg, next2->res.reg, next2->res.raw_type);                                      \
-	AIWNIOS_ADD_CODE(op, into_reg, AIWNIOS_TMP_IREG_POOP2);                                              \
-	if (rpn->res.mode != MD_REG) {                                                                       \
-		tmp.raw_type = rpn->raw_type;                                                                    \
-		tmp.reg = 0;                                                                                     \
-		tmp.mode = MD_REG;                                                                               \
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);                                         \
-	}
-		BACKEND_LOGICAL_BINOP(X86XorReg);
-		break;
-	ic_eq_eq:
-#define BACKEND_CMP                                                                                                                       \
-	next = ICArgN(rpn, 1);                                                                                                                \
-	next2 = ICArgN(rpn, 0);                                                                                                               \
-	code_off = __OptPassFinal(cctrl, next, bin, code_off);                                                                                \
-	code_off = __OptPassFinal(cctrl, next2, bin, code_off);                                                                               \
-	code_off = PutICArgIntoReg(cctrl, &next2->res, rpn->raw_type, (rpn->raw_type == RT_F64) ? 1 : AIWNIOS_TMP_IREG_POOP2, bin, code_off); \
-	code_off = PutICArgIntoReg(cctrl, &next->res, rpn->raw_type, 0, bin, code_off);                                                       \
-	if (rpn->raw_type == RT_F64) {                                                                                                        \
-		AIWNIOS_ADD_CODE(X86COMISDRegReg, next->res.reg, next2->res.reg);                                                                 \
-	} else {                                                                                                                              \
-		AIWNIOS_ADD_CODE(X86CmpRegReg, next->res.reg, next2->res.reg);                                                                    \
-	}
-		BACKEND_CMP;
-		if (old_pass_misc && old_fail_misc) {
-			AIWNIOS_ADD_CODE(X86Jcc, X86_COND_Z, 0);
-			CodeMiscAddRef(old_pass_misc, bin + code_off - 4);
-			AIWNIOS_ADD_CODE(X86Jmp, 0);
-			CodeMiscAddRef(old_fail_misc, bin + code_off - 4);
-		}
-		if (use_flags)
-			goto ret;
-		if (rpn->res.mode == MD_REG && rpn->res.mode != RT_F64) {
-			into_reg = rpn->res.reg;
-		} else
-			into_reg = 0;
-		AIWNIOS_ADD_CODE(X86Setcc, X86_COND_E, into_reg);
-		if (!(rpn->res.mode == MD_REG && rpn->res.mode != RT_F64)) {
-			tmp.raw_type = RT_I64i;
-			tmp.reg = 0;
-			tmp.mode = MD_REG;
-			if (rpn->res.keep_in_tmp)
-				rpn->res = tmp;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		}
-		break;
-	ic_ne:
-		BACKEND_CMP;
-		if (old_fail_misc && old_pass_misc) {
-			AIWNIOS_ADD_CODE(X86Jcc, X86_COND_Z ^ 1, 0);
-			CodeMiscAddRef(old_pass_misc, bin + code_off - 4);
-			AIWNIOS_ADD_CODE(X86Jmp, 0);
-			CodeMiscAddRef(old_fail_misc, bin + code_off - 4);
-		}
-		if (use_flags)
-			goto ret;
-		if (rpn->res.mode == MD_REG && rpn->res.mode != RT_F64) {
-			into_reg = rpn->res.reg;
-		} else
-			into_reg = 0;
-		AIWNIOS_ADD_CODE(X86Setcc, X86_COND_E | 1, into_reg);
-		if (!(rpn->res.mode == MD_REG && rpn->res.mode != RT_F64)) {
-			tmp.raw_type = RT_I64i;
-			tmp.reg = 0;
-			tmp.mode = MD_REG;
-			if (rpn->res.keep_in_tmp)
-				rpn->res = tmp;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		}
-		break;
-	ic_lsh:
-		if (rpn->raw_type != RT_F64) {
-			next2 = ICArgN(rpn, 0);
-			next = ICArgN(rpn, 1);
-			if (IsConst(next2) && Is32Bit(ConstVal(next2))) {
-				if(rpn->raw_type!=RT_F64) rpn->res.set_flags=1;
-				BACKEND_BINOP_IMM(X86ShlImm, X86AddReg); // X86AddReg wont be used here
-				break;
-			}
-			tmp.raw_type = RT_I64i;
-			tmp.reg = RCX;
-			tmp.mode = MD_REG;
-			code_off = __OptPassFinal(cctrl, next, bin, code_off);
-			code_off = __OptPassFinal(cctrl, next2, bin, code_off);
-			code_off = PutICArgIntoReg(cctrl, &next2->res, RT_U64i, RCX, bin, code_off);
-			tmp2.mode = MD_REG; // TODO IMPROVE
-			tmp2.raw_type = RT_PTR;
-			tmp2.reg = 0;
-			code_off = ICMov(cctrl, &tmp2, &next->res, bin, code_off);
-			code_off = PutICArgIntoReg(cctrl, &tmp2, RT_U64i, AIWNIOS_TMP_IREG_POOP, bin, code_off);
-			code_off = ICMov(cctrl, &tmp, &next2->res, bin, code_off);
-			AIWNIOS_ADD_CODE(X86ShlRCX, tmp2.reg);
-			if(rpn->raw_type!=RT_F64) rpn->res.set_flags=1;
-			if (rpn->res.keep_in_tmp)
-				rpn->res = tmp2;
-			code_off = ICMov(cctrl, &rpn->res, &tmp2, bin, code_off);
-		} else {
-			next = ICArgN(rpn, 1);
-			next2 = ICArgN(rpn, 0);
-			if (IsConst(next2) && Is32Bit(ConstVal(next2))) {
-				if(rpn->raw_type!=RT_F64) rpn->res.set_flags=1;
-				BACKEND_BINOP_IMM(X86ShlImm, X86AddReg); // X86AddReg wont be used here
-			}
-			code_off = __OptPassFinal(cctrl, next, bin, code_off);
-			code_off = __OptPassFinal(cctrl, next2, bin, code_off);
-			code_off = PutICArgIntoReg(cctrl, &next->res, rpn->raw_type, 1, bin, code_off);
-			code_off = PushToStack(cctrl, &next->res, bin, code_off);
-			code_off = PutICArgIntoReg(cctrl, &next2->res, RT_I64i, 0, bin, code_off);
-			tmp.raw_type = RT_I64i;
-			tmp.mode = MD_REG;
-			tmp.reg = RAX;
-			code_off = PopFromStack(cctrl, &next->res, bin, code_off);
-			AIWNIOS_ADD_CODE(X86ShlImm, tmp.reg, next2->res.integer);
-			if (rpn->res.keep_in_tmp)
-				rpn->res = tmp;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		}
-		break;
-	ic_rsh:
-		next = ICArgN(rpn, 1);
-		next2 = ICArgN(rpn, 0);
-		if (rpn->raw_type == RT_F64) {
-			code_off = __OptPassFinal(cctrl, next, bin, code_off);
-			code_off = __OptPassFinal(cctrl, next2, bin, code_off);
-			code_off = PutICArgIntoReg(cctrl, &next->res, rpn->raw_type, 0, bin, code_off);
-			code_off = PushToStack(cctrl, &next->res, bin, code_off);
-			code_off = PutICArgIntoReg(cctrl, &next2->res, RT_I64i, AIWNIOS_TMP_IREG_POOP2, bin, code_off);
-			tmp.raw_type = RT_I64i;
-			tmp.mode = MD_REG;
-			tmp.reg = RAX;
-			code_off = PopFromStack(cctrl, &next->res, bin, code_off);
-			AIWNIOS_ADD_CODE(X86ShrImm, tmp.reg, next2->res.reg);
-			if(rpn->raw_type!=RT_F64) rpn->res.set_flags=1;
-			if (rpn->res.keep_in_tmp)
-				rpn->res = tmp;
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-			break;
-		}
-		switch (rpn->raw_type) {
-		case RT_U8i:
-		case RT_U16i:
-		case RT_U32i:
-		case RT_U64i:
-			if (IsConst(next2) && Is32Bit(ConstVal(next2))) {
-				if(rpn->raw_type!=RT_F64) rpn->res.set_flags=1;
-				BACKEND_BINOP_IMM(X86ShrImm, X86AddReg); // X86AddReg wont be used here
-			}
-			next2 = ICArgN(rpn, 0);
-			next = ICArgN(rpn, 1);
-			tmp.raw_type = RT_I64i;
-			tmp.reg = RCX;
-			tmp.mode = MD_REG;
-			code_off = __OptPassFinal(cctrl, next, bin, code_off);
-			code_off = __OptPassFinal(cctrl, next2, bin, code_off);
-			code_off = PutICArgIntoReg(cctrl, &next2->res, RT_U64i, RCX, bin, code_off);
-			tmp2.mode = MD_REG; // TODO IMPROVE
-			tmp2.raw_type = RT_PTR;
-			tmp2.reg = 0;
-			code_off = ICMov(cctrl, &tmp2, &next->res, bin, code_off);
-			// POOP2 is RCX
-			code_off = PutICArgIntoReg(cctrl, &tmp2, RT_U64i, AIWNIOS_TMP_IREG_POOP, bin, code_off);
-			code_off = ICMov(cctrl, &tmp, &next2->res, bin, code_off);
-			AIWNIOS_ADD_CODE(X86ShrRCX, tmp2.reg);
-			if(rpn->raw_type!=RT_F64) rpn->res.set_flags=1;
-			if (rpn->res.keep_in_tmp)
-				rpn->res = tmp2;
-			code_off = ICMov(cctrl, &rpn->res, &tmp2, bin, code_off);
-			break;
-		default:
-			if (IsConst(next2) && Is32Bit(ConstVal(next2))) {
-				if(rpn->raw_type!=RT_F64) rpn->res.set_flags=1;
-				BACKEND_BINOP_IMM(X86SarImm, X86AddReg); // X86AddReg wont be used here
-			}
-			tmp.raw_type = RT_I64i;
-			tmp.reg = RCX;
-			tmp.mode = MD_REG;
-			code_off = __OptPassFinal(cctrl, next, bin, code_off);
-			code_off = __OptPassFinal(cctrl, next2, bin, code_off);
-			code_off = PutICArgIntoReg(cctrl, &next2->res, RT_U64i, RCX, bin, code_off);
-			tmp2.mode = MD_REG; // TODO IMPROVE
-			tmp2.raw_type = RT_PTR;
-			tmp2.reg = 0;
-			code_off = ICMov(cctrl, &tmp2, &next->res, bin, code_off);
-			code_off = PutICArgIntoReg(cctrl, &tmp2, RT_U64i, AIWNIOS_TMP_IREG_POOP, bin, code_off);
-			code_off = ICMov(cctrl, &tmp, &next2->res, bin, code_off);
-			AIWNIOS_ADD_CODE(X86SarRCX, tmp2.reg);
-			if(rpn->raw_type!=RT_F64) rpn->res.set_flags=1;
-			if (rpn->res.keep_in_tmp)
-				rpn->res = tmp2;
-			code_off = ICMov(cctrl, &rpn->res, &tmp2, bin, code_off);
-		}
-		break;
-	ic_call:
-		//
-		// ()_()_()_()
-		// /          \     // When we call a function,all temp registers
-		// | O______O |     // are invalidated,so we can reset the temp register
-		// | \______/ |===> // counts (for the new expressions).
-		// \__________/     //
-		//   \./   \./      // We will restore the temp register counts after the
-		//   call
-		//
-		i = cctrl->backend_user_data2;
-		i2 = cctrl->backend_user_data3;
-		cctrl->backend_user_data2 = 0;
-		cctrl->backend_user_data3 = 0;
-		code_off = __ICFCallTOS(cctrl, rpn, bin, code_off);
-		cctrl->backend_user_data2 = i;
-		cctrl->backend_user_data3 = i2;
-		break;
-	ic_vargs:
-		//  ^^^^^^^^
-		// (        \      ___________________
-		// ( (*) (*)|     /                   \
+#define BACKEND_BINOP(f_op, i_op, f_sib_op, i_sib_op)                          \
+  do {                                                                         \
+    next = ICArgN(rpn, 1);                                                     \
+    next2 = ICArgN(rpn, 0);                                                    \
+    orig_dst = next->res;                                                      \
+    if (ModeIsDerefToSIB(next2) &&                                             \
+        ((next2->raw_type == RT_F64) == (rpn->raw_type == RT_F64))) {          \
+      if (!(next->raw_type != RT_F64 && next->res.mode != MD_REG) &&           \
+          RawTypeIs64(next2->raw_type)) {                                      \
+        code_off = __OptPassFinal(cctrl, next, bin, code_off);                 \
+        code_off = DerefToICArg(cctrl, &derefed, next2,                        \
+                                AIWNIOS_TMP_IREG_POOP2, bin, code_off);        \
+        if (rpn->res.mode == MD_NULL)                                          \
+          break;                                                               \
+        if (rpn->res.mode == MD_REG &&                                         \
+            !DstRegAffectsMode(&rpn->res, &derefed)) {                         \
+          into_reg = rpn->res.reg;                                             \
+        } else                                                                 \
+          into_reg = 0;                                                        \
+        tmp.mode = MD_REG;                                                     \
+        tmp.raw_type = rpn->raw_type;                                          \
+        tmp.reg = into_reg;                                                    \
+        code_off = ICMov(cctrl, &tmp, &next->res, bin, code_off);              \
+        if (rpn->raw_type == RT_F64) {                                         \
+          AIWNIOS_ADD_CODE(f_sib_op, tmp.reg, derefed.__SIB_scale,             \
+                           derefed.reg2, derefed.reg, derefed.off);            \
+        } else {                                                               \
+          AIWNIOS_ADD_CODE(i_sib_op, tmp.reg, derefed.__SIB_scale,             \
+                           derefed.reg2, derefed.reg, derefed.off);            \
+        }                                                                      \
+        if (rpn->res.keep_in_tmp)                                              \
+          rpn->res = next->res;                                                \
+        if (rpn->res.mode != MD_NULL) {                                        \
+          code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);             \
+        }                                                                      \
+        break;                                                                 \
+      }                                                                        \
+    }                                                                          \
+    code_off = __OptPassFinal(cctrl, next, bin, code_off);                     \
+    code_off = __OptPassFinal(cctrl, next2, bin, code_off);                    \
+    if (rpn->res.mode == MD_NULL)                                              \
+      break;                                                                   \
+    if (rpn->res.mode == MD_REG &&                                             \
+        !DstRegAffectsMode(&rpn->res, &next2->res)) {                          \
+      into_reg = rpn->res.reg;                                                 \
+    } else                                                                     \
+      into_reg = 0;                                                            \
+    tmp.mode = MD_REG;                                                         \
+    tmp.raw_type = rpn->raw_type;                                              \
+    tmp.reg = into_reg;                                                        \
+    code_off = ICMov(cctrl, &tmp, &next->res, bin, code_off);                  \
+    if (rpn->raw_type == RT_F64) {                                             \
+      code_off =                                                               \
+          PutICArgIntoReg(cctrl, &tmp, rpn->raw_type, 0, bin, code_off);       \
+      code_off = PutICArgIntoReg(cctrl, &next2->res, rpn->raw_type, 1, bin,    \
+                                 code_off);                                    \
+    } else {                                                                   \
+      code_off = PutICArgIntoReg(cctrl, &tmp, rpn->raw_type,                   \
+                                 AIWNIOS_TMP_IREG_POOP, bin, code_off);        \
+      code_off = PutICArgIntoReg(cctrl, &next2->res, rpn->raw_type,            \
+                                 AIWNIOS_TMP_IREG_POOP2, bin, code_off);       \
+    }                                                                          \
+    if (rpn->raw_type == RT_F64) {                                             \
+      AIWNIOS_ADD_CODE(f_op, tmp.reg, next2->res.reg);                         \
+    } else {                                                                   \
+      AIWNIOS_ADD_CODE(i_op, tmp.reg, next2->res.reg);                         \
+    }                                                                          \
+    if (rpn->res.keep_in_tmp)                                                  \
+      rpn->res = tmp;                                                          \
+    if (rpn->res.mode != MD_NULL) {                                            \
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);                 \
+    }                                                                          \
+  } while (0);
+#define BACKEND_BINOP_IMM(i_imm_op, i_op)                                      \
+  next = ICArgN(rpn, 1);                                                       \
+  next2 = ICArgN(rpn, 0);                                                      \
+  if (rpn->raw_type != RT_F64 && IsConst(next2) && Is32Bit(ConstVal(next2)) && \
+      next2->type != IC_F64 && next2->integer >= 0) {                          \
+    code_off = __OptPassFinal(cctrl, next, bin, code_off);                     \
+    tmp2 = next->res;                                                          \
+    if (rpn->res.mode == MD_NULL)                                              \
+      break;                                                                   \
+    if (rpn->res.mode == MD_REG)                                               \
+      into_reg = rpn->res.reg;                                                 \
+    else                                                                       \
+      into_reg = 0;                                                            \
+    code_off =                                                                 \
+        PutICArgIntoReg(cctrl, &tmp2, RT_I64i, into_reg, bin, code_off);       \
+    if (Is32Bit(next2->integer)) {                                             \
+      tmp.reg = into_reg;                                                      \
+      tmp.mode = MD_REG;                                                       \
+      tmp.raw_type = rpn->raw_type;                                            \
+      code_off = ICMov(cctrl, &tmp, &tmp2, bin, code_off);                     \
+      AIWNIOS_ADD_CODE(i_imm_op, into_reg, next2->integer);                    \
+    } else {                                                                   \
+      tmp.mode = MD_REG;                                                       \
+      tmp.reg = AIWNIOS_TMP_IREG_POOP;                                         \
+      tmp.raw_type = RT_I64i;                                                  \
+      code_off = ICMov(cctrl, &tmp, &next2->res, bin, code_off);               \
+      AIWNIOS_ADD_CODE(i_op, into_reg, tmp.reg);                               \
+    }                                                                          \
+    if (rpn->res.keep_in_tmp)                                                  \
+      rpn->res = tmp;                                                          \
+    if (rpn->res.mode != MD_REG && rpn->res.mode != MD_NULL) {                 \
+      tmp.raw_type = rpn->raw_type;                                            \
+      tmp.reg = into_reg;                                                      \
+      tmp.mode = MD_REG;                                                       \
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);                 \
+    }                                                                          \
+    break;                                                                     \
+  }
+    if (rpn->raw_type != RT_F64)
+      rpn->res.set_flags = 1;
+    BACKEND_BINOP_IMM(X86AddImm32, X86AddReg);
+    BACKEND_BINOP(X86AddSDReg, X86AddReg, X86AddSDSIB64, X86AddSIB64);
+    break;
+  ic_comma:
+    next = ICArgN(rpn, 1);
+    next2 = ICArgN(rpn, 0);
+    orig_dst = next->res;
+    code_off = __OptPassFinal(cctrl, next2, bin, code_off);
+    code_off = __OptPassFinal(cctrl, next, bin, code_off);
+    code_off = ICMov(cctrl, &rpn->res, &next2->res, bin, code_off);
+    break;
+  ic_eq:
+    next = ICArgN(rpn, 1);
+    next2 = ICArgN(rpn, 0);
+    orig_dst = next->res;
+    code_off = __OptPassFinal(cctrl, next2, bin, code_off);
+    if (next->type == IC_TYPECAST) {
+      TYPECAST_ASSIGN_BEGIN(next, next2);
+      if (rpn->res.mode != MD_NULL) {
+        // Avoid a double-derefernce
+        code_off = PutICArgIntoReg(
+            cctrl, &next2->res, rpn->raw_type,
+            rpn->raw_type == RT_F64 ? 0 : AIWNIOS_TMP_IREG_POOP, bin, code_off);
+      }
+      code_off = ICMov(cctrl, &next->res, &next2->res, bin, code_off);
+      TYPECAST_ASSIGN_END(next);
+    } else if (next->type == IC_DEREF) {
+      tmp = next->res;
+      code_off = DerefToICArg(cctrl, &tmp, next, AIWNIOS_TMP_IREG_POOP2, bin,
+                              code_off);
+      if (rpn->res.mode != MD_NULL) {
+        // Avoid a double-derefernce
+        code_off = PutICArgIntoReg(
+            cctrl, &next2->res, rpn->raw_type,
+            rpn->raw_type == RT_F64 ? 0 : AIWNIOS_TMP_IREG_POOP, bin, code_off);
+      }
+      code_off = ICMov(cctrl, &tmp, &next2->res, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+      break;
+    } else if (next->type == IC_GLOBAL) {
+      next->res.mode = MD_PTR;
+      next->res.raw_type = next->raw_type;
+      if (next->global_var->base.type & HTT_GLBL_VAR) {
+        next->res.off = (int64_t)next->global_var->data_addr;
+      } else if (next->global_var->base.type & HTT_FUN) {
+        next->res.off = (int64_t)((CHashFun *)next->global_var)->fun_ptr;
+      }
+      code_off = __OptPassFinal(cctrl, next, bin, code_off);
+      if (rpn->res.mode != MD_NULL) {
+        // Avoid a double-derefernce
+        code_off = PutICArgIntoReg(
+            cctrl, &next2->res, rpn->raw_type,
+            rpn->raw_type == RT_F64 ? 0 : AIWNIOS_TMP_IREG_POOP, bin, code_off);
+      }
+      code_off = ICMov(cctrl, &next->res, &next2->res, bin, code_off);
+    } else {
+      code_off = __OptPassFinal(cctrl, next, bin, code_off);
+      if (rpn->res.mode != MD_NULL) {
+        // Avoid a double-derefernce
+        code_off = PutICArgIntoReg(
+            cctrl, &next2->res, rpn->raw_type,
+            rpn->raw_type == RT_F64 ? 0 : AIWNIOS_TMP_IREG_POOP, bin, code_off);
+      }
+      code_off = ICMov(cctrl, &next->res, &next2->res, bin, code_off);
+    }
+    code_off = ICMov(cctrl, &rpn->res, &next2->res, bin, code_off);
+    break;
+  ic_sub:
+    if (rpn->raw_type != RT_F64)
+      rpn->res.set_flags = 1;
+    BACKEND_BINOP_IMM(X86SubImm32, X86SubReg);
+    BACKEND_BINOP(X86SubSDReg, X86SubReg, X86SubSDSIB64, X86SubSIB64);
+    break;
+  ic_div:
+    next = rpn->base.next;
+    next2 = ICArgN(rpn, 1);
+    if (next->type == IC_I64 && next2->raw_type != RT_F64) {
+      if (__builtin_popcountll(next->integer) == 1) {
+        code_off = __OptPassFinal(cctrl, next2, bin, code_off);
+        if (rpn->res.mode == MD_REG)
+          into_reg = rpn->res.reg;
+        else
+          into_reg = RAX;
+        tmp.mode = MD_REG;
+        tmp.raw_type = RT_I64i;
+        tmp.reg = into_reg;
+        code_off = ICMov(cctrl, &tmp, &next2->res, bin, code_off);
+        switch (next2->raw_type) {
+        case RT_I8i:
+        case RT_I16i:
+        case RT_I32i:
+        case RT_I64i:
+          AIWNIOS_ADD_CODE(X86SarImm, into_reg,
+                           __builtin_ffsll(next->integer) - 1);
+          if (rpn->raw_type != RT_F64)
+            rpn->res.set_flags = 1;
+          break;
+        default:
+          AIWNIOS_ADD_CODE(X86ShrImm, into_reg,
+                           __builtin_ffsll(next->integer) - 1);
+          if (rpn->raw_type != RT_F64)
+            rpn->res.set_flags = 1;
+          break;
+        }
+        if (rpn->res.keep_in_tmp)
+          rpn->res = tmp;
+        code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+        break;
+      }
+    }
+    if (rpn->raw_type == RT_U64i) {
+#define CQO_OP(use_reg, op, sib_op)                                            \
+  next = ICArgN(rpn, 1);                                                       \
+  next2 = ICArgN(rpn, 0);                                                      \
+  orig_dst = next->res;                                                        \
+  if (ModeIsDerefToSIB(next2) &&                                               \
+      ((next2->raw_type == RT_F64) == (rpn->raw_type == RT_F64)) &&            \
+      RawTypeIs64(next2->raw_type)) {                                          \
+    code_off = __OptPassFinal(cctrl, next, bin, code_off);                     \
+    code_off = DerefToICArg(cctrl, &derefed, next2, AIWNIOS_TMP_IREG_POOP2,    \
+                            bin, code_off);                                    \
+    tmp.raw_type = RT_I64i;                                                    \
+    tmp.reg = RAX;                                                             \
+    tmp.mode = MD_REG;                                                         \
+    code_off = ICMov(cctrl, &tmp, &next->res, bin, code_off);                  \
+    if (rpn->raw_type == RT_U64i) {                                            \
+      AIWNIOS_ADD_CODE(X86XorReg, RDX, RDX);                                   \
+    } else {                                                                   \
+      AIWNIOS_ADD_CODE(X86Cqo, 0);                                             \
+    }                                                                          \
+    AIWNIOS_ADD_CODE(sib_op, derefed.__SIB_scale, derefed.reg2, derefed.reg,   \
+                     derefed.off);                                             \
+    tmp.reg = use_reg;                                                         \
+    if (rpn->res.keep_in_tmp)                                                  \
+      rpn->res = tmp;                                                          \
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);                   \
+    break;                                                                     \
+  }                                                                            \
+  tmp.raw_type = RT_I64i;                                                      \
+  tmp.reg = RAX;                                                               \
+  tmp.mode = MD_REG;                                                           \
+  code_off = __OptPassFinal(cctrl, next, bin, code_off);                       \
+  code_off = __OptPassFinal(cctrl, next2, bin, code_off);                      \
+  code_off = ICMov(cctrl, &tmp, &next->res, bin, code_off);                    \
+  code_off = PutICArgIntoReg(cctrl, &next2->res, RT_U64i, R8, bin, code_off);  \
+  if (rpn->raw_type == RT_U64i) {                                              \
+    AIWNIOS_ADD_CODE(X86XorReg, RDX, RDX);                                     \
+  } else {                                                                     \
+    AIWNIOS_ADD_CODE(X86Cqo, 0);                                               \
+  }                                                                            \
+  AIWNIOS_ADD_CODE(op, next2->res.reg);                                        \
+  tmp.reg = use_reg;                                                           \
+  if (rpn->res.keep_in_tmp)                                                    \
+    rpn->res = tmp;                                                            \
+  code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+      CQO_OP(RAX, X86DivReg, X86DivSIB64);
+    } else if (rpn->raw_type != RT_F64) {
+      CQO_OP(RAX, X86IDivReg, X86IDivSIB64);
+    } else {
+      BACKEND_BINOP(X86DivSDReg, X86DivSDReg, X86DivSDSIB64, X86DivSDSIB64);
+    }
+    break;
+  ic_mul:
+    next = rpn->base.next;
+    next2 = ICArgN(rpn, 1);
+    if (next->type == IC_I64 && next2->raw_type != RT_F64) {
+      if (__builtin_popcountll(next->integer) == 1) {
+        code_off = __OptPassFinal(cctrl, next2, bin, code_off);
+        code_off = PutICArgIntoReg(cctrl, &next2->res, next2->raw_type,
+                                   AIWNIOS_TMP_IREG_POOP, bin, code_off);
+        if (rpn->res.mode == MD_REG) {
+          code_off = ICMov(cctrl, &rpn->res, &next2->res, bin, code_off);
+          AIWNIOS_ADD_CODE(X86ShlImm, rpn->res.reg,
+                           __builtin_ffsll(next->integer) - 1);
+        } else {
+          tmp.raw_type = RT_I64i;
+          tmp.reg = RAX;
+          tmp.mode = MD_REG;
+          code_off = ICMov(cctrl, &tmp, &next2->res, bin, code_off);
+          AIWNIOS_ADD_CODE(X86ShlImm, tmp.reg,
+                           __builtin_ffsll(next->integer) - 1);
+          if (rpn->res.keep_in_tmp)
+            rpn->res = tmp;
+          code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+        }
+        break;
+      }
+    }
+    if (rpn->raw_type == RT_U64i) {
+      CQO_OP(RAX, X86MulReg, X86MulSIB64);
+    } else {
+      BACKEND_BINOP(X86MulSDReg, X86IMul2Reg, X86MulSDSIB64, X86IMul2SIB64);
+    }
+    break;
+  ic_deref:
+    next = rpn->base.next;
+    i = 0;
+    //
+    // Here's the Donald Trump deal,Derefernced function pointers
+    // don't derefence(you dont copy a function into memory).
+    //
+    // I64 (*fptr)()=&Foo;
+    // (*fptr)(); //Doesn't "dereference"
+    //
+    if (rpn->raw_type == RT_FUNC) {
+      code_off = __OptPassFinal(cctrl, next, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
+      goto ret;
+    }
+    code_off =
+        DerefToICArg(cctrl, &tmp, rpn, AIWNIOS_TMP_IREG_POOP2, bin, code_off);
+    if (rpn->res.keep_in_tmp)
+      rpn->res = tmp;
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    break;
+  ic_and:
+    if (rpn->raw_type != RT_F64)
+      rpn->res.set_flags = 1;
+    BACKEND_BINOP_IMM(X86AndImm, X86AndImm);
+    BACKEND_BINOP(X86AndPDReg, X86AndReg, X86AndPDSIB64, X86AndSIB64);
+    break;
+  ic_addr_of:
+    next = rpn->base.next;
+    switch (next->type) {
+      break;
+    case __IC_STATIC_REF:
+      if (rpn->res.mode == MD_REG)
+        into_reg = rpn->res.reg;
+      else
+        into_reg = 0;
+      AIWNIOS_ADD_CODE(X86LeaSIB, into_reg, -1, -1, RIP, 0);
+      if (bin)
+        CodeMiscAddRef(cctrl->statics_label, bin + code_off - 4)->offset =
+            rpn->integer;
+      goto restore_reg;
+      break;
+    case IC_DEREF:
+      next = rpn->base.next;
+      code_off = __OptPassFinal(cctrl, next, bin, code_off);
+      code_off = PutICArgIntoReg(cctrl, &next->res, RT_PTR,
+                                 AIWNIOS_TMP_IREG_POOP2, bin, code_off);
+      code_off = ICMov(cctrl, &rpn->res, &next->res, bin, code_off);
+      break;
+    case IC_BASE_PTR:
+      if (rpn->res.mode == MD_REG)
+        into_reg = rpn->res.reg;
+      else
+        into_reg = 0;
+      AIWNIOS_ADD_CODE(X86LeaSIB, into_reg, -1, -1, RBP, -next->integer);
+      goto restore_reg;
+      break;
+    case IC_STATIC:
+      if (rpn->res.mode == MD_REG)
+        into_reg = rpn->res.reg;
+      else
+        into_reg = 0;
+      AIWNIOS_ADD_CODE(X86LeaSIB, into_reg, -1, -1, RIP,
+                       (char *)rpn->integer - (bin + code_off));
+      goto restore_reg;
+    case IC_GLOBAL:
+    get_glbl_ptr:
+      if (rpn->res.mode == MD_REG)
+        into_reg = rpn->res.reg;
+      else
+        into_reg = 0;
+      if (next->global_var->base.type & HTT_GLBL_VAR) {
+        enter_addr = next->global_var->data_addr;
+      } else if (next->global_var->base.type & HTT_FUN) {
+        enter_addr = ((CHashFun *)next->global_var)->fun_ptr;
+      } else
+        abort();
+      // Undefined?
+      if (!enter_addr) {
+        misc = AddRelocMisc(cctrl, next->global_var->base.str);
+        AIWNIOS_ADD_CODE(
+            X86MovRegIndirI64, into_reg, -1, -1, RIP,
+            X86MovRegIndirI64(NULL, into_reg, -1, -1, RIP,
+                              0)); // X86MovRegIndirI64 will return inst size
+        CodeMiscAddRef(misc, bin + code_off - 4);
+        goto restore_reg;
+      } else if (Is32Bit(enter_addr - (bin + code_off))) {
+        AIWNIOS_ADD_CODE(X86LeaSIB, into_reg, -1, -1, RIP,
+                         enter_addr - (bin + code_off));
+        goto restore_reg;
+      }
+      code_off =
+          __ICMoveI64(cctrl, into_reg, (int64_t)enter_addr, bin, code_off);
+    restore_reg:
+      tmp.mode = MD_REG;
+      tmp.raw_type = rpn->raw_type;
+      tmp.reg = into_reg;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+      break;
+    default:
+      abort();
+    }
+    break;
+  ic_xor:
+    if (rpn->raw_type != RT_F64) {
+      rpn->res.set_flags = 1;
+      BACKEND_BINOP_IMM(X86XorImm, X86XorReg);
+    }
+    BACKEND_BINOP(X86XorPDReg, X86XorReg, X86XorPDSIB64, X86XorSIB64);
+    break;
+  ic_mod:
+    next = ICArgN(rpn, 1);
+    next2 = ICArgN(rpn, 0);
+    if (rpn->raw_type != RT_F64) {
+      if (rpn->raw_type == RT_U64i) {
+        CQO_OP(RDX, X86DivReg, X86DivSIB64);
+      } else {
+        CQO_OP(RDX, X86IDivReg, X86IDivSIB64);
+      }
+    } else {
+      code_off = __OptPassFinal(cctrl, next, bin, code_off);
+      code_off = __OptPassFinal(cctrl, next2, bin, code_off);
+      code_off = PutICArgIntoReg(cctrl, &next2->res, RT_F64, 1, bin, code_off);
+      code_off = PutICArgIntoReg(cctrl, &next->res, RT_F64, 0, bin, code_off);
+      tmp2.reg = 2;
+      tmp2.mode = MD_REG;
+      tmp2.raw_type = RT_F64;
+      code_off = ICMov(cctrl, &tmp2, &next->res, bin, code_off);
+      AIWNIOS_ADD_CODE(X86DivSDReg, tmp2.reg, next2->res.reg);
+      code_off = PushToStack(cctrl, &tmp2, bin, code_off);
+      AIWNIOS_ADD_CODE(X86CVTTSD2SIRegSIB64, RAX, -1, -1, RSP, 0);
+      AIWNIOS_ADD_CODE(X86MovIndirRegI64, RAX, -1, -1, RSP, 0);
+      AIWNIOS_ADD_CODE(X86CVTTSI2SDRegSIB64, tmp2.reg, -1, -1, RSP, 0);
+      AIWNIOS_ADD_CODE(X86PopReg, RAX);
+      AIWNIOS_ADD_CODE(X86MulSDReg, tmp2.reg, next2->res.reg);
+      tmp.reg = 0;
+      tmp.mode = MD_REG;
+      tmp.raw_type = RT_F64;
+      code_off = ICMov(cctrl, &tmp, &next->res, bin, code_off); // tmp.reg==0
+      AIWNIOS_ADD_CODE(X86SubSDReg, tmp.reg, tmp2.reg);
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    }
+    break;
+  ic_or:
+    if (rpn->raw_type != RT_F64)
+      rpn->res.set_flags = 1;
+    BACKEND_BINOP_IMM(X86OrImm, X86OrReg);
+    BACKEND_BINOP(X86OrPDReg, X86OrReg, X86OrPDSIB64, X86OrSIB64);
+    break;
+  ic_lt:
+  ic_gt:
+  ic_le:
+  ic_ge:
+    //
+    // Ask nroot how this works if you want to know
+    //
+    // X/V3 is for lefthand side
+    // X/V4 is for righthand side
+    range = NULL;
+    range_args = NULL;
+    range_fail_addrs = NULL;
+    range_cmp_types = NULL;
+  get_range_items:
+    cnt = 0;
+    for (next = rpn; 1; next = ICFwd(next->base.next) // TODO explain
+    ) {
+      switch (next->type) {
+      case IC_LT:
+      case IC_GT:
+      case IC_LE:
+      case IC_GE:
+        goto cmp_pass;
+      }
+      if (range_args)
+        range_args[cnt] = next; // See below
+      break;
+    cmp_pass:
+      //
+      // <
+      //    right rpn.next
+      //    left  ICFwd(rpn.next)
+      //
+      if (range_args)
+        range_args[cnt] = next->base.next;
+      if (range)
+        range[cnt] = next;
+      cnt++;
+    }
+    if (!range) {
+      // This are reversed
+      range_args = A_MALLOC(sizeof(CRPN *) * (cnt + 1), cctrl->hc);
+      range = A_MALLOC(sizeof(CRPN *) * cnt, cctrl->hc);
+      range_fail_addrs = A_MALLOC(sizeof(CRPN *) * cnt, cctrl->hc);
+      range_cmp_types = A_MALLOC(sizeof(int64_t) * cnt, cctrl->hc);
+      goto get_range_items;
+    }
+    code_off = __OptPassFinal(cctrl, next = range_args[cnt], bin, code_off);
+    for (i = cnt - 1; i >= 0; i--) {
+      next2 = range_args[i];
+      code_off = __OptPassFinal(cctrl, next2, bin, code_off);
+      memcpy(&tmp, &next->res, sizeof(CICArg));
+      memcpy(&tmp2, &next2->res, sizeof(CICArg));
+      use_flt_cmp = next->raw_type == RT_F64 || next2->raw_type == RT_F64;
+      i2 = RT_I64i;
+      i2 = next->res.raw_type > i2 ? next->res.raw_type : i2;
+      i2 = next2->res.raw_type > i2 ? next2->res.raw_type : i2;
+      code_off = PutICArgIntoReg(cctrl, &tmp, i2, AIWNIOS_TMP_IREG_POOP2, bin,
+                                 code_off);
+      code_off = PutICArgIntoReg(cctrl, &tmp2, i2, 0, bin, code_off);
+      if (use_flt_cmp) {
+        AIWNIOS_ADD_CODE(X86COMISDRegReg, tmp.reg, tmp2.reg);
+      } else {
+        AIWNIOS_ADD_CODE(X86CmpRegReg, tmp.reg, tmp2.reg);
+      }
+      //
+      // We use the opposite compare because if fail we jump to the fail
+      // zone
+      //
+      if (use_flt_cmp) {
+      unsigned_cmp:
+        switch (range[i]->type) {
+          break;
+        case IC_LT:
+          range_cmp_types[i] = X86_COND_B | 1;
+          break;
+        case IC_GT:
+          range_cmp_types[i] = X86_COND_A | 1;
+          break;
+        case IC_LE:
+          range_cmp_types[i] = X86_COND_BE | 1;
+          break;
+        case IC_GE:
+          range_cmp_types[i] = X86_COND_AE | 1;
+        }
+      } else if (next->raw_type == RT_U64i || next2->raw_type == RT_U64i) {
+        goto unsigned_cmp;
+      } else {
+        switch (range[i]->type) {
+          break;
+        case IC_LT:
+          range_cmp_types[i] = X86_COND_L | 1;
+          break;
+        case IC_GT:
+          range_cmp_types[i] = X86_COND_G | 1;
+          break;
+        case IC_LE:
+          range_cmp_types[i] = X86_COND_LE | 1;
+          break;
+        case IC_GE:
+          range_cmp_types[i] = X86_COND_GE | 1;
+        }
+      }
+      range_fail_addrs[i] = bin + code_off;
+      AIWNIOS_ADD_CODE(X86Jcc, range_cmp_types[i],
+                       0); // WILL BE FILLED IN LATER
+      if (old_fail_misc)
+        CodeMiscAddRef(old_fail_misc, bin + code_off - 4);
+      next = next2;
+    }
+    if (!(old_fail_misc && old_pass_misc)) {
+      tmp.mode = MD_I64;
+      tmp.integer = 1;
+      tmp.raw_type = RT_I64i;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+      exit_addr = bin + code_off;
+      AIWNIOS_ADD_CODE(X86Jmp, 0);
+      if (bin)
+        for (i = 0; i != cnt; i++) {
+          X86Jcc(range_fail_addrs[i], range_cmp_types[i],
+                 (bin + code_off) -
+                     (char *)range_fail_addrs[i]); // TODO unsigned
+        }
+      tmp.mode = MD_I64;
+      tmp.integer = 0;
+      tmp.raw_type = RT_I64i;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+      if (bin)
+        X86Jmp(exit_addr, (bin + code_off) - exit_addr);
+    } else {
+      AIWNIOS_ADD_CODE(X86Jmp, 0);
+      CodeMiscAddRef(old_pass_misc, bin + code_off - 4);
+    }
+    A_FREE(range);
+    A_FREE(range_args);
+    A_FREE(range_fail_addrs);
+    A_FREE(range_cmp_types);
+    break;
+  ic_lnot:
+    next = rpn->base.next;
+    code_off = __OptPassFinal(cctrl, next, bin, code_off);
+    code_off =
+        PutICArgIntoReg(cctrl, &next->res, rpn->raw_type, 0, bin, code_off);
+    if (next->res.raw_type != RT_F64) {
+      AIWNIOS_ADD_CODE(X86Test, next->res.reg, next->res.reg);
+    } else {
+      code_off = __ICMoveF64(cctrl, 1, 0, bin, code_off);
+      AIWNIOS_ADD_CODE(X86COMISDRegReg, 1, 0);
+    }
+    if (old_pass_misc && old_fail_misc) {
+      AIWNIOS_ADD_CODE(X86Jcc, X86_COND_Z, 0);
+      if (bin)
+        CodeMiscAddRef(old_pass_misc, bin + code_off - 4);
+      AIWNIOS_ADD_CODE(X86Jmp, 0);
+      if (bin)
+        CodeMiscAddRef(old_fail_misc, bin + code_off - 4);
+      goto ret;
+    }
+    if (rpn->res.mode == MD_REG && rpn->res.mode != RT_F64) {
+      into_reg = rpn->res.reg;
+    } else
+      into_reg = 0; // Store into reg 0
+    AIWNIOS_ADD_CODE(X86Setcc, X86_COND_Z, into_reg);
+    if (!(rpn->res.mode == MD_REG && rpn->res.mode != RT_F64)) {
+      tmp.raw_type = RT_I64i;
+      tmp.reg = 0;
+      tmp.mode = MD_REG;
+      if (rpn->res.keep_in_tmp)
+        rpn->res = tmp;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    }
+    break;
+  ic_bnot:
+    if (rpn->raw_type == RT_F64) {
+      code_off = __OptPassFinal(cctrl, next, bin, code_off);
+      code_off =
+          PutICArgIntoReg(cctrl, &next->res, rpn->raw_type, 1, bin, code_off);
+      static double ul;
+      *(int64_t *)&ul = ~0ll;
+      code_off = __ICMoveF64(cctrl, 0, ul, bin, code_off);
+      AIWNIOS_ADD_CODE(X86XorPDReg, next->res.reg, 0);
+      goto ret;
+    }
+    if (rpn->raw_type != RT_F64)
+      rpn->res.set_flags = 1;
+    BACKEND_UNOP(X86NotReg, X86NotReg);
+    break;
+  ic_post_inc:
+    code_off = __SexyPostOp(cctrl, rpn, X86AddImm32, X86AddReg, X86AddSDReg,
+                            X86IncReg, X86IncSIB64, bin, code_off);
+    break;
+  ic_post_dec:
+    code_off = __SexyPostOp(cctrl, rpn, X86SubImm32, X86SubReg, X86SubSDReg,
+                            X86DecReg, X86DecSIB64, bin, code_off);
+    break;
+  ic_pre_inc:
+    code_off = __SexyPreOp(cctrl, rpn, X86AddImm32, X86AddReg, X86AddSDReg,
+                           X86IncReg, X86IncSIB64, bin, code_off);
+    break;
+  ic_pre_dec:
+    code_off = __SexyPreOp(cctrl, rpn, X86SubImm32, X86SubReg, X86SubSDReg,
+                           X86DecReg, X86DecSIB64, bin, code_off);
+    break;
+  ic_and_and:
+#define BACKEND_TEST(_res)                                                     \
+  {                                                                            \
+    int64_t rt = (_res)->raw_type;                                             \
+    code_off = PutICArgIntoReg(cctrl, (_res), rt, 0, bin, code_off);           \
+    int64_t reg = (_res)->reg;                                                 \
+    if ((rt) != RT_F64) {                                                      \
+      AIWNIOS_ADD_CODE(X86Test, reg, reg);                                     \
+    } else {                                                                   \
+      code_off = __ICMoveF64(cctrl, 2, 0, bin, code_off);                      \
+      AIWNIOS_ADD_CODE(X86COMISDRegReg, reg, 2);                               \
+    }                                                                          \
+  }
+    if (old_pass_misc && old_fail_misc) {
+      a = ICArgN(rpn, 1);
+      b = ICArgN(rpn, 0);
+      code_off = __OptPassFinal(cctrl, a, bin, code_off);
+      BACKEND_TEST(&a->res);
+      AIWNIOS_ADD_CODE(X86Jcc, X86_COND_Z, 6);
+      CodeMiscAddRef(old_fail_misc, bin + code_off - 4);
+      code_off = __OptPassFinal(cctrl, b, bin, code_off);
+      BACKEND_TEST(&b->res);
+      AIWNIOS_ADD_CODE(X86Jcc, X86_COND_Z, 6);
+      CodeMiscAddRef(old_fail_misc, bin + code_off - 4);
+      AIWNIOS_ADD_CODE(X86Jmp, 0);
+      CodeMiscAddRef(old_pass_misc, bin + code_off - 4);
+      goto ret;
+    }
+#define BACKEND_BOOLIFY(to, reg, rt)                                           \
+  if ((rt) != RT_F64) {                                                        \
+    AIWNIOS_ADD_CODE(X86Test, reg, reg);                                       \
+    AIWNIOS_ADD_CODE(X86Setcc, X86_COND_Z | 1, to);                            \
+  } else {                                                                     \
+    code_off = __ICMoveF64(cctrl, 2, 0, bin, code_off);                        \
+    AIWNIOS_ADD_CODE(X86COMISDRegReg, reg, 2);                                 \
+    AIWNIOS_ADD_CODE(X86Setcc, X86_COND_E | 1, to);                            \
+  }
+    if (!rpn->code_misc)
+      rpn->code_misc = CodeMiscNew(cctrl, CMT_LABEL);
+    if (!rpn->code_misc2)
+      rpn->code_misc2 = CodeMiscNew(cctrl, CMT_LABEL);
+    if (!rpn->code_misc3)
+      rpn->code_misc3 = CodeMiscNew(cctrl, CMT_LABEL);
+    if (!rpn->code_misc4)
+      rpn->code_misc4 = CodeMiscNew(cctrl, CMT_LABEL);
+    a = ICArgN(rpn, 1);
+    b = ICArgN(rpn, 0);
+    cctrl->backend_user_data5 = (int64_t)rpn->code_misc;
+    cctrl->backend_user_data6 = (int64_t)rpn->code_misc2;
+    code_off = __OptPassFinal(cctrl, a, bin, code_off);
+    cctrl->backend_user_data6 = (int64_t)rpn->code_misc3;
+    rpn->code_misc2->addr = bin + code_off;
+    code_off = __OptPassFinal(cctrl, b, bin, code_off);
+    rpn->code_misc->addr = bin + code_off;
+    tmp.mode = MD_I64;
+    tmp.raw_type = RT_I64i;
+    tmp.integer = 0;
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    AIWNIOS_ADD_CODE(X86Jmp, 0);
+    CodeMiscAddRef(rpn->code_misc4, bin + code_off - 4);
+    rpn->code_misc3->addr = bin + code_off;
+    tmp.integer = 1;
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    rpn->code_misc4->addr = bin + code_off;
+    break;
+  ic_or_or:
+    if (old_pass_misc || old_fail_misc) {
+      a = ICArgN(rpn, 1);
+      b = ICArgN(rpn, 0);
+      code_off = __OptPassFinal(cctrl, a, bin, code_off);
+      BACKEND_TEST(&a->res);
+      AIWNIOS_ADD_CODE(X86Jcc, X86_COND_Z ^ 1, 6);
+      CodeMiscAddRef(old_pass_misc, bin + code_off - 4);
+      code_off = __OptPassFinal(cctrl, b, bin, code_off);
+      BACKEND_TEST(&b->res);
+      AIWNIOS_ADD_CODE(X86Jcc, X86_COND_Z ^ 1, 6);
+      CodeMiscAddRef(old_pass_misc, bin + code_off - 4);
+      AIWNIOS_ADD_CODE(X86Jmp, 0);
+      CodeMiscAddRef(old_fail_misc, bin + code_off - 4);
+      goto ret;
+    }
+    // A
+    // rpn->code_misc3:
+    // B
+    // rpn->code_misc4:
+    // res=0;
+    // JMP rpn->code_misc2
+    // rpn->code_misc:
+    // res=1
+    // rpn->code_misc2:
+    if (!rpn->code_misc)
+      rpn->code_misc = CodeMiscNew(cctrl, CMT_LABEL);
+    if (!rpn->code_misc2)
+      rpn->code_misc2 = CodeMiscNew(cctrl, CMT_LABEL);
+    if (!rpn->code_misc3)
+      rpn->code_misc3 = CodeMiscNew(cctrl, CMT_LABEL);
+    if (!rpn->code_misc4)
+      rpn->code_misc4 = CodeMiscNew(cctrl, CMT_LABEL);
+    a = ICArgN(rpn, 1);
+    b = ICArgN(rpn, 0);
+    cctrl->backend_user_data5 = (int64_t)rpn->code_misc3;
+    cctrl->backend_user_data6 = (int64_t)rpn->code_misc;
+    code_off = __OptPassFinal(cctrl, a, bin, code_off);
+    rpn->code_misc3->addr = bin + code_off;
+    cctrl->backend_user_data5 = (int64_t)rpn->code_misc4;
+    code_off = __OptPassFinal(cctrl, b, bin, code_off);
+    rpn->code_misc4->addr = bin + code_off;
+    tmp.mode = MD_I64;
+    tmp.integer = 0;
+    tmp.raw_type = RT_I64i;
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    AIWNIOS_ADD_CODE(X86Jmp, 0);
+    CodeMiscAddRef(rpn->code_misc2, bin + code_off - 4);
+    rpn->code_misc->addr = bin + code_off;
+    tmp.integer = 1;
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    rpn->code_misc2->addr = bin + code_off;
+    break;
+  ic_xor_xor:
+#define BACKEND_LOGICAL_BINOP(op)                                              \
+  next = ICArgN(rpn, 1);                                                       \
+  next2 = ICArgN(rpn, 0);                                                      \
+  code_off = __OptPassFinal(cctrl, next2, bin, code_off);                      \
+  code_off = __OptPassFinal(cctrl, next, bin, code_off);                       \
+  if (rpn->res.mode == MD_REG) {                                               \
+    into_reg = rpn->res.reg;                                                   \
+  } else                                                                       \
+    into_reg = 0;                                                              \
+  code_off = PutICArgIntoReg(cctrl, &next->res, rpn->raw_type,                 \
+                             AIWNIOS_TMP_IREG_POOP2, bin, code_off);           \
+  code_off = PutICArgIntoReg(cctrl, &next2->res, rpn->raw_type,                \
+                             AIWNIOS_TMP_IREG_POOP, bin, code_off);            \
+  BACKEND_BOOLIFY(AIWNIOS_TMP_IREG_POOP2, next->res.reg, next->res.raw_type);  \
+  BACKEND_BOOLIFY(into_reg, next2->res.reg, next2->res.raw_type);              \
+  AIWNIOS_ADD_CODE(op, into_reg, AIWNIOS_TMP_IREG_POOP2);                      \
+  if (rpn->res.mode != MD_REG) {                                               \
+    tmp.raw_type = rpn->raw_type;                                              \
+    tmp.reg = 0;                                                               \
+    tmp.mode = MD_REG;                                                         \
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);                   \
+  }
+    BACKEND_LOGICAL_BINOP(X86XorReg);
+    break;
+  ic_eq_eq:
+#define BACKEND_CMP                                                            \
+  next = ICArgN(rpn, 1);                                                       \
+  next2 = ICArgN(rpn, 0);                                                      \
+  code_off = __OptPassFinal(cctrl, next, bin, code_off);                       \
+  code_off = __OptPassFinal(cctrl, next2, bin, code_off);                      \
+  code_off = PutICArgIntoReg(                                                  \
+      cctrl, &next2->res, rpn->raw_type,                                       \
+      (rpn->raw_type == RT_F64) ? 1 : AIWNIOS_TMP_IREG_POOP2, bin, code_off);  \
+  code_off =                                                                   \
+      PutICArgIntoReg(cctrl, &next->res, rpn->raw_type, 0, bin, code_off);     \
+  if (rpn->raw_type == RT_F64) {                                               \
+    AIWNIOS_ADD_CODE(X86COMISDRegReg, next->res.reg, next2->res.reg);          \
+  } else {                                                                     \
+    AIWNIOS_ADD_CODE(X86CmpRegReg, next->res.reg, next2->res.reg);             \
+  }
+    BACKEND_CMP;
+    if (old_pass_misc && old_fail_misc) {
+      AIWNIOS_ADD_CODE(X86Jcc, X86_COND_Z, 0);
+      CodeMiscAddRef(old_pass_misc, bin + code_off - 4);
+      AIWNIOS_ADD_CODE(X86Jmp, 0);
+      CodeMiscAddRef(old_fail_misc, bin + code_off - 4);
+    }
+    if (use_flags)
+      goto ret;
+    if (rpn->res.mode == MD_REG && rpn->res.mode != RT_F64) {
+      into_reg = rpn->res.reg;
+    } else
+      into_reg = 0;
+    AIWNIOS_ADD_CODE(X86Setcc, X86_COND_E, into_reg);
+    if (!(rpn->res.mode == MD_REG && rpn->res.mode != RT_F64)) {
+      tmp.raw_type = RT_I64i;
+      tmp.reg = 0;
+      tmp.mode = MD_REG;
+      if (rpn->res.keep_in_tmp)
+        rpn->res = tmp;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    }
+    break;
+  ic_ne:
+    BACKEND_CMP;
+    if (old_fail_misc && old_pass_misc) {
+      AIWNIOS_ADD_CODE(X86Jcc, X86_COND_Z ^ 1, 0);
+      CodeMiscAddRef(old_pass_misc, bin + code_off - 4);
+      AIWNIOS_ADD_CODE(X86Jmp, 0);
+      CodeMiscAddRef(old_fail_misc, bin + code_off - 4);
+    }
+    if (use_flags)
+      goto ret;
+    if (rpn->res.mode == MD_REG && rpn->res.mode != RT_F64) {
+      into_reg = rpn->res.reg;
+    } else
+      into_reg = 0;
+    AIWNIOS_ADD_CODE(X86Setcc, X86_COND_E | 1, into_reg);
+    if (!(rpn->res.mode == MD_REG && rpn->res.mode != RT_F64)) {
+      tmp.raw_type = RT_I64i;
+      tmp.reg = 0;
+      tmp.mode = MD_REG;
+      if (rpn->res.keep_in_tmp)
+        rpn->res = tmp;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    }
+    break;
+  ic_lsh:
+    if (rpn->raw_type != RT_F64) {
+      next2 = ICArgN(rpn, 0);
+      next = ICArgN(rpn, 1);
+      if (IsConst(next2) && Is32Bit(ConstVal(next2))) {
+        if (rpn->raw_type != RT_F64)
+          rpn->res.set_flags = 1;
+        BACKEND_BINOP_IMM(X86ShlImm, X86AddReg); // X86AddReg wont be used here
+        break;
+      }
+      tmp.raw_type = RT_I64i;
+      tmp.reg = RCX;
+      tmp.mode = MD_REG;
+      code_off = __OptPassFinal(cctrl, next, bin, code_off);
+      code_off = __OptPassFinal(cctrl, next2, bin, code_off);
+      code_off =
+          PutICArgIntoReg(cctrl, &next2->res, RT_U64i, RCX, bin, code_off);
+      tmp2.mode = MD_REG; // TODO IMPROVE
+      tmp2.raw_type = RT_PTR;
+      tmp2.reg = 0;
+      code_off = ICMov(cctrl, &tmp2, &next->res, bin, code_off);
+      code_off = PutICArgIntoReg(cctrl, &tmp2, RT_U64i, AIWNIOS_TMP_IREG_POOP,
+                                 bin, code_off);
+      code_off = ICMov(cctrl, &tmp, &next2->res, bin, code_off);
+      AIWNIOS_ADD_CODE(X86ShlRCX, tmp2.reg);
+      if (rpn->raw_type != RT_F64)
+        rpn->res.set_flags = 1;
+      if (rpn->res.keep_in_tmp)
+        rpn->res = tmp2;
+      code_off = ICMov(cctrl, &rpn->res, &tmp2, bin, code_off);
+    } else {
+      next = ICArgN(rpn, 1);
+      next2 = ICArgN(rpn, 0);
+      if (IsConst(next2) && Is32Bit(ConstVal(next2))) {
+        if (rpn->raw_type != RT_F64)
+          rpn->res.set_flags = 1;
+        BACKEND_BINOP_IMM(X86ShlImm, X86AddReg); // X86AddReg wont be used here
+      }
+      code_off = __OptPassFinal(cctrl, next, bin, code_off);
+      code_off = __OptPassFinal(cctrl, next2, bin, code_off);
+      code_off =
+          PutICArgIntoReg(cctrl, &next->res, rpn->raw_type, 1, bin, code_off);
+      code_off = PushToStack(cctrl, &next->res, bin, code_off);
+      code_off = PutICArgIntoReg(cctrl, &next2->res, RT_I64i, 0, bin, code_off);
+      tmp.raw_type = RT_I64i;
+      tmp.mode = MD_REG;
+      tmp.reg = RAX;
+      code_off = PopFromStack(cctrl, &next->res, bin, code_off);
+      AIWNIOS_ADD_CODE(X86ShlImm, tmp.reg, next2->res.integer);
+      if (rpn->res.keep_in_tmp)
+        rpn->res = tmp;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    }
+    break;
+  ic_rsh:
+    next = ICArgN(rpn, 1);
+    next2 = ICArgN(rpn, 0);
+    if (rpn->raw_type == RT_F64) {
+      code_off = __OptPassFinal(cctrl, next, bin, code_off);
+      code_off = __OptPassFinal(cctrl, next2, bin, code_off);
+      code_off =
+          PutICArgIntoReg(cctrl, &next->res, rpn->raw_type, 0, bin, code_off);
+      code_off = PushToStack(cctrl, &next->res, bin, code_off);
+      code_off = PutICArgIntoReg(cctrl, &next2->res, RT_I64i,
+                                 AIWNIOS_TMP_IREG_POOP2, bin, code_off);
+      tmp.raw_type = RT_I64i;
+      tmp.mode = MD_REG;
+      tmp.reg = RAX;
+      code_off = PopFromStack(cctrl, &next->res, bin, code_off);
+      AIWNIOS_ADD_CODE(X86ShrImm, tmp.reg, next2->res.reg);
+      if (rpn->raw_type != RT_F64)
+        rpn->res.set_flags = 1;
+      if (rpn->res.keep_in_tmp)
+        rpn->res = tmp;
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+      break;
+    }
+    switch (rpn->raw_type) {
+    case RT_U8i:
+    case RT_U16i:
+    case RT_U32i:
+    case RT_U64i:
+      if (IsConst(next2) && Is32Bit(ConstVal(next2))) {
+        if (rpn->raw_type != RT_F64)
+          rpn->res.set_flags = 1;
+        BACKEND_BINOP_IMM(X86ShrImm, X86AddReg); // X86AddReg wont be used here
+      }
+      next2 = ICArgN(rpn, 0);
+      next = ICArgN(rpn, 1);
+      tmp.raw_type = RT_I64i;
+      tmp.reg = RCX;
+      tmp.mode = MD_REG;
+      code_off = __OptPassFinal(cctrl, next, bin, code_off);
+      code_off = __OptPassFinal(cctrl, next2, bin, code_off);
+      code_off =
+          PutICArgIntoReg(cctrl, &next2->res, RT_U64i, RCX, bin, code_off);
+      tmp2.mode = MD_REG; // TODO IMPROVE
+      tmp2.raw_type = RT_PTR;
+      tmp2.reg = 0;
+      code_off = ICMov(cctrl, &tmp2, &next->res, bin, code_off);
+      // POOP2 is RCX
+      code_off = PutICArgIntoReg(cctrl, &tmp2, RT_U64i, AIWNIOS_TMP_IREG_POOP,
+                                 bin, code_off);
+      code_off = ICMov(cctrl, &tmp, &next2->res, bin, code_off);
+      AIWNIOS_ADD_CODE(X86ShrRCX, tmp2.reg);
+      if (rpn->raw_type != RT_F64)
+        rpn->res.set_flags = 1;
+      if (rpn->res.keep_in_tmp)
+        rpn->res = tmp2;
+      code_off = ICMov(cctrl, &rpn->res, &tmp2, bin, code_off);
+      break;
+    default:
+      if (IsConst(next2) && Is32Bit(ConstVal(next2))) {
+        if (rpn->raw_type != RT_F64)
+          rpn->res.set_flags = 1;
+        BACKEND_BINOP_IMM(X86SarImm, X86AddReg); // X86AddReg wont be used here
+      }
+      tmp.raw_type = RT_I64i;
+      tmp.reg = RCX;
+      tmp.mode = MD_REG;
+      code_off = __OptPassFinal(cctrl, next, bin, code_off);
+      code_off = __OptPassFinal(cctrl, next2, bin, code_off);
+      code_off =
+          PutICArgIntoReg(cctrl, &next2->res, RT_U64i, RCX, bin, code_off);
+      tmp2.mode = MD_REG; // TODO IMPROVE
+      tmp2.raw_type = RT_PTR;
+      tmp2.reg = 0;
+      code_off = ICMov(cctrl, &tmp2, &next->res, bin, code_off);
+      code_off = PutICArgIntoReg(cctrl, &tmp2, RT_U64i, AIWNIOS_TMP_IREG_POOP,
+                                 bin, code_off);
+      code_off = ICMov(cctrl, &tmp, &next2->res, bin, code_off);
+      AIWNIOS_ADD_CODE(X86SarRCX, tmp2.reg);
+      if (rpn->raw_type != RT_F64)
+        rpn->res.set_flags = 1;
+      if (rpn->res.keep_in_tmp)
+        rpn->res = tmp2;
+      code_off = ICMov(cctrl, &rpn->res, &tmp2, bin, code_off);
+    }
+    break;
+  ic_call:
+    //
+    // ()_()_()_()
+    // /          \     // When we call a function,all temp registers
+    // | O______O |     // are invalidated,so we can reset the temp register
+    // | \______/ |===> // counts (for the new expressions).
+    // \__________/     //
+    //   \./   \./      // We will restore the temp register counts after the
+    //   call
+    //
+    i = cctrl->backend_user_data2;
+    i2 = cctrl->backend_user_data3;
+    cctrl->backend_user_data2 = 0;
+    cctrl->backend_user_data3 = 0;
+    code_off = __ICFCallTOS(cctrl, rpn, bin, code_off);
+    cctrl->backend_user_data2 = i;
+    cctrl->backend_user_data3 = i2;
+    break;
+  ic_vargs:
+    //  ^^^^^^^^
+    // (        \      ___________________
+    // ( (*) (*)|     /                   \
     //  \   ^   |    |__IFCall            |
-		//   \  <>  | <==| Will unwind for you| //TODO validate for X86_64
-		//    \    /      \__________________/
-		//      \_/
-		AIWNIOS_ADD_CODE(X86SubImm32, X86_64_STACK_REG, 8 * rpn->length)
-		for (i = 0; i != rpn->length; i++) {
-			next = ICArgN(rpn, rpn->length - i - 1);
-			code_off = __OptPassFinal(cctrl, next, bin, code_off);
-			tmp.reg = X86_64_STACK_REG;
-			tmp.off = 8 * i;
-			tmp.mode = MD_INDIR_REG;
-			tmp.raw_type = next->raw_type;
-			if (tmp.raw_type < RT_I64i)
-				tmp.raw_type = RT_I64i;
-			code_off = ICMov(cctrl, &tmp, &next->res, bin, code_off);
-		}
-		break;
-	ic_add_eq:
-		code_off = __SexyAssignOp(cctrl, rpn, bin, code_off);
-		break;
-	ic_sub_eq:
-		code_off = __SexyAssignOp(cctrl, rpn, bin, code_off);
-		break;
-	ic_mul_eq:
-		code_off = __SexyAssignOp(cctrl, rpn, bin, code_off);
-		break;
-	ic_div_eq:
-		code_off = __SexyAssignOp(cctrl, rpn, bin, code_off);
-		break;
-	ic_lsh_eq:
-		code_off = __SexyAssignOp(cctrl, rpn, bin, code_off);
-		break;
-	ic_rsh_eq:
-		code_off = __SexyAssignOp(cctrl, rpn, bin, code_off);
-		break;
-	ic_and_eq:
-		code_off = __SexyAssignOp(cctrl, rpn, bin, code_off);
-		break;
-	ic_or_eq:
-		code_off = __SexyAssignOp(cctrl, rpn, bin, code_off);
-		break;
-	ic_xor_eq:
-		code_off = __SexyAssignOp(cctrl, rpn, bin, code_off);
-		break;
-		abort();
-		break;
-		abort();
-		break;
-	ic_mod_eq:
-		code_off = __SexyAssignOp(cctrl, rpn, bin, code_off);
-		break;
-	ic_i64:
-		tmp.mode = MD_I64;
-		tmp.raw_type = RT_I64i;
-		tmp.integer = rpn->integer;
-		if (rpn->res.mode != MD_I64)
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		break;
-	ic_f64:
-		tmp.mode = MD_F64;
-		tmp.raw_type = RT_F64;
-		tmp.flt = rpn->flt;
-		if (rpn->res.mode != MD_F64)
-			code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		break;
-	ic_array_acc:
-		abort();
-		break;
-	ic_ret:
-		next = ICArgN(rpn, 0);
-		PushTmpDepthFirst(cctrl, next, 0);
-		PopTmp(cctrl, next);
-		code_off = __OptPassFinal(cctrl, next, bin, code_off);
-		if (cctrl->cur_fun)
-			tmp.raw_type = cctrl->cur_fun->return_class->raw_type;
-		else if (rpn->ic_class) {
-			// No return type so just return what we have
-			tmp.raw_type = rpn->ic_class->raw_type;
-		} else
-			// No return type so just return what we have
-			tmp.raw_type = next->raw_type;
-		tmp.reg = 0; // 0 is return register
-		tmp.mode = MD_REG;
-		code_off = ICMov(cctrl, &tmp, &next->res, bin, code_off);
-		// TempleOS will always store F64 result in RAX(integer register)
-		// Let's merge the two togheter
-		if (tmp.raw_type == RT_F64) {
-			AIWNIOS_ADD_CODE(X86MovQI64F64, 0, 0);
-		} else {
-			// Vise versa
-			AIWNIOS_ADD_CODE(X86MovQF64I64, 0, 0);
-		}
-		// TODO  jump to return area,not generate epilog for each poo poo
-		AIWNIOS_ADD_CODE(X86Jmp, 0);
-		CodeMiscAddRef(cctrl->epilog_label, bin + code_off - 4);
-		break;
-	ic_base_ptr:
-		tmp.raw_type = rpn->raw_type;
-		tmp.off = rpn->integer;
-		tmp.reg = RBP;
-		tmp.mode = MD_FRAME;
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		break;
-	ic_static:
-		tmp.raw_type = rpn->raw_type;
-		tmp.off = rpn->integer;
-		tmp.mode = MD_PTR;
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		break;
-	ic_ireg:
-		tmp.raw_type = RT_I64i;
-		tmp.reg = rpn->integer;
-		tmp.mode = MD_REG;
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		break;
-	ic_freg:
-		tmp.raw_type = RT_F64;
-		tmp.reg = rpn->integer;
-		tmp.mode = MD_REG;
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		break;
-		abort();
-		break;
-		abort();
-		break;
-	ic_bt:
-#define BTX_OP(lock, f_imm_sib, f_imm_reg, f_sib, f_reg)                                                       \
-	a = ICArgN(rpn, 1);                                                                                        \
-	b = ICArgN(rpn, 0);                                                                                        \
-	if (IsConst(b) && ConstVal(b) <= 63) {                                                                     \
-		if (a->res.mode == __MD_X86_64_LEA_SIB) {                                                              \
-			if (a->res.__sib_base_rpn)                                                                         \
-				code_off = __OptPassFinal(cctrl, a->res.__sib_base_rpn, bin, code_off);                        \
-			if (a->res.__sib_idx_rpn)                                                                          \
-				code_off = __OptPassFinal(cctrl, a->res.__sib_idx_rpn, bin, code_off);                         \
-			if (lock)                                                                                          \
-				AIWNIOS_ADD_CODE(X86Lock, 0);                                                                  \
-			AIWNIOS_ADD_CODE(f_imm_sib, ConstVal(b), a->res.__SIB_scale, a->res.reg2, a->res.reg, a->res.off); \
-		} else {                                                                                               \
-			code_off = __OptPassFinal(cctrl, a, bin, code_off);                                                \
-			code_off = PutICArgIntoReg(cctrl, &a->res, RT_I64i, AIWNIOS_TMP_IREG_POOP2, bin, code_off);        \
-			if (lock)                                                                                          \
-				AIWNIOS_ADD_CODE(X86Lock, 0);                                                                  \
-			AIWNIOS_ADD_CODE(f_imm_sib, ConstVal(b), -1, -1, a->res.reg, 0);                                   \
-		}                                                                                                      \
-	} else {                                                                                                   \
-		code_off = __OptPassFinal(cctrl, b, bin, code_off);                                                    \
-		if (a->res.mode == __MD_X86_64_LEA_SIB) {                                                              \
-			if (a->res.__sib_base_rpn)                                                                         \
-				code_off = __OptPassFinal(cctrl, a->res.__sib_base_rpn, bin, code_off);                        \
-			if (a->res.__sib_idx_rpn)                                                                          \
-				code_off = __OptPassFinal(cctrl, a->res.__sib_idx_rpn, bin, code_off);                         \
-			code_off = PutICArgIntoReg(cctrl, &b->res, RT_I64i, AIWNIOS_TMP_IREG_POOP, bin, code_off);         \
-			if (lock)                                                                                          \
-				AIWNIOS_ADD_CODE(X86Lock, 0);                                                                  \
-			AIWNIOS_ADD_CODE(f_sib, b->res.reg, a->res.__SIB_scale, a->res.reg2, a->res.reg, a->res.off);      \
-		} else {                                                                                               \
-			code_off = __OptPassFinal(cctrl, a, bin, code_off);                                                \
-			code_off = PutICArgIntoReg(cctrl, &a->res, RT_I64i, AIWNIOS_TMP_IREG_POOP2, bin, code_off);        \
-			code_off = PutICArgIntoReg(cctrl, &b->res, RT_I64i, AIWNIOS_TMP_IREG_POOP, bin, code_off);         \
-			if (lock)                                                                                          \
-				AIWNIOS_ADD_CODE(X86Lock, 0);                                                                  \
-			AIWNIOS_ADD_CODE(f_sib, b->res.reg, -1, -1, a->res.reg, 0);                                        \
-		}                                                                                                      \
-	}                                                                                                          \
-	if (old_fail_misc && old_pass_misc) {                                                                      \
-		AIWNIOS_ADD_CODE(X86Jcc, X86_COND_C, 0);                                                               \
-		CodeMiscAddRef(old_pass_misc, bin + code_off - 4);                                                     \
-		AIWNIOS_ADD_CODE(X86Jmp, 0);                                                                           \
-		CodeMiscAddRef(old_fail_misc, bin + code_off - 4);                                                     \
-		goto ret;                                                                                              \
-	}                                                                                                          \
-	if (rpn->res.mode != MD_NULL) {                                                                            \
-		into_reg = 0;                                                                                          \
-		if (rpn->res.mode == MD_REG)                                                                           \
-			into_reg = rpn->res.reg;                                                                           \
-		AIWNIOS_ADD_CODE(X86Setcc, X86_COND_C, into_reg);                                                      \
-		goto restore_reg;                                                                                      \
-	}
-		BTX_OP(0, X86BtSIBImm, X86BtRegImm, X86BtSIBReg, X86BtRegReg);
-		break;
-	ic_btc:
-		BTX_OP(0, X86BtcSIBImm, X86BtcRegImm, X86BtcSIBReg, X86BtcRegReg);
-		break;
-	ic_bts:
-		BTX_OP(0, X86BtsSIBImm, X86BtsRegImm, X86BtsSIBReg, X86BtsRegReg);
-		break;
-	ic_btr:
-		BTX_OP(0, X86BtrSIBImm, X86BtrRegImm, X86BtrSIBReg, X86BtrRegReg);
-		break;
-	ic_lbtc:
-		BTX_OP(1, X86BtcSIBImm, X86BtcRegImm, X86BtcSIBReg, X86BtcRegReg);
-		break;
-	ic_lbts:
-		BTX_OP(1, X86BtsSIBImm, X86BtsRegImm, X86BtsSIBReg, X86BtsRegReg);
-		break;
-	ic_lbtr:
-		BTX_OP(1, X86BtrSIBImm, X86BtrRegImm, X86BtrSIBReg, X86BtrRegReg);
-	ic_max_i64:
-	ic_max_u64:
-	ic_min_i64:
-	ic_min_u64:
-	ic_sign_i64:
-	ic_sqr_i64:
-	ic_sqr_u64:
-	ic_sqr:
-	ic_abs:
-	ic_sqrt:
-	ic_cos:
-	ic_sin:
-	ic_tan:
-	ic_atan:
-		/*break;case IC_MAX_I64:
-		break;case IC_MIN_I64:
-		break;case IC_MAX_U64:
-		break;case IC_MIN_U64:
-		break;case IC_SIGN_I64:
-		break;case IC_SQR_I64:
-		break;case IC_SQR_U64:
-		break;case IC_SQR:
-		break;case IC_ABS:
-		break;case IC_SQRT:
-		break;case IC_SIN:
-		break;case IC_COS:
-		break;case IC_TAN:
-		break;case IC_ATAN:*/
-		break;
-	ic_static_ref:
-		tmp.raw_type = rpn->raw_type;
-		tmp.off = rpn->integer;
-		tmp.mode = MD_STATIC;
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-		break;
-	ic_set_static_data:
-		//TODO later
-		break;
-	ic_raw_bytes:
-		if (cctrl->code_ctrl->final_pass) {
-			memcpy(
-				bin+code_off,
-				rpn->raw_bytes,
-				rpn->length);
-		}
-		code_off+=rpn->length;
-	} while (0);
+    //   \  <>  | <==| Will unwind for you| //TODO validate for X86_64
+    //    \    /      \__________________/
+    //      \_/
+    AIWNIOS_ADD_CODE(X86SubImm32, X86_64_STACK_REG, 8 * rpn->length)
+    for (i = 0; i != rpn->length; i++) {
+      next = ICArgN(rpn, rpn->length - i - 1);
+      code_off = __OptPassFinal(cctrl, next, bin, code_off);
+      tmp.reg = X86_64_STACK_REG;
+      tmp.off = 8 * i;
+      tmp.mode = MD_INDIR_REG;
+      tmp.raw_type = next->raw_type;
+      if (tmp.raw_type < RT_I64i)
+        tmp.raw_type = RT_I64i;
+      code_off = ICMov(cctrl, &tmp, &next->res, bin, code_off);
+    }
+    break;
+  ic_add_eq:
+    code_off = __SexyAssignOp(cctrl, rpn, bin, code_off);
+    break;
+  ic_sub_eq:
+    code_off = __SexyAssignOp(cctrl, rpn, bin, code_off);
+    break;
+  ic_mul_eq:
+    code_off = __SexyAssignOp(cctrl, rpn, bin, code_off);
+    break;
+  ic_div_eq:
+    code_off = __SexyAssignOp(cctrl, rpn, bin, code_off);
+    break;
+  ic_lsh_eq:
+    code_off = __SexyAssignOp(cctrl, rpn, bin, code_off);
+    break;
+  ic_rsh_eq:
+    code_off = __SexyAssignOp(cctrl, rpn, bin, code_off);
+    break;
+  ic_and_eq:
+    code_off = __SexyAssignOp(cctrl, rpn, bin, code_off);
+    break;
+  ic_or_eq:
+    code_off = __SexyAssignOp(cctrl, rpn, bin, code_off);
+    break;
+  ic_xor_eq:
+    code_off = __SexyAssignOp(cctrl, rpn, bin, code_off);
+    break;
+    abort();
+    break;
+    abort();
+    break;
+  ic_mod_eq:
+    code_off = __SexyAssignOp(cctrl, rpn, bin, code_off);
+    break;
+  ic_i64:
+    tmp.mode = MD_I64;
+    tmp.raw_type = RT_I64i;
+    tmp.integer = rpn->integer;
+    if (rpn->res.mode != MD_I64)
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    break;
+  ic_f64:
+    tmp.mode = MD_F64;
+    tmp.raw_type = RT_F64;
+    tmp.flt = rpn->flt;
+    if (rpn->res.mode != MD_F64)
+      code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    break;
+  ic_array_acc:
+    abort();
+    break;
+  ic_ret:
+    next = ICArgN(rpn, 0);
+    PushTmpDepthFirst(cctrl, next, 0);
+    PopTmp(cctrl, next);
+    code_off = __OptPassFinal(cctrl, next, bin, code_off);
+    if (cctrl->cur_fun)
+      tmp.raw_type = cctrl->cur_fun->return_class->raw_type;
+    else if (rpn->ic_class) {
+      // No return type so just return what we have
+      tmp.raw_type = rpn->ic_class->raw_type;
+    } else
+      // No return type so just return what we have
+      tmp.raw_type = next->raw_type;
+    tmp.reg = 0; // 0 is return register
+    tmp.mode = MD_REG;
+    code_off = ICMov(cctrl, &tmp, &next->res, bin, code_off);
+    // TempleOS will always store F64 result in RAX(integer register)
+    // Let's merge the two togheter
+    if (tmp.raw_type == RT_F64) {
+      AIWNIOS_ADD_CODE(X86MovQI64F64, 0, 0);
+    } else {
+      // Vise versa
+      AIWNIOS_ADD_CODE(X86MovQF64I64, 0, 0);
+    }
+    // TODO  jump to return area,not generate epilog for each poo poo
+    AIWNIOS_ADD_CODE(X86Jmp, 0);
+    CodeMiscAddRef(cctrl->epilog_label, bin + code_off - 4);
+    break;
+  ic_base_ptr:
+    tmp.raw_type = rpn->raw_type;
+    tmp.off = rpn->integer;
+    tmp.reg = RBP;
+    tmp.mode = MD_FRAME;
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    break;
+  ic_static:
+    tmp.raw_type = rpn->raw_type;
+    tmp.off = rpn->integer;
+    tmp.mode = MD_PTR;
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    break;
+  ic_ireg:
+    tmp.raw_type = RT_I64i;
+    tmp.reg = rpn->integer;
+    tmp.mode = MD_REG;
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    break;
+  ic_freg:
+    tmp.raw_type = RT_F64;
+    tmp.reg = rpn->integer;
+    tmp.mode = MD_REG;
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    break;
+    abort();
+    break;
+    abort();
+    break;
+  ic_bt:
+#define BTX_OP(lock, f_imm_sib, f_imm_reg, f_sib, f_reg)                       \
+  a = ICArgN(rpn, 1);                                                          \
+  b = ICArgN(rpn, 0);                                                          \
+  if (IsConst(b) && ConstVal(b) <= 63) {                                       \
+    if (a->res.mode == __MD_X86_64_LEA_SIB) {                                  \
+      if (a->res.__sib_base_rpn)                                               \
+        code_off =                                                             \
+            __OptPassFinal(cctrl, a->res.__sib_base_rpn, bin, code_off);       \
+      if (a->res.__sib_idx_rpn)                                                \
+        code_off = __OptPassFinal(cctrl, a->res.__sib_idx_rpn, bin, code_off); \
+      if (lock)                                                                \
+        AIWNIOS_ADD_CODE(X86Lock, 0);                                          \
+      AIWNIOS_ADD_CODE(f_imm_sib, ConstVal(b), a->res.__SIB_scale,             \
+                       a->res.reg2, a->res.reg, a->res.off);                   \
+    } else {                                                                   \
+      code_off = __OptPassFinal(cctrl, a, bin, code_off);                      \
+      code_off = PutICArgIntoReg(cctrl, &a->res, RT_I64i,                      \
+                                 AIWNIOS_TMP_IREG_POOP2, bin, code_off);       \
+      if (lock)                                                                \
+        AIWNIOS_ADD_CODE(X86Lock, 0);                                          \
+      AIWNIOS_ADD_CODE(f_imm_sib, ConstVal(b), -1, -1, a->res.reg, 0);         \
+    }                                                                          \
+  } else {                                                                     \
+    code_off = __OptPassFinal(cctrl, b, bin, code_off);                        \
+    if (a->res.mode == __MD_X86_64_LEA_SIB) {                                  \
+      if (a->res.__sib_base_rpn)                                               \
+        code_off =                                                             \
+            __OptPassFinal(cctrl, a->res.__sib_base_rpn, bin, code_off);       \
+      if (a->res.__sib_idx_rpn)                                                \
+        code_off = __OptPassFinal(cctrl, a->res.__sib_idx_rpn, bin, code_off); \
+      code_off = PutICArgIntoReg(cctrl, &b->res, RT_I64i,                      \
+                                 AIWNIOS_TMP_IREG_POOP, bin, code_off);        \
+      if (lock)                                                                \
+        AIWNIOS_ADD_CODE(X86Lock, 0);                                          \
+      AIWNIOS_ADD_CODE(f_sib, b->res.reg, a->res.__SIB_scale, a->res.reg2,     \
+                       a->res.reg, a->res.off);                                \
+    } else {                                                                   \
+      code_off = __OptPassFinal(cctrl, a, bin, code_off);                      \
+      code_off = PutICArgIntoReg(cctrl, &a->res, RT_I64i,                      \
+                                 AIWNIOS_TMP_IREG_POOP2, bin, code_off);       \
+      code_off = PutICArgIntoReg(cctrl, &b->res, RT_I64i,                      \
+                                 AIWNIOS_TMP_IREG_POOP, bin, code_off);        \
+      if (lock)                                                                \
+        AIWNIOS_ADD_CODE(X86Lock, 0);                                          \
+      AIWNIOS_ADD_CODE(f_sib, b->res.reg, -1, -1, a->res.reg, 0);              \
+    }                                                                          \
+  }                                                                            \
+  if (old_fail_misc && old_pass_misc) {                                        \
+    AIWNIOS_ADD_CODE(X86Jcc, X86_COND_C, 0);                                   \
+    CodeMiscAddRef(old_pass_misc, bin + code_off - 4);                         \
+    AIWNIOS_ADD_CODE(X86Jmp, 0);                                               \
+    CodeMiscAddRef(old_fail_misc, bin + code_off - 4);                         \
+    goto ret;                                                                  \
+  }                                                                            \
+  if (rpn->res.mode != MD_NULL) {                                              \
+    into_reg = 0;                                                              \
+    if (rpn->res.mode == MD_REG)                                               \
+      into_reg = rpn->res.reg;                                                 \
+    AIWNIOS_ADD_CODE(X86Setcc, X86_COND_C, into_reg);                          \
+    goto restore_reg;                                                          \
+  }
+    BTX_OP(0, X86BtSIBImm, X86BtRegImm, X86BtSIBReg, X86BtRegReg);
+    break;
+  ic_btc:
+    BTX_OP(0, X86BtcSIBImm, X86BtcRegImm, X86BtcSIBReg, X86BtcRegReg);
+    break;
+  ic_bts:
+    BTX_OP(0, X86BtsSIBImm, X86BtsRegImm, X86BtsSIBReg, X86BtsRegReg);
+    break;
+  ic_btr:
+    BTX_OP(0, X86BtrSIBImm, X86BtrRegImm, X86BtrSIBReg, X86BtrRegReg);
+    break;
+  ic_lbtc:
+    BTX_OP(1, X86BtcSIBImm, X86BtcRegImm, X86BtcSIBReg, X86BtcRegReg);
+    break;
+  ic_lbts:
+    BTX_OP(1, X86BtsSIBImm, X86BtsRegImm, X86BtsSIBReg, X86BtsRegReg);
+    break;
+  ic_lbtr:
+    BTX_OP(1, X86BtrSIBImm, X86BtrRegImm, X86BtrSIBReg, X86BtrRegReg);
+  ic_max_i64:
+  ic_max_u64:
+  ic_min_i64:
+  ic_min_u64:
+  ic_sign_i64:
+  ic_sqr_i64:
+  ic_sqr_u64:
+  ic_sqr:
+  ic_abs:
+  ic_sqrt:
+  ic_cos:
+  ic_sin:
+  ic_tan:
+  ic_atan:
+    /*break;case IC_MAX_I64:
+    break;case IC_MIN_I64:
+    break;case IC_MAX_U64:
+    break;case IC_MIN_U64:
+    break;case IC_SIGN_I64:
+    break;case IC_SQR_I64:
+    break;case IC_SQR_U64:
+    break;case IC_SQR:
+    break;case IC_ABS:
+    break;case IC_SQRT:
+    break;case IC_SIN:
+    break;case IC_COS:
+    break;case IC_TAN:
+    break;case IC_ATAN:*/
+    break;
+  ic_static_ref:
+    tmp.raw_type = rpn->raw_type;
+    tmp.off = rpn->integer;
+    tmp.mode = MD_STATIC;
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+    break;
+  ic_set_static_data:
+    // TODO later
+    break;
+  ic_raw_bytes:
+    if (cctrl->code_ctrl->final_pass) {
+      memcpy(bin + code_off, rpn->raw_bytes, rpn->length);
+    }
+    code_off += rpn->length;
+  } while (0);
 ret:
-	if (old_fail_misc || old_pass_misc) {
-		misc = old_fail_misc;
-		misc2 = old_pass_misc;
-		switch (rpn->type) {
-		case IC_OR_OR:
-		case IC_AND_AND:
-		case IC_LT:
-		case IC_GT:
-		case IC_GE:
-		case IC_LE:
-		case IC_EQ_EQ:
-		case IC_NE:
-		case IC_LNOT:
-		case IC_BT:
-		case IC_BTS:
-		case IC_BTR:
-		case IC_BTC:
-		case IC_LBTS:
-		case IC_LBTR:
-		case IC_LBTC:
-			break;
-		default:
-			if (rpn->res.raw_type == RT_F64) {
-				code_off = PutICArgIntoReg(cctrl, &rpn->res, RT_F64, 1, bin, code_off);
-				code_off = __ICMoveF64(cctrl, 2, 0, bin, code_off);
-				AIWNIOS_ADD_CODE(X86COMISDRegReg, rpn->res.reg, 2);
-			} else {
-				tmp = rpn->res;
-				code_off = PutICArgIntoReg(cctrl, &tmp, RT_I64i, RAX, bin, code_off);
-				AIWNIOS_ADD_CODE(X86Test, tmp.reg, tmp.reg);
-			}
-			// Pass address
-			AIWNIOS_ADD_CODE(X86Jcc, X86_COND_Z | 1, 0);
-			CodeMiscAddRef(misc2, bin + code_off - 4);
-			// Fail address
-			AIWNIOS_ADD_CODE(X86Jmp, 5);
-			CodeMiscAddRef(misc, bin + code_off - 4);
-		}
-	}
-	if (rpn->flags & ICF_STUFF_IN_REG) {
-		tmp = rpn->res;
-		if (rpn->res.raw_type != RT_F64)
-			rpn->res.raw_type = RT_I64i;
-		else
-			rpn->res.raw_type = RT_F64;
-		rpn->res.mode = MD_REG;
-		rpn->res.reg = rpn->stuff_in_reg;
-		code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
-	}
-	cctrl->backend_user_data5 = (int64_t)old_fail_misc;
-	cctrl->backend_user_data6 = (int64_t)old_pass_misc;
-	return code_off;
+  if (old_fail_misc || old_pass_misc) {
+    misc = old_fail_misc;
+    misc2 = old_pass_misc;
+    switch (rpn->type) {
+    case IC_OR_OR:
+    case IC_AND_AND:
+    case IC_LT:
+    case IC_GT:
+    case IC_GE:
+    case IC_LE:
+    case IC_EQ_EQ:
+    case IC_NE:
+    case IC_LNOT:
+    case IC_BT:
+    case IC_BTS:
+    case IC_BTR:
+    case IC_BTC:
+    case IC_LBTS:
+    case IC_LBTR:
+    case IC_LBTC:
+      break;
+    default:
+      if (rpn->res.raw_type == RT_F64) {
+        code_off = PutICArgIntoReg(cctrl, &rpn->res, RT_F64, 1, bin, code_off);
+        code_off = __ICMoveF64(cctrl, 2, 0, bin, code_off);
+        AIWNIOS_ADD_CODE(X86COMISDRegReg, rpn->res.reg, 2);
+      } else {
+        tmp = rpn->res;
+        code_off = PutICArgIntoReg(cctrl, &tmp, RT_I64i, RAX, bin, code_off);
+        AIWNIOS_ADD_CODE(X86Test, tmp.reg, tmp.reg);
+      }
+      // Pass address
+      AIWNIOS_ADD_CODE(X86Jcc, X86_COND_Z | 1, 0);
+      CodeMiscAddRef(misc2, bin + code_off - 4);
+      // Fail address
+      AIWNIOS_ADD_CODE(X86Jmp, 5);
+      CodeMiscAddRef(misc, bin + code_off - 4);
+    }
+  }
+  if (rpn->flags & ICF_STUFF_IN_REG) {
+    tmp = rpn->res;
+    if (rpn->res.raw_type != RT_F64)
+      rpn->res.raw_type = RT_I64i;
+    else
+      rpn->res.raw_type = RT_F64;
+    rpn->res.mode = MD_REG;
+    rpn->res.reg = rpn->stuff_in_reg;
+    code_off = ICMov(cctrl, &rpn->res, &tmp, bin, code_off);
+  }
+  cctrl->backend_user_data5 = (int64_t)old_fail_misc;
+  cctrl->backend_user_data6 = (int64_t)old_pass_misc;
+  return code_off;
 }
 
 // This dude calls __OptPassFinal 3 times.
@@ -6218,220 +6498,225 @@ ret:
 // 2. Fill in function body,accounting for not worst case jumps
 // 3. Fill in the poo poo's
 //
-char* OptPassFinal(CCmpCtrl* cctrl, int64_t* res_sz, char** dbg_info)
-{
-	int64_t code_off, run, idx, cnt = 0, cnt2, final_size, is_terminal;
-	int64_t min_ln = 0, max_ln = 0, statics_sz = 0;
-	char* bin = NULL;
-	char* ptr;
-	CCodeMisc* misc;
-	CCodeMiscRef *cm_ref, *cm_ref_tmp;
-	CHashImport* import;
-	CRPN* r;
-	cctrl->epilog_label = CodeMiscNew(cctrl, CMT_LABEL);
-	cctrl->statics_label = CodeMiscNew(cctrl, CMT_LABEL);
-	for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code; r = r->base.next) {
-		if (r->ic_line) {
-			if (!min_ln)
-				min_ln = r->ic_line;
-			min_ln = (min_ln < r->ic_line) ? min_ln : r->ic_line;
-			if (!max_ln)
-				max_ln = r->ic_line;
-			max_ln = (max_ln > r->ic_line) ? max_ln : r->ic_line;
-		}
-		if (r->type == IC_BASE_PTR) {
-		} else if (r->type == __IC_STATICS_SIZE)
-			statics_sz = r->integer;
-	}
-	for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code; r = ICFwd(r)) {
-		cnt++;
-	}
-	if (dbg_info) {
-		// Dont allocate on cctrl->hc heap ctrl as we want to share our datqa
-		cctrl->code_ctrl->dbg_info = dbg_info;
-		cctrl->code_ctrl->min_ln = min_ln;
-	}
-	CRPN* forwards[cnt2 = cnt];
-	cnt = 0;
-	for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code; r = ICFwd(r)) {
-		forwards[cnt2 - ++cnt] = r;
-	}
-	// We DONT reset the wiggle room
-	cctrl->backend_user_data0 = 0;
-	// 0 get maximum code size,
-	// 1 compute bin
-	for (run = 0; run < 2; run++) {
-		cctrl->code_ctrl->final_pass = run;
-		cctrl->backend_user_data1 = 0;
-		cctrl->backend_user_data2 = 0;
-		cctrl->backend_user_data3 = 0;
-		if (run == 0) {
-			code_off = 0;
-			bin = NULL;
-		} else if (run == 1) {
-			// Dont allocate on cctrl->hc heap ctrl as we want to share our data
-			bin = A_MALLOC(64 + code_off, NULL);
-			code_off = 0;
-		}
-		code_off = FuncProlog(cctrl, bin, code_off);
-		for (cnt = 0; cnt < cnt2; cnt++) {
-		enter:
-			r = forwards[cnt];
-			if (PushTmpDepthFirst(cctrl, r, 0))
-				PopTmp(cctrl, r);
-			// These modes expect you run ->__sib_base_rpn/__sib_index_rpn
-			if (r->res.mode != __MD_X86_64_LEA_SIB && r->res.mode != __MD_X86_64_SIB) {
-				r->res.mode = MD_NULL;
-			}
-			assert(cctrl->backend_user_data1 == 0);
-			assert(cctrl->backend_user_data2 == 0);
-			assert(cctrl->backend_user_data3 == 0);
-			code_off = __OptPassFinal(cctrl, r, bin, code_off);
-			if (IsTerminalInst(r)) {
-				cnt++;
-				for (; cnt < cnt2; cnt++) {
-					if (forwards[cnt]->type == IC_LABEL)
-						goto enter;
-				}
-			}
-		}
-		cctrl->epilog_label->addr = bin + code_off;
-		code_off = FuncEpilog(cctrl, bin, code_off);
-		for (misc = cctrl->code_ctrl->code_misc->next;
-			 misc != cctrl->code_ctrl->code_misc; misc = misc->base.next) {
-			int64_t old_code_off = code_off;
-			switch (misc->type) {
-				break;
-			case CMT_INT_CONST:
-				if (code_off % 8)
-					code_off += 8 - code_off % 8;
-				misc->addr = bin + code_off;
-				if (bin)
-					*(int64_t*)(bin + code_off) = misc->integer;
-				code_off += 8;
-			fill_in_refs:
-				for (cm_ref = misc->refs; cm_ref; cm_ref = cm_ref_tmp) {
-					cm_ref_tmp = cm_ref->next;
-					if (run)
-						*cm_ref->add_to = (char*)misc->addr - (char*)cm_ref->add_to - 4 + cm_ref->offset;
-					A_FREE(cm_ref);
-				}
-				misc->refs = NULL;
-				break;
-			case CMT_FLOAT_CONST:
-				if (code_off % 8)
-					code_off += 8 - code_off % 8;
-				misc->addr = bin + code_off;
-				if (bin)
-					*(double*)(bin + code_off) = misc->flt;
-				code_off += 8;
-				goto fill_in_refs;
-				break;
-			case CMT_JMP_TAB:
-				if (code_off % 8)
-					code_off += 8 - code_off % 8;
-				misc->addr = bin + code_off;
-				if (misc->patch_addr)
-					*misc->patch_addr = misc->addr;
-				if (bin) {
-					for (idx = 0; idx <= misc->hi - misc->lo; idx++)
-						*(void**)(bin + code_off + idx * 8) = (char*)misc->jmp_tab[idx]->addr;
-				}
-				code_off += (misc->hi - misc->lo + 1) * 8;
-				goto fill_in_refs;
-				break;
-			case CMT_LABEL:
-				if (misc->patch_addr)
-					*misc->patch_addr = misc->addr;
-				// We assign the statics offset later
-				if (misc == cctrl->statics_label)
-					break;
-				goto fill_in_refs;
-			case CMT_SHORT_ADDR:
-				if (run && misc->patch_addr) {
-					*misc->patch_addr = misc->addr;
-				}
-				break;
-			case CMT_RELOC_U64:
-				if (code_off % 8)
-					code_off += 8 - code_off % 8;
-				misc->addr = bin + code_off;
-				if (bin)
-					*(void**)(bin + code_off) = &DoNothing;
-				code_off += 8;
-				if (run) {
-					import = A_CALLOC(sizeof(CHashImport), NULL);
-					import->base.type = HTT_IMPORT_SYS_SYM;
-					import->base.str = A_STRDUP(misc->str, NULL);
-					import->address = misc->addr;
-					HashAdd(import, Fs->hash_table);
-				}
-				if (run && misc->patch_addr) {
-					*misc->patch_addr = misc->addr;
-				}
-				goto fill_in_refs;
-				break;
-			case CMT_STRING:
-				if (!(cctrl->flags & CCF_STRINGS_ON_HEAP)) {
-					if (code_off % 8)
-						code_off += 8 - code_off % 8;
-					misc->addr = bin + code_off;
-					if (bin)
-						memcpy(bin + code_off, misc->str, misc->str_len);
-					code_off += misc->str_len;
-				} else {
-					if (run) {
-						// See IC_STR: We "steal" the ->str because it's already on the heap.
-						//  IC_STR steals the ->str point so we dont want to Free it
-						misc->str = NULL;
-					}
-				}
-				goto fill_in_refs;
-			}
-		}
-		if (code_off % 8) // Align to 8
-			code_off += 8 - code_off % 8;
-		cctrl->code_ctrl->statics_offset = code_off;
-		cctrl->statics_label->addr = bin + cctrl->code_ctrl->statics_offset;
-		// Fill in the static references
-		if(bin)
-			for(r=cctrl->code_ctrl->ir_code->next;r!=cctrl->code_ctrl->ir_code;r=r->base.next) {
-				if(r->type==__IC_SET_STATIC_DATA) {
-					memcpy(
-						bin+cctrl->code_ctrl->statics_offset+r->code_misc->integer,
-						r->code_misc->str,
-						r->code_misc->str_len
-					);
-				}
-			}
-		if (bin) {
-			for (cm_ref = cctrl->statics_label->refs; cm_ref; cm_ref = cm_ref_tmp) {
-				cm_ref_tmp = cm_ref->next;
-				*cm_ref->add_to = (char*)cctrl->statics_label->addr - (char*)cm_ref->add_to - 4 + cm_ref->offset;
-				A_FREE(cm_ref);
-			}
-		}
-		if (statics_sz)
-			code_off += statics_sz + 8;
-	}
-	final_size = code_off;
-	if (dbg_info) {
-		cnt = MSize(dbg_info) / 8;
-		ptr = dbg_info[0] = bin;
-		for (idx = 1; idx < cnt; idx++) {
-			if (!dbg_info[idx]) {
-				dbg_info[idx] = NULL;
-				continue;
-			}
-			if (ptr > dbg_info[idx]) {
-				// No backwards jumps
-				dbg_info[idx] = NULL;
-				continue;
-			}
-			ptr = dbg_info[idx];
-		}
-	}
-	if (res_sz)
-		*res_sz = final_size;
-	return bin;
+char *OptPassFinal(CCmpCtrl *cctrl, int64_t *res_sz, char **dbg_info) {
+  int64_t code_off, run, idx, cnt = 0, cnt2, final_size, is_terminal;
+  int64_t min_ln = 0, max_ln = 0, statics_sz = 0;
+  char *bin = NULL;
+  char *ptr;
+  CCodeMisc *misc;
+  CCodeMiscRef *cm_ref, *cm_ref_tmp;
+  CHashImport *import;
+  CRPN *r;
+  cctrl->epilog_label = CodeMiscNew(cctrl, CMT_LABEL);
+  cctrl->statics_label = CodeMiscNew(cctrl, CMT_LABEL);
+  for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code;
+       r = r->base.next) {
+    if (r->ic_line) {
+      if (!min_ln)
+        min_ln = r->ic_line;
+      min_ln = (min_ln < r->ic_line) ? min_ln : r->ic_line;
+      if (!max_ln)
+        max_ln = r->ic_line;
+      max_ln = (max_ln > r->ic_line) ? max_ln : r->ic_line;
+    }
+    if (r->type == IC_BASE_PTR) {
+    } else if (r->type == __IC_STATICS_SIZE)
+      statics_sz = r->integer;
+  }
+  for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code;
+       r = ICFwd(r)) {
+    cnt++;
+  }
+  if (dbg_info) {
+    // Dont allocate on cctrl->hc heap ctrl as we want to share our datqa
+    cctrl->code_ctrl->dbg_info = dbg_info;
+    cctrl->code_ctrl->min_ln = min_ln;
+  }
+  CRPN *forwards[cnt2 = cnt];
+  cnt = 0;
+  for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code;
+       r = ICFwd(r)) {
+    forwards[cnt2 - ++cnt] = r;
+  }
+  // We DONT reset the wiggle room
+  cctrl->backend_user_data0 = 0;
+  // 0 get maximum code size,
+  // 1 compute bin
+  for (run = 0; run < 2; run++) {
+    cctrl->code_ctrl->final_pass = run;
+    cctrl->backend_user_data1 = 0;
+    cctrl->backend_user_data2 = 0;
+    cctrl->backend_user_data3 = 0;
+    if (run == 0) {
+      code_off = 0;
+      bin = NULL;
+    } else if (run == 1) {
+      // Dont allocate on cctrl->hc heap ctrl as we want to share our data
+      bin = A_MALLOC(64 + code_off, NULL);
+      code_off = 0;
+    }
+    code_off = FuncProlog(cctrl, bin, code_off);
+    for (cnt = 0; cnt < cnt2; cnt++) {
+    enter:
+      r = forwards[cnt];
+      if (PushTmpDepthFirst(cctrl, r, 0))
+        PopTmp(cctrl, r);
+      // These modes expect you run ->__sib_base_rpn/__sib_index_rpn
+      if (r->res.mode != __MD_X86_64_LEA_SIB &&
+          r->res.mode != __MD_X86_64_SIB) {
+        r->res.mode = MD_NULL;
+      }
+      assert(cctrl->backend_user_data1 == 0);
+      assert(cctrl->backend_user_data2 == 0);
+      assert(cctrl->backend_user_data3 == 0);
+      code_off = __OptPassFinal(cctrl, r, bin, code_off);
+      if (IsTerminalInst(r)) {
+        cnt++;
+        for (; cnt < cnt2; cnt++) {
+          if (forwards[cnt]->type == IC_LABEL)
+            goto enter;
+        }
+      }
+    }
+    cctrl->epilog_label->addr = bin + code_off;
+    code_off = FuncEpilog(cctrl, bin, code_off);
+    for (misc = cctrl->code_ctrl->code_misc->next;
+         misc != cctrl->code_ctrl->code_misc; misc = misc->base.next) {
+      int64_t old_code_off = code_off;
+      switch (misc->type) {
+        break;
+      case CMT_INT_CONST:
+        if (code_off % 8)
+          code_off += 8 - code_off % 8;
+        misc->addr = bin + code_off;
+        if (bin)
+          *(int64_t *)(bin + code_off) = misc->integer;
+        code_off += 8;
+      fill_in_refs:
+        for (cm_ref = misc->refs; cm_ref; cm_ref = cm_ref_tmp) {
+          cm_ref_tmp = cm_ref->next;
+          if (run)
+            *cm_ref->add_to = (char *)misc->addr - (char *)cm_ref->add_to - 4 +
+                              cm_ref->offset;
+          A_FREE(cm_ref);
+        }
+        misc->refs = NULL;
+        break;
+      case CMT_FLOAT_CONST:
+        if (code_off % 8)
+          code_off += 8 - code_off % 8;
+        misc->addr = bin + code_off;
+        if (bin)
+          *(double *)(bin + code_off) = misc->flt;
+        code_off += 8;
+        goto fill_in_refs;
+        break;
+      case CMT_JMP_TAB:
+        if (code_off % 8)
+          code_off += 8 - code_off % 8;
+        misc->addr = bin + code_off;
+        if (misc->patch_addr)
+          *misc->patch_addr = misc->addr;
+        if (bin) {
+          for (idx = 0; idx <= misc->hi - misc->lo; idx++)
+            *(void **)(bin + code_off + idx * 8) =
+                (char *)misc->jmp_tab[idx]->addr;
+        }
+        code_off += (misc->hi - misc->lo + 1) * 8;
+        goto fill_in_refs;
+        break;
+      case CMT_LABEL:
+        if (misc->patch_addr)
+          *misc->patch_addr = misc->addr;
+        // We assign the statics offset later
+        if (misc == cctrl->statics_label)
+          break;
+        goto fill_in_refs;
+      case CMT_SHORT_ADDR:
+        if (run && misc->patch_addr) {
+          *misc->patch_addr = misc->addr;
+        }
+        break;
+      case CMT_RELOC_U64:
+        if (code_off % 8)
+          code_off += 8 - code_off % 8;
+        misc->addr = bin + code_off;
+        if (bin)
+          *(void **)(bin + code_off) = &DoNothing;
+        code_off += 8;
+        if (run) {
+          import = A_CALLOC(sizeof(CHashImport), NULL);
+          import->base.type = HTT_IMPORT_SYS_SYM;
+          import->base.str = A_STRDUP(misc->str, NULL);
+          import->address = misc->addr;
+          HashAdd(import, Fs->hash_table);
+        }
+        if (run && misc->patch_addr) {
+          *misc->patch_addr = misc->addr;
+        }
+        goto fill_in_refs;
+        break;
+      case CMT_STRING:
+        if (!(cctrl->flags & CCF_STRINGS_ON_HEAP)) {
+          if (code_off % 8)
+            code_off += 8 - code_off % 8;
+          misc->addr = bin + code_off;
+          if (bin)
+            memcpy(bin + code_off, misc->str, misc->str_len);
+          code_off += misc->str_len;
+        } else {
+          if (run) {
+            // See IC_STR: We "steal" the ->str because it's already on the
+            // heap.
+            //  IC_STR steals the ->str point so we dont want to Free it
+            misc->str = NULL;
+          }
+        }
+        goto fill_in_refs;
+      }
+    }
+    if (code_off % 8) // Align to 8
+      code_off += 8 - code_off % 8;
+    cctrl->code_ctrl->statics_offset = code_off;
+    cctrl->statics_label->addr = bin + cctrl->code_ctrl->statics_offset;
+    // Fill in the static references
+    if (bin)
+      for (r = cctrl->code_ctrl->ir_code->next; r != cctrl->code_ctrl->ir_code;
+           r = r->base.next) {
+        if (r->type == __IC_SET_STATIC_DATA) {
+          memcpy(bin + cctrl->code_ctrl->statics_offset + r->code_misc->integer,
+                 r->code_misc->str, r->code_misc->str_len);
+        }
+      }
+    if (bin) {
+      for (cm_ref = cctrl->statics_label->refs; cm_ref; cm_ref = cm_ref_tmp) {
+        cm_ref_tmp = cm_ref->next;
+        *cm_ref->add_to = (char *)cctrl->statics_label->addr -
+                          (char *)cm_ref->add_to - 4 + cm_ref->offset;
+        A_FREE(cm_ref);
+      }
+    }
+    if (statics_sz)
+      code_off += statics_sz + 8;
+  }
+  final_size = code_off;
+  if (dbg_info) {
+    cnt = MSize(dbg_info) / 8;
+    ptr = dbg_info[0] = bin;
+    for (idx = 1; idx < cnt; idx++) {
+      if (!dbg_info[idx]) {
+        dbg_info[idx] = NULL;
+        continue;
+      }
+      if (ptr > dbg_info[idx]) {
+        // No backwards jumps
+        dbg_info[idx] = NULL;
+        continue;
+      }
+      ptr = dbg_info[idx];
+    }
+  }
+  if (res_sz)
+    *res_sz = final_size;
+  return bin;
 }


### PR DESCRIPTION
Dropped yasm for x86_64 as yasm doesn't provide any significant benefit over using the C compiler to assemble them directly
Added build options to optimize better, inline functions and reduce binary size, removed a bunch of options that drastically slow down the HolyC compiler(eg, -fstack-protector), and added BUILD_HCRT cmake option because requiring a rebuild of HCRT everytime a change happens in the C side becomes annoying(YES by default so it works like before if unspecified)
Added 60fps and SetFPS()

Builds tested both on Windows&Linux