### PR TITLE
Windows compatibility layer

### DIFF
--- a/c/dbg.c
+++ b/c/dbg.c
@@ -1,63 +1,90 @@
-#include "c/aiwn_asm.h"
-#include "c/aiwn_except.h"
-#include "c/aiwn_hash.h"
-#include "c/aiwn_mem.h"
-#include "c/aiwn_multic.h"
-#include "c/aiwn_que.h"
-#include <signal.h>
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-// Look at your vendor's ucontext.h
-#define __USE_GNU
-#define _XOPEN_SOURCE    1
-#define DBG_MSG_RESUME   "%p:%d,RESUME,%p\n"   //(task,pid,single_step)
-#define DBG_MSG_START    "%p:%d,START,%p\n"    //(task,pid,dump_regs_to)
-#define DBG_MSG_SET_GREG "%p:%d,SGREG,%p,%p\n" //(task,pid,which_reg,value)
-#define DBG_MSG_WATCH_TID                                                      \
-  "0:0,WATCHTID,%d\n" //(tid,aiwnios is a Godsend,it will send you a message for
-                      // the important TIDs(cores))
-#define DBG_MSG_OK "OK"
-#if defined(__OpenBSD__) || defined(__NetBSD__) || defined(__linux__) || defined(__FreeBSD__) ||      \
-    defined(__APPLE__)
-#  include <poll.h>
-#  include <sys/ptrace.h>
-#  include <sys/types.h>
-#  include <sys/wait.h>
-#  include <unistd.h>
-#  ifdef __OpenBSD__
-#    include <machine/reg.h>
-#  else
-#    include <ucontext.h>
-#  endif
-#  if defined(__FreeBSD__)
-#    include <machine/reg.h>
-#  endif
-#  if defined(__linux__)
-#    include <linux/elf.h> //Why do I need this for NT_PRSTATUS
-#    include <sys/uio.h>
-#    include <sys/user.h>
-#  endif
+#ifdef __EMSCRIPTEN__
+#  include "c/aiwn_asm.h"
+#  include "c/aiwn_bytecode.h"
+#  include "c/aiwn_except.h"
+#  include "c/aiwn_hash.h"
+#  include "c/aiwn_mem.h"
+#  include "c/aiwn_multic.h"
+#  include "c/aiwn_que.h"
+#  include <emscripten.h>
+#  include <stdint.h>
+#  include <string.h>
+void DebuggerClientSetGreg(void *task, int64_t which, int64_t v) {
+}
+void DebuggerClientStart(void *task, void **write_regs_to) {
+  memcpy(write_regs_to, AiwnBCDbgCurContext(), sizeof(ABCFrame));
+}
+void DebuggerClientEnd(void *task, int64_t wants_singlestep) {
+}
+void DebuggerClientWatchThisTID() {
+}
+void DebuggerBegin() {
+}
+void InstallDbgSignalsForThread() {
+}
 #else
-#  include <windows.h>
-#  include <errhandlingapi.h>
-#  include <handleapi.h>
-#  include <processthreadsapi.h>
-#  include <sys/types.h>
-#endif
-#if defined(__APPLE__)
+#  include "aiwn_bytecode.h"
+#  include "c/aiwn_asm.h"
+#  include "c/aiwn_except.h"
+#  include "c/aiwn_hash.h"
+#  include "c/aiwn_mem.h"
+#  include "c/aiwn_multic.h"
+#  include "c/aiwn_que.h"
+#  include <signal.h>
+#  include <stdarg.h>
+#  include <stdint.h>
+#  include <stdio.h>
+#  include <stdlib.h>
+#  include <string.h>
+// Look at your vendor's ucontext.h
+#  define __USE_GNU
+#  define _XOPEN_SOURCE    1
+#  define DBG_MSG_RESUME   "%p:%d,RESUME,%p\n"   //(task,pid,single_step)
+#  define DBG_MSG_START    "%p:%d,START,%p\n"    //(task,pid,dump_regs_to)
+#  define DBG_MSG_SET_GREG "%p:%d,SGREG,%p,%p\n" //(task,pid,which_reg,value)
+#  define DBG_MSG_WATCH_TID                                                    \
+    "0:0,WATCHTID,%d\n" //(tid,aiwnios is a Godsend,it will send you a message
+                        //for
+                        // the important TIDs(cores))
+#  define DBG_MSG_OK "OK"
+#  if defined(__OpenBSD__) || defined(__NetBSD__) || defined(__linux__) ||     \
+      defined(__FreeBSD__) || defined(__APPLE__)
+#    include <poll.h>
+#    include <sys/ptrace.h>
+#    include <sys/types.h>
+#    include <sys/wait.h>
+#    include <unistd.h>
+#    ifdef __OpenBSD__
+#      include <machine/reg.h>
+#    else
+#      include <ucontext.h>
+#    endif
+#    if defined(__FreeBSD__)
+#      include <machine/reg.h>
+#    endif
+#    if defined(__linux__)
+#      include <linux/elf.h> //Why do I need this for NT_PRSTATUS
+#      include <sys/uio.h>
+#      include <sys/user.h>
+#    endif
+#  elif defined(WIN32) || defined(_WIN32) || defined(_WIN64) || defined(WIN64)
+#    include <windows.h>
+#    include <errhandlingapi.h>
+#    include <handleapi.h>
+#    include <processthreadsapi.h>
+#    include <sys/types.h>
+#  endif
+#  if defined(__APPLE__)
 typedef struct CFuckup {
   struct CQue base;
   int64_t signal;
   pid_t pid;
   void *task;
 } CFuckup;
