### PR TITLE
Fix multic.c compile error

### DIFF
--- a/multic.c
+++ b/multic.c
@@ -5,7 +5,7 @@
 #if defined(__linux__) && defined(__x86_64__)
 // See /usr/include/x86_64-linux-gnu/sys/ucontext.h
 enum {
-  REG_R8 = 0,C
+  REG_R8 = 0,
   REG_R9,
   REG_R10,
   REG_R11,


### PR DESCRIPTION
I couldn't get the lastest Aiwnios to compile, seems there is a stray C character in multic.c