-#  define PTRACE_TRACEME PT_TRACE_ME
-#  define gettid         getpid
-#endif
-#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#    define PTRACE_TRACEME PT_TRACE_ME
+#    define gettid         getpid
+#  endif
+#  if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
 typedef struct CFuckup {
   struct CQue base;
   int64_t signal;
@@ -66,35 +93,35 @@ typedef struct CFuckup {
   struct reg regs;
   struct fpreg fp;
 } CFuckup;
-#  define PTRACE_TRACEME   PT_TRACE_ME
-#  define PTRACE_ATTACH    PT_ATTACH
-#  define PTRACE_SETREGS   PT_SETREGS
-#  define PTRACE_GETREGS   PT_GETREGS
-#  define PTRACE_SETFPREGS PT_SETFPREGS
-#  define PTRACE_GETFPREGS PT_GETFPREGS
-#  define gettid           getpid
-#endif
-#if defined(__linux__)
-#  include <asm/ptrace.h>
-#  include <sys/user.h>
+#    define PTRACE_TRACEME   PT_TRACE_ME
+#    define PTRACE_ATTACH    PT_ATTACH
+#    define PTRACE_SETREGS   PT_SETREGS
+#    define PTRACE_GETREGS   PT_GETREGS
+#    define PTRACE_SETFPREGS PT_SETFPREGS
+#    define PTRACE_GETFPREGS PT_GETFPREGS
+#    define gettid           getpid
+#  endif
+#  if defined(__linux__)
+#    include <asm/ptrace.h>
+#    include <sys/user.h>
 typedef struct CFuckup {
   struct CQue base;
   int64_t signal;
   pid_t pid;
   void *task;
-#  if defined(_M_ARM64) || defined(__aarch64__)
+#    if defined(_M_ARM64) || defined(__aarch64__)
   struct user_pt_regs regs;
   struct user_fpsimd_struct fp;
-#  elif defined(__x86_64__)
+#    elif defined(__x86_64__)
   struct user_fpregs_struct fp;
   struct user_regs_struct regs;
-#  elif defined(__riscv__) || defined(__riscv)
+#    elif defined(__riscv__) || defined(__riscv)
   struct user_regs_struct regs;
   union __riscv_fp_state fp;
-#  endif
+#    endif
 } CFuckup;
-#elif defined(_WIN64)
-#  include <winnt.h>
+#  elif defined(_WIN64)
+#    include <winnt.h>
 typedef struct CFuckup {
   struct CQue base;
   int64_t signal;
@@ -102,10 +129,10 @@ typedef struct CFuckup {
   void *task;
   CONTEXT *_regs; // regs may be alligned
 } CFuckup;
-#  ifndef SIGCONT
-#    define SIGCONT 0x101
+#    ifndef SIGCONT
+#      define SIGCONT 0x101
+#    endif
 #  endif
-#endif
 CFuckup *GetFuckupByTask(CQue *head, void *t) {
   CFuckup *fu;
   for (fu = head->next; fu != head; fu = fu->base.next) {
@@ -125,7 +152,7 @@ CFuckup *GetFuckupByPid(CQue *head, int64_t pid) {
 // Im making fuckups global on windows because debugging is not event driven on
 // windows
 static CQue fuckups;
-#if defined(WIN32) || defined(_WIN32)
+#  if defined(WIN32) || defined(_WIN32)
 static int64_t gettid() {
   return GetCurrentThreadId();
 }
@@ -136,7 +163,7 @@ typedef struct _CDbgMsgQue {
 } _CDbgMsgQue;
 static CQue debugger_msgs;
 static HANDLE debugger_mtx;
-#  define HARD_CORE_CNT 64
+#    define HARD_CORE_CNT 64
 static HANDLE active_threads[HARD_CORE_CNT];
 static CONTEXT thread_use_ctx[HARD_CORE_CNT];
 static int64_t fault_codes[HARD_CORE_CNT];
@@ -197,7 +224,7 @@ static void AllowNext(int64_t pid) {
 found:;
   ResumeThread(active_threads[tr]);
 }
-#else
+#  else
 static int debugger_pipe[2];
 static void ReadMsg(char *buf) {
   if (!debugger_pipe[0])
@@ -220,10 +247,10 @@ static void WriteMsg(char const *fmt, ...) {
   va_end(l);
   write(debugger_pipe[1], "", 1);
 }
-#  if __OpenBSD__ + __NetBSD__ > 0
-#    include <poll.h>
-#    define POLL_IN POLLIN
-#  endif
+#    if __OpenBSD__ + __NetBSD__ > 0
+#      include <poll.h>
+#      define POLL_IN POLLIN
+#    endif
 static int64_t MsgPoll() {
   struct pollfd poll_for;
   memset(&poll_for, 0, sizeof(struct pollfd));
@@ -234,16 +261,16 @@ static int64_t MsgPoll() {
   return 0;
 }
 static void GrabDebugger(int64_t code) {
-#  if defined(__APPLE__)
+#    if defined(__APPLE__)
 // Tee hee
-#  else
+#    else
   raise(code);
-#  endif
+#    endif
 }
-#endif
+#  endif
 
 void DebuggerClientWatchThisTID() {
-#if defined(_WIN32) || defined(WIN32)
+#  if defined(_WIN32) || defined(WIN32)
   int64_t tr;
   WaitForSingleObject(debugger_mtx, INFINITE);
   for (tr = 0; active_threads[tr]; tr++)
@@ -252,12 +279,12 @@ void DebuggerClientWatchThisTID() {
   DuplicateHandle(GetCurrentProcess(), GetCurrentThread(), GetCurrentProcess(),
                   &active_threads[tr], 0, FALSE, DUPLICATE_SAME_ACCESS);
   ReleaseMutex(debugger_mtx);
-#else
+#  else
   int64_t tid = gettid();
   WriteMsg(DBG_MSG_WATCH_TID, tid);
-#endif
+#  endif
 }
-#if defined(_WIN32) || defined(WIN32)
+#  if defined(_WIN32) || defined(WIN32)
 static int64_t DebuggerWait(CQue *head, pid_t *got) {
   int64_t s, tid;
   CFuckup *fu;
@@ -278,7 +305,7 @@ static int64_t DebuggerWait(CQue *head, pid_t *got) {
   }
   return 0;
 }
-#else
+#  else
 static int64_t DebuggerWait(CQue *head, pid_t *got) {
   int code, sig;
   pid_t pid = waitpid(-1, &code, WNOHANG | WUNTRACED | WCONTINUED);
@@ -316,13 +343,13 @@ static int64_t DebuggerWait(CQue *head, pid_t *got) {
     case SIGSTOP:
       break;
     default:
-#  if defined(__x86_64__)
+#    if defined(__x86_64__)
       // IF you are blessed you are running on a platform that has these
       // Here's the deal Linux takes it in data/freebsd takes it in
       // addr(only 1 is used my homie)
       ptrace(PTRACE_GETREGS, pid, &fu->regs, &fu->regs);
       ptrace(PTRACE_GETFPREGS, pid, &fu->fp, &fu->fp);
-#  elif defined(PTRACE_GETREGSET)
+#    elif defined(PTRACE_GETREGSET)
       struct iovec poop;
       poop.iov_len = sizeof(fu->regs);
       poop.iov_base = &fu->regs;
@@ -330,42 +357,42 @@ static int64_t DebuggerWait(CQue *head, pid_t *got) {
       poop.iov_len = sizeof(fu->fp);
       poop.iov_base = &fu->fp;
       ptrace(PTRACE_GETREGSET, pid, NT_PRFPREG, &poop);
-#  endif
+#    endif
     }
     if (got)
       *got = pid;
     return sig;
   }
 }
-#endif
+#  endif
 static void PTWriteAPtr(int64_t tid, void *to, uint64_t v) {
   int64_t s;
-#if defined(_WIN32) || defined(WIN32)
+#  if defined(_WIN32) || defined(WIN32)
   *(void **)to = (void *)v;
-#endif
-#if defined(__linux__)
-#  if defined(_M_ARM64) || defined(__aarch64__) || defined(__x86_64__) ||      \
-      defined(__riscv) || defined(__riscv__)
+#  endif
+#  if defined(__linux__)
+#    if defined(_M_ARM64) || defined(__aarch64__) || defined(__x86_64__) ||    \
+        defined(__riscv) || defined(__riscv__)
   for (s = 0; s != 8 / 2; s++) {
     if (!s)
       ptrace(PTRACE_POKETEXT, tid, to + s, v & 0xffff);
     else
       ptrace(PTRACE_POKETEXT, tid, to + s * 2, (v >> (s * 16ul)) & 0xfffful);
   }
-#  endif
-#elif defined(__FreeBSD__)
+#    endif
+#  elif defined(__FreeBSD__)
   for (s = 0; s != 8 / 4; s++)
     ptrace(PT_WRITE_D, tid, to + s * 4, (v >> (s * 32ul)) & 0xffffFFFFul);
-#endif
+#  endif
 }
 void DebuggerBegin() {
   pid_t tid = 0;
-#if __OpenBSD__ + __NetBSD__ > 0
+#  if __OpenBSD__ + __NetBSD__ > 0
   // OpenBSD ptrace is poopy
   return;
-#endif
+#  endif
 
-#if defined(_WIN32) || defined(WIN32)
+#  if defined(_WIN32) || defined(WIN32)
   static int64_t init = 0;
   tid = init; // SIMULATE fork sort of
   if (!init) {
@@ -375,28 +402,28 @@ void DebuggerBegin() {
     QueInit(&debugger_msgs);
     init = 1;
   }
-#else
+#  else
   pipe(debugger_pipe);
   tid = fork();
-#endif
+#  endif
   int code, sig;
   void *task;
   char buf[4048], *ptr;
   pid_t child = tid;
   if (!tid) {
-#if !(defined(_WIN32) || defined(WIN32))
+#  if !(defined(_WIN32) || defined(WIN32))
     ptrace(PTRACE_TRACEME, tid, NULL, NULL);
     raise(SIGSTOP);
-#else
+#  else
     CreateThread(NULL, 0, &DebuggerBegin, NULL, 0, NULL);
-#endif
+#  endif
     WriteMsg(DBG_MSG_OK);
     return;
   } else {
-#if !(defined(_WIN32) || defined(WIN32))
+#  if !(defined(_WIN32) || defined(WIN32))
     wait(tid);
     ptrace(PT_CONTINUE, tid, 1, NULL);
-#endif
+#  endif
     while (1) {
       ReadMsg(buf);
       if (strcmp(buf, DBG_MSG_OK))
@@ -405,9 +432,9 @@ void DebuggerBegin() {
         break;
     }
 
-#if defined(__linux__)
+#  if defined(__linux__)
     struct iovec poop;
-#endif
+#  endif
     CFuckup *fu, *last;
     char *ptr, *name;
     int64_t which, value, sig, *write_regs_to;
@@ -440,7 +467,7 @@ void DebuggerBegin() {
                 }
               }
               // SEE swapctxX86.s
-#if defined(_WIN32) || defined(WIN32)
+#  if defined(_WIN32) || defined(WIN32)
               switch (which) {
               case 0:
                 fu->_regs->Rip = value;
@@ -453,8 +480,8 @@ void DebuggerBegin() {
                 break;
               }
               AllowNext(tid);
-#endif
-#if defined(__FreeBSD__) && defined(__x86_64__)
+#  endif
+#  if defined(__FreeBSD__) && defined(__x86_64__)
               switch (which) {
               case 0:
                 fu->regs.r_rip = value;
@@ -468,8 +495,8 @@ void DebuggerBegin() {
                 // DONT RELY ON CHANGING GPs
               }
               ptrace(PT_CONTINUE, tid, 1, 0);
-#endif
-#if defined(__linux__) && defined(__x86_64__)
+#  endif
+#  if defined(__linux__) && defined(__x86_64__)
               switch (which) {
               case 0:
                 fu->regs.rip = value;
@@ -483,8 +510,8 @@ void DebuggerBegin() {
                 // DONT RELY ON CHANGING GPs
               }
               ptrace(PT_CONTINUE, tid, 0, 0);
-#endif
-#if defined(__linux__) && (defined(_M_ARM64) || defined(__aarch64__))
+#  endif
+#  if defined(__linux__) && (defined(_M_ARM64) || defined(__aarch64__))
               switch (which) {
               case 22:
                 fu->regs.pc = value;
@@ -498,8 +525,8 @@ void DebuggerBegin() {
                 // DONT RELY ON CHANGING GPs
               }
               ptrace(PT_CONTINUE, tid, 0, 0);
-#endif
-#if (defined(__riscv) || defined(__riscv__)) && defined(__linux__)
+#  endif
+#  if (defined(__riscv) || defined(__riscv__)) && defined(__linux__)
               switch (which) {
               case 0:
                 fu->regs.pc = value;
@@ -545,7 +572,7 @@ void DebuggerBegin() {
                 break;
               }
               ptrace(PT_CONTINUE, tid, 0, 0);
-#endif
+#  endif
               break;
             } else if (!strncmp(name, "WATCHTID", strlen("WATCHTID"))) {
               int64_t tr;
@@ -554,9 +581,9 @@ void DebuggerBegin() {
                 abort();
               ptr++;
 // On FreeBSD there is no "TID"s
-#if defined(__linux__)
+#  if defined(__linux__)
               ptrace(PTRACE_ATTACH, strtoul(ptr, NULL, 10), NULL, NULL);
-#endif
+#  endif
               break;
             } else if (!strncmp(name, "START", strlen("START"))) {
               void *task;
@@ -576,29 +603,29 @@ void DebuggerBegin() {
                 puts("undef Fu");
               else {
 // See your swapctx for your arch(swapctxAARCH64/swapctxX86)
-#if defined(__x86_64__)
-#  if defined(__linux__)
+#  if defined(__x86_64__)
+#    if defined(__linux__)
                 PTWriteAPtr(tid, &write_regs_to[0], fu->regs.rip);
                 PTWriteAPtr(tid, &write_regs_to[1], fu->regs.rsp);
                 PTWriteAPtr(tid, &write_regs_to[2], fu->regs.rbp);
-#  elif defined(__FreeBSD__)
+#    elif defined(__FreeBSD__)
                 PTWriteAPtr(tid, &write_regs_to[0], fu->regs.r_rip);
                 PTWriteAPtr(tid, &write_regs_to[1], fu->regs.r_rsp);
                 PTWriteAPtr(tid, &write_regs_to[2], fu->regs.r_rbp);
-#  elif defined(_WIN32) || defined(WIN32)
+#    elif defined(_WIN32) || defined(WIN32)
                 PTWriteAPtr(tid, &write_regs_to[0], fu->_regs->Rip);
                 PTWriteAPtr(tid, &write_regs_to[1], fu->_regs->Rsp);
                 PTWriteAPtr(tid, &write_regs_to[2], fu->_regs->Rbp);
+#    endif
 #  endif
-#endif
 
-#if defined(_M_ARM64) || defined(__aarch64__)
-#  if defined(__linux__)
+#  if defined(_M_ARM64) || defined(__aarch64__)
+#    if defined(__linux__)
                 //???
-#  elif defined(__FreeBSD__)
+#    elif defined(__FreeBSD__)
+#    endif
 #  endif
-#endif
-#if (defined(__riscv) || defined(__riscv__)) && defined(__linux__)
+#  if (defined(__riscv) || defined(__riscv__)) && defined(__linux__)
                 PTWriteAPtr(tid, &write_regs_to[0], fu->regs.pc);
                 PTWriteAPtr(tid, &write_regs_to[1], fu->regs.sp);
                 PTWriteAPtr(tid, &write_regs_to[2], fu->regs.s0);
@@ -613,13 +640,13 @@ void DebuggerBegin() {
                 PTWriteAPtr(tid, &write_regs_to[11], fu->regs.s9);
                 PTWriteAPtr(tid, &write_regs_to[12], fu->regs.s10);
                 PTWriteAPtr(tid, &write_regs_to[13], fu->regs.s11);
-#endif
+#  endif
               }
-#if defined(_WIN32) || defined(WIN32)
+#  if defined(_WIN32) || defined(WIN32)
               AllowNext(tid);
-#else
+#  else
               ptrace(PT_CONTINUE, tid, 1, 0);
-#endif
+#  endif
               break;
             } else if (!strncmp(name, "RESUME", strlen("RESUME"))) {
               void *task;
@@ -637,29 +664,29 @@ void DebuggerBegin() {
               }
               fu = GetFuckupByTask(&fuckups, task);
               if (!fu) {
-#if defined(_WIN32) || defined(WIN32)
+#  if defined(_WIN32) || defined(WIN32)
                 AllowNext(tid);
-#else
+#  else
                 ptrace(PT_CONTINUE, tid, 1, 0);
-#endif
+#  endif
                 break;
               }
-#if !(defined(_WIN32) || defined(WIN32))
-#  if defined(__x86_64__)
+#  if !(defined(_WIN32) || defined(WIN32))
+#    if defined(__x86_64__)
               // IF you are blessed you are running on a platform that has
               // these Here's the deal Linux takes it in data/freebsd takes it
               // in addr(only 1 is used my homie)
               ptrace(PTRACE_SETREGS, tid, &fu->regs, &fu->regs);
               ptrace(PTRACE_SETFPREGS, tid, &fu->fp, &fu->fp);
-#  elif defined(__linux__)
+#    elif defined(__linux__)
               poop.iov_len = sizeof(fu->regs);
               poop.iov_base = &fu->regs;
               ptrace(PTRACE_SETREGSET, tid, NT_PRSTATUS, &poop);
               poop.iov_len = sizeof(fu->fp);
               poop.iov_base = &fu->fp;
               ptrace(PTRACE_SETREGSET, tid, NT_PRFPREG, &poop);
-#  endif
-#else
+#    endif
+#  else
               // See thread_use_ctx
               int64_t tr;
               for (tr = 0; tr != HARD_CORE_CNT; tr++) {
@@ -668,28 +695,28 @@ void DebuggerBegin() {
                 if (GetThreadId(active_threads[tr]) == tid)
                   break;
               }
-#endif
+#  endif
               if (ss) {
-#if defined(__FreeBSD__)
+#  if defined(__FreeBSD__)
                 ptrace(PT_STEP, tid, 1, 0);
-#elif defined(_WIN32) || defined(WIN32)
+#  elif defined(_WIN32) || defined(WIN32)
                 fu->_regs->EFlags |= 1 << 8; // Trap flag
                 AllowNext(tid);
-#elif defined(__linux__)
+#  elif defined(__linux__)
                 ptrace(PTRACE_SINGLESTEP, tid, 0, 0);
-#endif
+#  endif
                 QueRem(fu);
                 free(fu);
               } else {
-#if defined(_WI32) || defined(WIN32)
+#  if defined(_WI32) || defined(WIN32)
                 AllowNext(tid);
-#else
-#  if defined(__x86_64__)
-                ptrace(PT_CONTINUE, tid, 1, 0);
 #  else
+#    if defined(__x86_64__)
+                ptrace(PT_CONTINUE, tid, 1, 0);
+#    else
                 ptrace(PT_CONTINUE, tid, 0, 0);
+#    endif
 #  endif
-#endif
                 QueRem(fu);
                 free(fu);
               }
@@ -700,8 +727,8 @@ void DebuggerBegin() {
           ptr++;
         }
       } else if (sig = DebuggerWait(&fuckups, &tid)) {
-#if defined(_WIN32) || defined(WIN32)
-#else
+#  if defined(_WIN32) || defined(WIN32)
+#  else
         if (sig == SIGCONT)
           ;
         else if (sig == SIGSTOP ||
@@ -709,14 +736,14 @@ void DebuggerBegin() {
           ptrace(PT_CONTINUE, tid, 1, 0);
         else
           ptrace(PT_CONTINUE, tid, 1, sig);
-#endif
+#  endif
       }
     }
   }
 }
 static void UnblockSignals() {
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__) ||        \
-    defined(__OpenBSD__) || defined(__NetBSD__)
+#  if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__) ||      \
+      defined(__OpenBSD__) || defined(__NetBSD__)
   sigset_t set;
   sigemptyset(&set);
   sigaddset(&set, SIGILL);
@@ -725,13 +752,13 @@ static void UnblockSignals() {
   sigaddset(&set, SIGTRAP);
   sigaddset(&set, SIGFPE);
   sigprocmask(SIG_UNBLOCK, &set, NULL);
-#endif
+#  endif
 }
-#if defined(__OpenBSD__)
+#  if defined(__OpenBSD__)
 static void SigHandler(int sig, siginfo_t *info, void *__ctx) {
   UnblockSignals();
   CHashExport *exp;
-//OpenBSD doesnt put anything juicy in the __ctx ,do man 2 sigaction
+  // OpenBSD doesnt put anything juicy in the __ctx ,do man 2 sigaction
   void *fp;
   int64_t actx[32];
   // AiwniosDbgCB will return 1 for singlestep
@@ -745,20 +772,24 @@ static void SigHandler(int sig, siginfo_t *info, void *__ctx) {
   } else
     abort();
 }
-#endif
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__) || defined(__NetBSD__)
-#  if defined(__APPLE__)
-#    include <arm/_mcontext.h>
 #  endif
+#  if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__) ||      \
+      defined(__NetBSD__)
+#    if defined(__APPLE__)
+#      include <arm/_mcontext.h>
+#    endif
 static void SigHandler(int sig, siginfo_t *info, void *__ctx) {
   ucontext_t *_ctx = __ctx;
   if (sig == SIGWINCH) {
-    puts("SIGWINCH");
     UnblockSignals();
     return;
   }
-#  if defined(__x86_64__)
-#    if defined(__linux__)
+#    if defined(USE_BYTECODE)
+  UnblockSignals();
+  AiwnBCDbgFault(sig);
+  return;
+#    elif defined(__x86_64__)
+#      if defined(__linux__)
   // See /usr/include/x86_64-linux-gnu/sys/ucontext.h
   enum {
     REG_R8 = 0,
@@ -800,7 +831,7 @@ static void SigHandler(int sig, siginfo_t *info, void *__ctx) {
   } else
     abort();
   return; // returning calls setcontext
-#    elif defined(__NetBSD__)
+#      elif defined(__NetBSD__)
   UnblockSignals();
   mcontext_t *ctx = &_ctx->uc_mcontext;
   int64_t actx[32];
@@ -822,7 +853,7 @@ static void SigHandler(int sig, siginfo_t *info, void *__ctx) {
   } else
     abort();
   return;
-#elif defined(__FreeBSD__)
+#      elif defined(__FreeBSD__)
   UnblockSignals();
   mcontext_t *ctx = &_ctx->uc_mcontext;
   int64_t actx[32];
@@ -845,8 +876,8 @@ static void SigHandler(int sig, siginfo_t *info, void *__ctx) {
     abort();
   return;
 
-#    endif
-#  elif defined(__aarch64__) || defined(_M_ARM64)
+#      endif
+#    elif defined(__aarch64__) || defined(_M_ARM64)
   mcontext_t *ctx = &_ctx->uc_mcontext;
   CHashExport *exp;
   int64_t is_single_step;
@@ -860,34 +891,34 @@ static void SigHandler(int sig, siginfo_t *info, void *__ctx) {
   UnblockSignals();
   for (i = 18; i <= 30; i++)
     if (i - 18 != 12) // the 12th one is the return register
-#    if defined(__linux__)
+#      if defined(__linux__)
       actx[i - 18] = ctx->regs[i];
-#    elif defined(__FreeBSD__)
+#      elif defined(__FreeBSD__)
       actx[i - 18] = ctx->mc_gpregs.gp_x[i];
-#    elif defined(__APPLE__)
+#      elif defined(__APPLE__)
 // See the
 // /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/mach/arm/_structs.h
 // file actx[i-18]=ctx->__ss.__x[i];
-#    endif
-#    if defined(__linux__)
+#      endif
+#      if defined(__linux__)
   actx[22] = ctx->pc;
-#    elif defined(__FreeBSD__)
-#    endif
-#    if defined(__linux__)
+#      elif defined(__FreeBSD__)
+#      endif
+#      if defined(__linux__)
   actx[21] = ctx->sp;
-#    elif defined(__FreeBSD__)
+#      elif defined(__FreeBSD__)
   actx[21] = ctx->mc_gpregs.gp_sp;
-#    elif defined(__APPLE__)
+#      elif defined(__APPLE__)
 // See the
 // /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/mach/arm/_structs.h
 // file actx[21]=ctx->__ss.__sp;
-#    endif
+#      endif
   // AiwniosDbgCB will return 1 for singlestep
   if (exp = HashFind("AiwniosDbgCB", Fs->hash_table, HTT_EXPORT_SYS_SYM, 1)) {
     fp = exp->val;
     if (FFI_CALL_TOS_2(fp, sig, actx)) { // Returns 1 for single step
-#    if defined(__x86_64__)
-#      if defined(__FreeBSD__)
+#      if defined(__x86_64__)
+#        if defined(__FreeBSD__)
 
       ctx->mc_rip = actx[0];
       ctx->mc_rsp = actx[1];
@@ -899,7 +930,7 @@ static void SigHandler(int sig, siginfo_t *info, void *__ctx) {
       ctx->mc_r13 = actx[7];
       ctx->mc_r14 = actx[8];
       ctx->mc_r15 = actx[9] ctx->mc_eflags |= 1 << 8;
-#      elif defined(__linux__)
+#        elif defined(__linux__)
       ctx->gregs[REG_RIP] = actx[0];
       ctx->gregs[REG_RSP] = actx[1];
       ctx->gregs[REG_RBP] = actx[2];
@@ -910,8 +941,8 @@ static void SigHandler(int sig, siginfo_t *info, void *__ctx) {
       ctx->gregs[REG_R13] = actx[7];
       ctx->gregs[REG_R14] = actx[8];
       ctx->gregs[REG_R15] = actx[9];
+#        endif
 #      endif
-#    endif
     }
   } else if (exp = HashFind("Exit", Fs->hash_table, HTT_EXPORT_SYS_SYM, 1)) {
   call_exit:
@@ -919,8 +950,8 @@ static void SigHandler(int sig, siginfo_t *info, void *__ctx) {
     FFI_CALL_TOS_0(fp2);
   } else
     abort();
-#  endif
-#  if (defined(__riscv__) || defined(__riscv)) && defined(__linux__)
+#    endif
+#    if (defined(__riscv__) || defined(__riscv)) && defined(__linux__)
   UnblockSignals();
   CHashExport *exp;
   void *fp;
@@ -935,11 +966,11 @@ static void SigHandler(int sig, siginfo_t *info, void *__ctx) {
     FFI_CALL_TOS_0(fp);
   } else
     abort();
-#  endif
+#    endif
 }
-#endif
-#ifdef _WIN32
-#  define E(code) EXCEPTION_##code
+#  endif
+#  ifdef _WIN32
+#    define E(code) EXCEPTION_##code
 static LONG WINAPI VectorHandler(EXCEPTION_POINTERS *einfo) {
   CONTEXT *ctx = einfo->ContextRecord;
   CFuckup *fu = calloc(1, sizeof *fu);
@@ -987,9 +1018,9 @@ static LONG WINAPI Div0Handler(EXCEPTION_POINTERS *info) {
     return EXCEPTION_CONTINUE_SEARCH;
   }
 }
-#endif
+#  endif
 void InstallDbgSignalsForThread() {
-#ifndef _WIN32
+#  ifndef _WIN32
   struct sigaction sa = {
       .sa_flags = SA_SIGINFO,
       .sa_sigaction = SigHandler,
@@ -997,16 +1028,25 @@ void InstallDbgSignalsForThread() {
   int sigs[] = {SIGSEGV, SIGBUS, SIGTRAP, SIGILL, -1};
   for (int *sigp = sigs; *sigp != -1; sigp++)
     sigaction(*sigp, &sa, 0);
-#else
+#  else
   /* If the First parameter is nonzero, the handler is the first handler to be
    * called until a subsequent call to AddVectoredExceptionHandler is used to
    * specify a different handler as the first handler.
    *   --Quoth MSDN */
   AddVectoredExceptionHandler(1, VectorHandler);
   AddVectoredExceptionHandler(1, Div0Handler);
-#endif
+#  endif
 }
 // This happens when after we call DebuggerClientEnd
+#  if defined(USE_BYTECODE)
+void DebuggerClientSetGreg(void *task, int64_t which, int64_t v) {
+}
+void DebuggerClientStart(void *task, void **write_regs_to) {
+  memcpy(write_regs_to, AiwnBCDbgCurContext(), sizeof(ABCFrame));
+}
+void DebuggerClientEnd(void *task, int64_t wants_singlestep) {
+}
+#  else
 void DebuggerClientSetGreg(void *task, int64_t which, int64_t v) {
   WriteMsg(DBG_MSG_SET_GREG, task, gettid(), which, v);
   GrabDebugger(SIGCONT);
@@ -1019,3 +1059,5 @@ void DebuggerClientEnd(void *task, int64_t wants_singlestep) {
   WriteMsg(DBG_MSG_RESUME, task, gettid(), wants_singlestep);
   GrabDebugger(SIGCONT);
 }
+#  endif
+#endif

--- a/c/dbg.c
+++ b/c/dbg.c
@@ -1,90 +1,63 @@
-#ifdef __EMSCRIPTEN__
-#  include "c/aiwn_asm.h"
-#  include "c/aiwn_bytecode.h"
-#  include "c/aiwn_except.h"
-#  include "c/aiwn_hash.h"
-#  include "c/aiwn_mem.h"
-#  include "c/aiwn_multic.h"
-#  include "c/aiwn_que.h"
-#  include <emscripten.h>
-#  include <stdint.h>
-#  include <string.h>
-void DebuggerClientSetGreg(void *task, int64_t which, int64_t v) {
-}
-void DebuggerClientStart(void *task, void **write_regs_to) {
-  memcpy(write_regs_to, AiwnBCDbgCurContext(), sizeof(ABCFrame));
-}
-void DebuggerClientEnd(void *task, int64_t wants_singlestep) {
-}
-void DebuggerClientWatchThisTID() {
-}
-void DebuggerBegin() {
-}
-void InstallDbgSignalsForThread() {
-}
-#else
-#  include "aiwn_bytecode.h"
-#  include "c/aiwn_asm.h"
-#  include "c/aiwn_except.h"
-#  include "c/aiwn_hash.h"
-#  include "c/aiwn_mem.h"
-#  include "c/aiwn_multic.h"
-#  include "c/aiwn_que.h"
-#  include <signal.h>
-#  include <stdarg.h>
-#  include <stdint.h>
-#  include <stdio.h>
-#  include <stdlib.h>
-#  include <string.h>
+#include "c/aiwn_asm.h"
+#include "c/aiwn_except.h"
+#include "c/aiwn_hash.h"
+#include "c/aiwn_mem.h"
+#include "c/aiwn_multic.h"
+#include "c/aiwn_que.h"
+#include <signal.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 // Look at your vendor's ucontext.h
-#  define __USE_GNU
-#  define _XOPEN_SOURCE    1
-#  define DBG_MSG_RESUME   "%p:%d,RESUME,%p\n"   //(task,pid,single_step)
-#  define DBG_MSG_START    "%p:%d,START,%p\n"    //(task,pid,dump_regs_to)
-#  define DBG_MSG_SET_GREG "%p:%d,SGREG,%p,%p\n" //(task,pid,which_reg,value)
-#  define DBG_MSG_WATCH_TID                                                    \
-    "0:0,WATCHTID,%d\n" //(tid,aiwnios is a Godsend,it will send you a message
-                        //for
-                        // the important TIDs(cores))
-#  define DBG_MSG_OK "OK"
-#  if defined(__OpenBSD__) || defined(__NetBSD__) || defined(__linux__) ||     \
-      defined(__FreeBSD__) || defined(__APPLE__)
-#    include <poll.h>
-#    include <sys/ptrace.h>
-#    include <sys/types.h>
-#    include <sys/wait.h>
-#    include <unistd.h>
-#    ifdef __OpenBSD__
-#      include <machine/reg.h>
-#    else
-#      include <ucontext.h>
-#    endif
-#    if defined(__FreeBSD__)
-#      include <machine/reg.h>
-#    endif
-#    if defined(__linux__)
-#      include <linux/elf.h> //Why do I need this for NT_PRSTATUS
-#      include <sys/uio.h>
-#      include <sys/user.h>
-#    endif
-#  elif defined(WIN32) || defined(_WIN32) || defined(_WIN64) || defined(WIN64)
-#    include <windows.h>
-#    include <errhandlingapi.h>
-#    include <handleapi.h>
-#    include <processthreadsapi.h>
-#    include <sys/types.h>
+#define __USE_GNU
+#define _XOPEN_SOURCE    1
+#define DBG_MSG_RESUME   "%p:%d,RESUME,%p\n"   //(task,pid,single_step)
+#define DBG_MSG_START    "%p:%d,START,%p\n"    //(task,pid,dump_regs_to)
+#define DBG_MSG_SET_GREG "%p:%d,SGREG,%p,%p\n" //(task,pid,which_reg,value)
+#define DBG_MSG_WATCH_TID                                                      \
+  "0:0,WATCHTID,%d\n" //(tid,aiwnios is a Godsend,it will send you a message for
+                      // the important TIDs(cores))
+#define DBG_MSG_OK "OK"
+#if defined(__OpenBSD__) || defined(__NetBSD__) || defined(__linux__) || defined(__FreeBSD__) ||      \
+    defined(__APPLE__)
+#  include <poll.h>
+#  include <sys/ptrace.h>
+#  include <sys/types.h>
+#  include <sys/wait.h>
+#  include <unistd.h>
+#  ifdef __OpenBSD__
+#    include <machine/reg.h>
+#  else
+#    include <ucontext.h>
 #  endif
-#  if defined(__APPLE__)
+#  if defined(__FreeBSD__)
+#    include <machine/reg.h>
+#  endif
+#  if defined(__linux__)
+#    include <linux/elf.h> //Why do I need this for NT_PRSTATUS
+#    include <sys/uio.h>
+#    include <sys/user.h>
+#  endif
+#else
+#  include <windows.h>
+#  include <errhandlingapi.h>
+#  include <handleapi.h>
+#  include <processthreadsapi.h>
+#  include <sys/types.h>
+#endif
+#if defined(__APPLE__)
 typedef struct CFuckup {
   struct CQue base;
   int64_t signal;
   pid_t pid;
   void *task;
 } CFuckup;
-#    define PTRACE_TRACEME PT_TRACE_ME
-#    define gettid         getpid
-#  endif
-#  if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#  define PTRACE_TRACEME PT_TRACE_ME
+#  define gettid         getpid
+#endif
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
 typedef struct CFuckup {
   struct CQue base;
   int64_t signal;
@@ -93,35 +66,35 @@ typedef struct CFuckup {
   struct reg regs;
   struct fpreg fp;
 } CFuckup;
-#    define PTRACE_TRACEME   PT_TRACE_ME
-#    define PTRACE_ATTACH    PT_ATTACH
-#    define PTRACE_SETREGS   PT_SETREGS
-#    define PTRACE_GETREGS   PT_GETREGS
-#    define PTRACE_SETFPREGS PT_SETFPREGS
-#    define PTRACE_GETFPREGS PT_GETFPREGS
-#    define gettid           getpid
-#  endif
-#  if defined(__linux__)
-#    include <asm/ptrace.h>
-#    include <sys/user.h>
+#  define PTRACE_TRACEME   PT_TRACE_ME
+#  define PTRACE_ATTACH    PT_ATTACH
+#  define PTRACE_SETREGS   PT_SETREGS
+#  define PTRACE_GETREGS   PT_GETREGS
+#  define PTRACE_SETFPREGS PT_SETFPREGS
+#  define PTRACE_GETFPREGS PT_GETFPREGS
+#  define gettid           getpid
+#endif
+#if defined(__linux__)
+#  include <asm/ptrace.h>
+#  include <sys/user.h>
 typedef struct CFuckup {
   struct CQue base;
   int64_t signal;
   pid_t pid;
   void *task;
-#    if defined(_M_ARM64) || defined(__aarch64__)
+#  if defined(_M_ARM64) || defined(__aarch64__)
   struct user_pt_regs regs;
   struct user_fpsimd_struct fp;
-#    elif defined(__x86_64__)
+#  elif defined(__x86_64__)
   struct user_fpregs_struct fp;
   struct user_regs_struct regs;
-#    elif defined(__riscv__) || defined(__riscv)
+#  elif defined(__riscv__) || defined(__riscv)
   struct user_regs_struct regs;
   union __riscv_fp_state fp;
-#    endif
+#  endif
 } CFuckup;
-#  elif defined(_WIN64)
-#    include <winnt.h>
+#elif defined(_WIN64)
+#  include <winnt.h>
 typedef struct CFuckup {
   struct CQue base;
   int64_t signal;
@@ -129,10 +102,10 @@ typedef struct CFuckup {
   void *task;
   CONTEXT *_regs; // regs may be alligned
 } CFuckup;
-#    ifndef SIGCONT
-#      define SIGCONT 0x101
-#    endif
+#  ifndef SIGCONT
+#    define SIGCONT 0x101
 #  endif
+#endif
 CFuckup *GetFuckupByTask(CQue *head, void *t) {
   CFuckup *fu;
   for (fu = head->next; fu != head; fu = fu->base.next) {
@@ -152,7 +125,7 @@ CFuckup *GetFuckupByPid(CQue *head, int64_t pid) {
 // Im making fuckups global on windows because debugging is not event driven on
 // windows
 static CQue fuckups;
-#  if defined(WIN32) || defined(_WIN32)
+#if defined(WIN32) || defined(_WIN32)
 static int64_t gettid() {
   return GetCurrentThreadId();
 }
@@ -163,7 +136,7 @@ typedef struct _CDbgMsgQue {
 } _CDbgMsgQue;
 static CQue debugger_msgs;
 static HANDLE debugger_mtx;
-#    define HARD_CORE_CNT 64
+#  define HARD_CORE_CNT 64
 static HANDLE active_threads[HARD_CORE_CNT];
 static CONTEXT thread_use_ctx[HARD_CORE_CNT];
 static int64_t fault_codes[HARD_CORE_CNT];
@@ -224,7 +197,7 @@ static void AllowNext(int64_t pid) {
 found:;
   ResumeThread(active_threads[tr]);
 }
-#  else
+#else
 static int debugger_pipe[2];
 static void ReadMsg(char *buf) {
   if (!debugger_pipe[0])
@@ -247,10 +220,10 @@ static void WriteMsg(char const *fmt, ...) {
   va_end(l);
   write(debugger_pipe[1], "", 1);
 }
-#    if __OpenBSD__ + __NetBSD__ > 0
-#      include <poll.h>
-#      define POLL_IN POLLIN
-#    endif
+#  if __OpenBSD__ + __NetBSD__ > 0
+#    include <poll.h>
+#    define POLL_IN POLLIN
+#  endif
 static int64_t MsgPoll() {
   struct pollfd poll_for;
   memset(&poll_for, 0, sizeof(struct pollfd));
@@ -261,16 +234,16 @@ static int64_t MsgPoll() {
   return 0;
 }
 static void GrabDebugger(int64_t code) {
-#    if defined(__APPLE__)
+#  if defined(__APPLE__)
 // Tee hee
-#    else
+#  else
   raise(code);
-#    endif
-}
 #  endif
+}
+#endif
 
 void DebuggerClientWatchThisTID() {
-#  if defined(_WIN32) || defined(WIN32)
+#if defined(_WIN32) || defined(WIN32)
   int64_t tr;
   WaitForSingleObject(debugger_mtx, INFINITE);
   for (tr = 0; active_threads[tr]; tr++)
@@ -279,12 +252,12 @@ void DebuggerClientWatchThisTID() {
   DuplicateHandle(GetCurrentProcess(), GetCurrentThread(), GetCurrentProcess(),
                   &active_threads[tr], 0, FALSE, DUPLICATE_SAME_ACCESS);
   ReleaseMutex(debugger_mtx);
-#  else
+#else
   int64_t tid = gettid();
   WriteMsg(DBG_MSG_WATCH_TID, tid);
-#  endif
+#endif
 }
-#  if defined(_WIN32) || defined(WIN32)
+#if defined(_WIN32) || defined(WIN32)
 static int64_t DebuggerWait(CQue *head, pid_t *got) {
   int64_t s, tid;
   CFuckup *fu;
@@ -305,7 +278,7 @@ static int64_t DebuggerWait(CQue *head, pid_t *got) {
   }
   return 0;
 }
-#  else
+#else
 static int64_t DebuggerWait(CQue *head, pid_t *got) {
   int code, sig;
   pid_t pid = waitpid(-1, &code, WNOHANG | WUNTRACED | WCONTINUED);
@@ -343,13 +316,13 @@ static int64_t DebuggerWait(CQue *head, pid_t *got) {
     case SIGSTOP:
       break;
     default:
-#    if defined(__x86_64__)
+#  if defined(__x86_64__)
       // IF you are blessed you are running on a platform that has these
       // Here's the deal Linux takes it in data/freebsd takes it in
       // addr(only 1 is used my homie)
       ptrace(PTRACE_GETREGS, pid, &fu->regs, &fu->regs);
       ptrace(PTRACE_GETFPREGS, pid, &fu->fp, &fu->fp);
-#    elif defined(PTRACE_GETREGSET)
+#  elif defined(PTRACE_GETREGSET)
       struct iovec poop;
       poop.iov_len = sizeof(fu->regs);
       poop.iov_base = &fu->regs;
@@ -357,42 +330,42 @@ static int64_t DebuggerWait(CQue *head, pid_t *got) {
       poop.iov_len = sizeof(fu->fp);
       poop.iov_base = &fu->fp;
       ptrace(PTRACE_GETREGSET, pid, NT_PRFPREG, &poop);
-#    endif
+#  endif
     }
     if (got)
       *got = pid;
     return sig;
   }
 }
-#  endif
+#endif
 static void PTWriteAPtr(int64_t tid, void *to, uint64_t v) {
   int64_t s;
-#  if defined(_WIN32) || defined(WIN32)
+#if defined(_WIN32) || defined(WIN32)
   *(void **)to = (void *)v;
-#  endif
-#  if defined(__linux__)
-#    if defined(_M_ARM64) || defined(__aarch64__) || defined(__x86_64__) ||    \
-        defined(__riscv) || defined(__riscv__)
+#endif
+#if defined(__linux__)
+#  if defined(_M_ARM64) || defined(__aarch64__) || defined(__x86_64__) ||      \
+      defined(__riscv) || defined(__riscv__)
   for (s = 0; s != 8 / 2; s++) {
     if (!s)
       ptrace(PTRACE_POKETEXT, tid, to + s, v & 0xffff);
     else
       ptrace(PTRACE_POKETEXT, tid, to + s * 2, (v >> (s * 16ul)) & 0xfffful);
   }
-#    endif
-#  elif defined(__FreeBSD__)
+#  endif
+#elif defined(__FreeBSD__)
   for (s = 0; s != 8 / 4; s++)
     ptrace(PT_WRITE_D, tid, to + s * 4, (v >> (s * 32ul)) & 0xffffFFFFul);
-#  endif
+#endif
 }
 void DebuggerBegin() {
   pid_t tid = 0;
-#  if __OpenBSD__ + __NetBSD__ > 0
+#if __OpenBSD__ + __NetBSD__ > 0
   // OpenBSD ptrace is poopy
   return;
-#  endif
+#endif
 
-#  if defined(_WIN32) || defined(WIN32)
+#if defined(_WIN32) || defined(WIN32)
   static int64_t init = 0;
   tid = init; // SIMULATE fork sort of
   if (!init) {
@@ -402,28 +375,28 @@ void DebuggerBegin() {
     QueInit(&debugger_msgs);
     init = 1;
   }
-#  else
+#else
   pipe(debugger_pipe);
   tid = fork();
-#  endif
+#endif
   int code, sig;
   void *task;
   char buf[4048], *ptr;
   pid_t child = tid;
   if (!tid) {
-#  if !(defined(_WIN32) || defined(WIN32))
+#if !(defined(_WIN32) || defined(WIN32))
     ptrace(PTRACE_TRACEME, tid, NULL, NULL);
     raise(SIGSTOP);
-#  else
+#else
     CreateThread(NULL, 0, &DebuggerBegin, NULL, 0, NULL);
-#  endif
+#endif
     WriteMsg(DBG_MSG_OK);
     return;
   } else {
-#  if !(defined(_WIN32) || defined(WIN32))
+#if !(defined(_WIN32) || defined(WIN32))
     wait(tid);
     ptrace(PT_CONTINUE, tid, 1, NULL);
-#  endif
+#endif
     while (1) {
       ReadMsg(buf);
       if (strcmp(buf, DBG_MSG_OK))
@@ -432,9 +405,9 @@ void DebuggerBegin() {
         break;
     }
 
-#  if defined(__linux__)
+#if defined(__linux__)
     struct iovec poop;
-#  endif
+#endif
     CFuckup *fu, *last;
     char *ptr, *name;
     int64_t which, value, sig, *write_regs_to;
@@ -467,7 +440,7 @@ void DebuggerBegin() {
                 }
               }
               // SEE swapctxX86.s
-#  if defined(_WIN32) || defined(WIN32)
+#if defined(_WIN32) || defined(WIN32)
               switch (which) {
               case 0:
                 fu->_regs->Rip = value;
@@ -480,8 +453,8 @@ void DebuggerBegin() {
                 break;
               }
               AllowNext(tid);
-#  endif
-#  if defined(__FreeBSD__) && defined(__x86_64__)
+#endif
+#if defined(__FreeBSD__) && defined(__x86_64__)
               switch (which) {
               case 0:
                 fu->regs.r_rip = value;
@@ -495,8 +468,8 @@ void DebuggerBegin() {
                 // DONT RELY ON CHANGING GPs
               }
               ptrace(PT_CONTINUE, tid, 1, 0);
-#  endif
-#  if defined(__linux__) && defined(__x86_64__)
+#endif
+#if defined(__linux__) && defined(__x86_64__)
               switch (which) {
               case 0:
                 fu->regs.rip = value;
@@ -510,8 +483,8 @@ void DebuggerBegin() {
                 // DONT RELY ON CHANGING GPs
               }
               ptrace(PT_CONTINUE, tid, 0, 0);
-#  endif
-#  if defined(__linux__) && (defined(_M_ARM64) || defined(__aarch64__))
+#endif
+#if defined(__linux__) && (defined(_M_ARM64) || defined(__aarch64__))
               switch (which) {
               case 22:
                 fu->regs.pc = value;
@@ -525,8 +498,8 @@ void DebuggerBegin() {
                 // DONT RELY ON CHANGING GPs
               }
               ptrace(PT_CONTINUE, tid, 0, 0);
-#  endif
-#  if (defined(__riscv) || defined(__riscv__)) && defined(__linux__)
+#endif
+#if (defined(__riscv) || defined(__riscv__)) && defined(__linux__)
               switch (which) {
               case 0:
                 fu->regs.pc = value;
@@ -572,7 +545,7 @@ void DebuggerBegin() {
                 break;
               }
               ptrace(PT_CONTINUE, tid, 0, 0);
-#  endif
+#endif
               break;
             } else if (!strncmp(name, "WATCHTID", strlen("WATCHTID"))) {
               int64_t tr;
@@ -581,9 +554,9 @@ void DebuggerBegin() {
                 abort();
               ptr++;
 // On FreeBSD there is no "TID"s
-#  if defined(__linux__)
+#if defined(__linux__)
               ptrace(PTRACE_ATTACH, strtoul(ptr, NULL, 10), NULL, NULL);
-#  endif
+#endif
               break;
             } else if (!strncmp(name, "START", strlen("START"))) {
               void *task;
@@ -603,29 +576,29 @@ void DebuggerBegin() {
                 puts("undef Fu");
               else {
 // See your swapctx for your arch(swapctxAARCH64/swapctxX86)
-#  if defined(__x86_64__)
-#    if defined(__linux__)
+#if defined(__x86_64__)
+#  if defined(__linux__)
                 PTWriteAPtr(tid, &write_regs_to[0], fu->regs.rip);
                 PTWriteAPtr(tid, &write_regs_to[1], fu->regs.rsp);
                 PTWriteAPtr(tid, &write_regs_to[2], fu->regs.rbp);
-#    elif defined(__FreeBSD__)
+#  elif defined(__FreeBSD__)
                 PTWriteAPtr(tid, &write_regs_to[0], fu->regs.r_rip);
                 PTWriteAPtr(tid, &write_regs_to[1], fu->regs.r_rsp);
                 PTWriteAPtr(tid, &write_regs_to[2], fu->regs.r_rbp);
-#    elif defined(_WIN32) || defined(WIN32)
+#  elif defined(_WIN32) || defined(WIN32)
                 PTWriteAPtr(tid, &write_regs_to[0], fu->_regs->Rip);
                 PTWriteAPtr(tid, &write_regs_to[1], fu->_regs->Rsp);
                 PTWriteAPtr(tid, &write_regs_to[2], fu->_regs->Rbp);
-#    endif
 #  endif
+#endif
 
-#  if defined(_M_ARM64) || defined(__aarch64__)
-#    if defined(__linux__)
+#if defined(_M_ARM64) || defined(__aarch64__)
+#  if defined(__linux__)
                 //???
-#    elif defined(__FreeBSD__)
-#    endif
+#  elif defined(__FreeBSD__)
 #  endif
-#  if (defined(__riscv) || defined(__riscv__)) && defined(__linux__)
+#endif
+#if (defined(__riscv) || defined(__riscv__)) && defined(__linux__)
                 PTWriteAPtr(tid, &write_regs_to[0], fu->regs.pc);
                 PTWriteAPtr(tid, &write_regs_to[1], fu->regs.sp);
                 PTWriteAPtr(tid, &write_regs_to[2], fu->regs.s0);
@@ -640,13 +613,13 @@ void DebuggerBegin() {
                 PTWriteAPtr(tid, &write_regs_to[11], fu->regs.s9);
                 PTWriteAPtr(tid, &write_regs_to[12], fu->regs.s10);
                 PTWriteAPtr(tid, &write_regs_to[13], fu->regs.s11);
-#  endif
+#endif
               }
-#  if defined(_WIN32) || defined(WIN32)
+#if defined(_WIN32) || defined(WIN32)
               AllowNext(tid);
-#  else
+#else
               ptrace(PT_CONTINUE, tid, 1, 0);
-#  endif
+#endif
               break;
             } else if (!strncmp(name, "RESUME", strlen("RESUME"))) {
               void *task;
@@ -664,29 +637,29 @@ void DebuggerBegin() {
               }
               fu = GetFuckupByTask(&fuckups, task);
               if (!fu) {
-#  if defined(_WIN32) || defined(WIN32)
+#if defined(_WIN32) || defined(WIN32)
                 AllowNext(tid);
-#  else
+#else
                 ptrace(PT_CONTINUE, tid, 1, 0);
-#  endif
+#endif
                 break;
               }
-#  if !(defined(_WIN32) || defined(WIN32))
-#    if defined(__x86_64__)
+#if !(defined(_WIN32) || defined(WIN32))
+#  if defined(__x86_64__)
               // IF you are blessed you are running on a platform that has
               // these Here's the deal Linux takes it in data/freebsd takes it
               // in addr(only 1 is used my homie)
               ptrace(PTRACE_SETREGS, tid, &fu->regs, &fu->regs);
               ptrace(PTRACE_SETFPREGS, tid, &fu->fp, &fu->fp);
-#    elif defined(__linux__)
+#  elif defined(__linux__)
               poop.iov_len = sizeof(fu->regs);
               poop.iov_base = &fu->regs;
               ptrace(PTRACE_SETREGSET, tid, NT_PRSTATUS, &poop);
               poop.iov_len = sizeof(fu->fp);
               poop.iov_base = &fu->fp;
               ptrace(PTRACE_SETREGSET, tid, NT_PRFPREG, &poop);
-#    endif
-#  else
+#  endif
+#else
               // See thread_use_ctx
               int64_t tr;
               for (tr = 0; tr != HARD_CORE_CNT; tr++) {
@@ -695,28 +668,28 @@ void DebuggerBegin() {
                 if (GetThreadId(active_threads[tr]) == tid)
                   break;
               }
-#  endif
+#endif
               if (ss) {
-#  if defined(__FreeBSD__)
+#if defined(__FreeBSD__)
                 ptrace(PT_STEP, tid, 1, 0);
-#  elif defined(_WIN32) || defined(WIN32)
+#elif defined(_WIN32) || defined(WIN32)
                 fu->_regs->EFlags |= 1 << 8; // Trap flag
                 AllowNext(tid);
-#  elif defined(__linux__)
+#elif defined(__linux__)
                 ptrace(PTRACE_SINGLESTEP, tid, 0, 0);
-#  endif
+#endif
                 QueRem(fu);
                 free(fu);
               } else {
-#  if defined(_WI32) || defined(WIN32)
+#if defined(_WI32) || defined(WIN32)
                 AllowNext(tid);
-#  else
-#    if defined(__x86_64__)
+#else
+#  if defined(__x86_64__)
                 ptrace(PT_CONTINUE, tid, 1, 0);
-#    else
+#  else
                 ptrace(PT_CONTINUE, tid, 0, 0);
-#    endif
 #  endif
+#endif
                 QueRem(fu);
                 free(fu);
               }
@@ -727,8 +700,8 @@ void DebuggerBegin() {
           ptr++;
         }
       } else if (sig = DebuggerWait(&fuckups, &tid)) {
-#  if defined(_WIN32) || defined(WIN32)
-#  else
+#if defined(_WIN32) || defined(WIN32)
+#else
         if (sig == SIGCONT)
           ;
         else if (sig == SIGSTOP ||
@@ -736,14 +709,14 @@ void DebuggerBegin() {
           ptrace(PT_CONTINUE, tid, 1, 0);
         else
           ptrace(PT_CONTINUE, tid, 1, sig);
-#  endif
+#endif
       }
     }
   }
 }
 static void UnblockSignals() {
-#  if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__) ||      \
-      defined(__OpenBSD__) || defined(__NetBSD__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__) ||        \
+    defined(__OpenBSD__) || defined(__NetBSD__)
   sigset_t set;
   sigemptyset(&set);
   sigaddset(&set, SIGILL);
@@ -752,13 +725,13 @@ static void UnblockSignals() {
   sigaddset(&set, SIGTRAP);
   sigaddset(&set, SIGFPE);
   sigprocmask(SIG_UNBLOCK, &set, NULL);
-#  endif
+#endif
 }
-#  if defined(__OpenBSD__)
+#if defined(__OpenBSD__)
 static void SigHandler(int sig, siginfo_t *info, void *__ctx) {
   UnblockSignals();
   CHashExport *exp;
-  // OpenBSD doesnt put anything juicy in the __ctx ,do man 2 sigaction
+//OpenBSD doesnt put anything juicy in the __ctx ,do man 2 sigaction
   void *fp;
   int64_t actx[32];
   // AiwniosDbgCB will return 1 for singlestep
@@ -772,24 +745,20 @@ static void SigHandler(int sig, siginfo_t *info, void *__ctx) {
   } else
     abort();
 }
+#endif
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__) || defined(__NetBSD__)
+#  if defined(__APPLE__)
+#    include <arm/_mcontext.h>
 #  endif
-#  if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__) ||      \
-      defined(__NetBSD__)
-#    if defined(__APPLE__)
-#      include <arm/_mcontext.h>
-#    endif
 static void SigHandler(int sig, siginfo_t *info, void *__ctx) {
   ucontext_t *_ctx = __ctx;
   if (sig == SIGWINCH) {
+    puts("SIGWINCH");
     UnblockSignals();
     return;
   }
-#    if defined(USE_BYTECODE)
-  UnblockSignals();
-  AiwnBCDbgFault(sig);
-  return;
-#    elif defined(__x86_64__)
-#      if defined(__linux__)
+#  if defined(__x86_64__)
+#    if defined(__linux__)
   // See /usr/include/x86_64-linux-gnu/sys/ucontext.h
   enum {
     REG_R8 = 0,
@@ -831,7 +800,7 @@ static void SigHandler(int sig, siginfo_t *info, void *__ctx) {
   } else
     abort();
   return; // returning calls setcontext
-#      elif defined(__NetBSD__)
+#    elif defined(__NetBSD__)
   UnblockSignals();
   mcontext_t *ctx = &_ctx->uc_mcontext;
   int64_t actx[32];
@@ -853,7 +822,7 @@ static void SigHandler(int sig, siginfo_t *info, void *__ctx) {
   } else
     abort();
   return;
-#      elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__)
   UnblockSignals();
   mcontext_t *ctx = &_ctx->uc_mcontext;
   int64_t actx[32];
@@ -876,8 +845,8 @@ static void SigHandler(int sig, siginfo_t *info, void *__ctx) {
     abort();
   return;
 
-#      endif
-#    elif defined(__aarch64__) || defined(_M_ARM64)
+#    endif
+#  elif defined(__aarch64__) || defined(_M_ARM64)
   mcontext_t *ctx = &_ctx->uc_mcontext;
   CHashExport *exp;
   int64_t is_single_step;
@@ -891,34 +860,34 @@ static void SigHandler(int sig, siginfo_t *info, void *__ctx) {
   UnblockSignals();
   for (i = 18; i <= 30; i++)
     if (i - 18 != 12) // the 12th one is the return register
-#      if defined(__linux__)
+#    if defined(__linux__)
       actx[i - 18] = ctx->regs[i];
-#      elif defined(__FreeBSD__)
+#    elif defined(__FreeBSD__)
       actx[i - 18] = ctx->mc_gpregs.gp_x[i];
-#      elif defined(__APPLE__)
+#    elif defined(__APPLE__)
 // See the
 // /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/mach/arm/_structs.h
 // file actx[i-18]=ctx->__ss.__x[i];
-#      endif
-#      if defined(__linux__)
+#    endif
+#    if defined(__linux__)
   actx[22] = ctx->pc;
-#      elif defined(__FreeBSD__)
-#      endif
-#      if defined(__linux__)
+#    elif defined(__FreeBSD__)
+#    endif
+#    if defined(__linux__)
   actx[21] = ctx->sp;
-#      elif defined(__FreeBSD__)
+#    elif defined(__FreeBSD__)
   actx[21] = ctx->mc_gpregs.gp_sp;
-#      elif defined(__APPLE__)
+#    elif defined(__APPLE__)
 // See the
 // /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/mach/arm/_structs.h
 // file actx[21]=ctx->__ss.__sp;
-#      endif
+#    endif
   // AiwniosDbgCB will return 1 for singlestep
   if (exp = HashFind("AiwniosDbgCB", Fs->hash_table, HTT_EXPORT_SYS_SYM, 1)) {
     fp = exp->val;
     if (FFI_CALL_TOS_2(fp, sig, actx)) { // Returns 1 for single step
-#      if defined(__x86_64__)
-#        if defined(__FreeBSD__)
+#    if defined(__x86_64__)
+#      if defined(__FreeBSD__)
 
       ctx->mc_rip = actx[0];
       ctx->mc_rsp = actx[1];
@@ -930,7 +899,7 @@ static void SigHandler(int sig, siginfo_t *info, void *__ctx) {
       ctx->mc_r13 = actx[7];
       ctx->mc_r14 = actx[8];
       ctx->mc_r15 = actx[9] ctx->mc_eflags |= 1 << 8;
-#        elif defined(__linux__)
+#      elif defined(__linux__)
       ctx->gregs[REG_RIP] = actx[0];
       ctx->gregs[REG_RSP] = actx[1];
       ctx->gregs[REG_RBP] = actx[2];
@@ -941,8 +910,8 @@ static void SigHandler(int sig, siginfo_t *info, void *__ctx) {
       ctx->gregs[REG_R13] = actx[7];
       ctx->gregs[REG_R14] = actx[8];
       ctx->gregs[REG_R15] = actx[9];
-#        endif
 #      endif
+#    endif
     }
   } else if (exp = HashFind("Exit", Fs->hash_table, HTT_EXPORT_SYS_SYM, 1)) {
   call_exit:
@@ -950,8 +919,8 @@ static void SigHandler(int sig, siginfo_t *info, void *__ctx) {
     FFI_CALL_TOS_0(fp2);
   } else
     abort();
-#    endif
-#    if (defined(__riscv__) || defined(__riscv)) && defined(__linux__)
+#  endif
+#  if (defined(__riscv__) || defined(__riscv)) && defined(__linux__)
   UnblockSignals();
   CHashExport *exp;
   void *fp;
@@ -966,11 +935,11 @@ static void SigHandler(int sig, siginfo_t *info, void *__ctx) {
     FFI_CALL_TOS_0(fp);
   } else
     abort();
-#    endif
-}
 #  endif
-#  ifdef _WIN32
-#    define E(code) EXCEPTION_##code
+}
+#endif
+#ifdef _WIN32
+#  define E(code) EXCEPTION_##code
 static LONG WINAPI VectorHandler(EXCEPTION_POINTERS *einfo) {
   CONTEXT *ctx = einfo->ContextRecord;
   CFuckup *fu = calloc(1, sizeof *fu);
@@ -978,27 +947,33 @@ static LONG WINAPI VectorHandler(EXCEPTION_POINTERS *einfo) {
   QueIns(fu, &fuckups);
   fu->pid = GetCurrentThreadId();
   fu->_regs = ctx;
+
   int64_t actx[23];
   actx[0] = ctx->Rip;
   actx[1] = ctx->Rsp;
   actx[2] = ctx->Rbp;
+
+  if (!Fs) {
+    return EXCEPTION_CONTINUE_SEARCH;
+  }
+
   CHashExport *exp;
   if (exp = HashFind("AiwniosDbgCB", Fs->hash_table, HTT_EXPORT_SYS_SYM, 1)) {
     switch (einfo->ExceptionRecord->ExceptionCode) {
-    case E(SINGLE_STEP):
-    case E(BREAKPOINT):
-      sig = 5;
+      case EXCEPTION_SINGLE_STEP:
+      case EXCEPTION_BREAKPOINT:
+        sig = 5;
+        break;
     }
     FFI_CALL_TOS_2(exp->val, sig, actx);
-  } else if (exp = HashFind("Exit", Fs->hash_table, HTT_EXPORT_SYS_SYM, 1))
+  } else if (exp = HashFind("Exit", Fs->hash_table, HTT_EXPORT_SYS_SYM, 1)) {
     FFI_CALL_TOS_0(exp->val);
-  else {
-    abort();
+  } else {
+    return EXCEPTION_CONTINUE_SEARCH;
   }
-fin:
+
   return EXCEPTION_CONTINUE_EXECUTION;
 }
-
 static LONG WINAPI Div0Handler(EXCEPTION_POINTERS *info) {
   CONTEXT *ctx = info->ContextRecord;
   switch (info->ExceptionRecord->ExceptionCode) {
@@ -1012,9 +987,9 @@ static LONG WINAPI Div0Handler(EXCEPTION_POINTERS *info) {
     return EXCEPTION_CONTINUE_SEARCH;
   }
 }
-#  endif
+#endif
 void InstallDbgSignalsForThread() {
-#  ifndef _WIN32
+#ifndef _WIN32
   struct sigaction sa = {
       .sa_flags = SA_SIGINFO,
       .sa_sigaction = SigHandler,
@@ -1022,25 +997,16 @@ void InstallDbgSignalsForThread() {
   int sigs[] = {SIGSEGV, SIGBUS, SIGTRAP, SIGILL, -1};
   for (int *sigp = sigs; *sigp != -1; sigp++)
     sigaction(*sigp, &sa, 0);
-#  else
+#else
   /* If the First parameter is nonzero, the handler is the first handler to be
    * called until a subsequent call to AddVectoredExceptionHandler is used to
    * specify a different handler as the first handler.
    *   --Quoth MSDN */
   AddVectoredExceptionHandler(1, VectorHandler);
   AddVectoredExceptionHandler(1, Div0Handler);
-#  endif
+#endif
 }
 // This happens when after we call DebuggerClientEnd
-#  if defined(USE_BYTECODE)
-void DebuggerClientSetGreg(void *task, int64_t which, int64_t v) {
-}
-void DebuggerClientStart(void *task, void **write_regs_to) {
-  memcpy(write_regs_to, AiwnBCDbgCurContext(), sizeof(ABCFrame));
-}
-void DebuggerClientEnd(void *task, int64_t wants_singlestep) {
-}
-#  else
 void DebuggerClientSetGreg(void *task, int64_t which, int64_t v) {
   WriteMsg(DBG_MSG_SET_GREG, task, gettid(), which, v);
   GrabDebugger(SIGCONT);
@@ -1053,5 +1019,3 @@ void DebuggerClientEnd(void *task, int64_t wants_singlestep) {
   WriteMsg(DBG_MSG_RESUME, task, gettid(), wants_singlestep);
   GrabDebugger(SIGCONT);
 }
-#  endif
-#endif


### PR DESCRIPTION
if you have an issue with windows seg fault this might help

on Windows, VectorHandler does this unguarded lookup:
`
HashFind("AiwniosDbgCB", Fs->hash_table, HTT_EXPORT_SYS_SYM, 1)`

and Fs is still null according to GDB result 

The handler is crashing while trying to handle the original exception. On Windows, it always returns EXCEPTION_CONTINUE_EXECUTION, so if the underlying fault is not actually repaired, execution will just retry and fault again.